### PR TITLE
Swap New Stuff and Refactoring Quadrant Positions

### DIFF
--- a/src/lib/contribution-analyzer.ts
+++ b/src/lib/contribution-analyzer.ts
@@ -184,8 +184,8 @@ export class ContributionAnalyzer {
     return {
       // Higher x (more additions) with some variance
       x: Math.min(95, additionRatio * 100 + Math.random() * 10),
-      // Lower y (fewer deletions) with some variance
-      y: Math.max(5, deletionRatio * 100 - Math.random() * 10),
+      // Higher y (more additions) with some variance
+      y: Math.min(95, additionRatio * 100 + Math.random() * 10),
       quadrant: 'newStuff'
     };
   }
@@ -202,9 +202,10 @@ export class ContributionAnalyzer {
 
   private static getRefactoringMetrics(additionRatio: number, deletionRatio: number): ContributionMetrics {
     return {
-      // Balanced x and y with some variance
-      x: Math.min(95, Math.max(5, additionRatio * 100 + Math.random() * 20 - 10)),
-      y: Math.min(95, Math.max(5, deletionRatio * 100 + Math.random() * 20 - 10)),
+      // Higher x (more additions) with some variance
+      x: Math.min(95, additionRatio * 100 + Math.random() * 10),
+      // Lower y (fewer deletions) with some variance
+      y: Math.max(5, deletionRatio * 100 - Math.random() * 10),
       quadrant: 'refactoring'
     };
   }

--- a/src/lib/contribution-analyzer.ts
+++ b/src/lib/contribution-analyzer.ts
@@ -184,8 +184,8 @@ export class ContributionAnalyzer {
     return {
       // Higher x (more additions) with some variance
       x: Math.min(95, additionRatio * 100 + Math.random() * 10),
-      // Higher y (more additions) with some variance
-      y: Math.min(95, additionRatio * 100 + Math.random() * 10),
+      // Lower y (fewer deletions) with some variance
+      y: Math.max(5, (1 - deletionRatio) * 50 - Math.random() * 10),
       quadrant: 'newStuff'
     };
   }


### PR DESCRIPTION
This pull request modifies the `ContributionAnalyzer` class in `src/lib/contribution-analyzer.ts` to adjust how contribution metrics are calculated. The changes focus on altering the variance for addition and deletion ratios to better align with the intended quadrant behavior.

Adjustments to contribution metrics:

* [`src/lib/contribution-analyzer.ts`](diffhunk://#diff-ca3f455a859745c0d7f6e24d7cc9312f42786bd9f335d46f65334f3a3e345339L187-R188): Updated the `getNewStuffMetrics` method to calculate higher `y` values (more additions) with variance, aligning it with the "newStuff" quadrant.
* [`src/lib/contribution-analyzer.ts`](diffhunk://#diff-ca3f455a859745c0d7f6e24d7cc9312f42786bd9f335d46f65334f3a3e345339L205-R208): Updated the `getRefactoringMetrics` method to calculate higher `x` values (more additions) and lower `y` values (fewer deletions) with variance, aligning it with the "refactoring" quadrant.