### PR TITLE
feat: add persistent PR activity settings with Zustand

### DIFF
--- a/src/components/pr-activity.tsx
+++ b/src/components/pr-activity.tsx
@@ -12,15 +12,12 @@ import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { PullRequestActivityFeed } from "./pr-activity/pr-activity-feed";
 import { usePRActivity } from "@/hooks/use-pr-activity";
-// Remove the unused PullRequestActivity import
+import { usePRActivityStore } from "@/lib/pr-activity-store";
 
 export default function PRActivity() {
   const { stats } = useContext(RepoStatsContext);
-  const [selectedTypes, setSelectedTypes] = useState<
-    Array<"opened" | "closed" | "merged" | "reviewed" | "commented">
-  >(["opened", "merged", "commented"]);
+  const { selectedTypes, includeBots, toggleActivityType, setIncludeBots } = usePRActivityStore();
   const [visibleCount, setVisibleCount] = useState(15);
-  const [includeBots, setIncludeBots] = useState(true);
   const [hasBots, setHasBots] = useState(false);
 
   const {
@@ -65,13 +62,7 @@ export default function PRActivity() {
             <Switch
               id="filter-opened"
               checked={selectedTypes.includes("opened")}
-              onCheckedChange={(checked) => {
-                setSelectedTypes((prev) =>
-                  checked
-                    ? [...prev, "opened"]
-                    : prev.filter((type) => type !== "opened")
-                );
-              }}
+              onCheckedChange={() => toggleActivityType("opened")}
             />
             <Label htmlFor="filter-opened" className="text-sm">
               Opened
@@ -81,13 +72,7 @@ export default function PRActivity() {
             <Switch
               id="filter-closed"
               checked={selectedTypes.includes("closed")}
-              onCheckedChange={(checked) => {
-                setSelectedTypes((prev) =>
-                  checked
-                    ? [...prev, "closed"]
-                    : prev.filter((type) => type !== "closed")
-                );
-              }}
+              onCheckedChange={() => toggleActivityType("closed")}
             />
             <Label htmlFor="filter-closed" className="text-sm">
               Closed
@@ -97,13 +82,7 @@ export default function PRActivity() {
             <Switch
               id="filter-merged"
               checked={selectedTypes.includes("merged")}
-              onCheckedChange={(checked) => {
-                setSelectedTypes((prev) =>
-                  checked
-                    ? [...prev, "merged"]
-                    : prev.filter((type) => type !== "merged")
-                );
-              }}
+              onCheckedChange={() => toggleActivityType("merged")}
             />
             <Label htmlFor="filter-merged" className="text-sm">
               Merged
@@ -113,13 +92,7 @@ export default function PRActivity() {
             <Switch
               id="filter-reviewed"
               checked={selectedTypes.includes("reviewed")}
-              onCheckedChange={(checked) => {
-                setSelectedTypes((prev) =>
-                  checked
-                    ? [...prev, "reviewed"]
-                    : prev.filter((type) => type !== "reviewed")
-                );
-              }}
+              onCheckedChange={() => toggleActivityType("reviewed")}
             />
             <Label htmlFor="filter-reviewed" className="text-sm">
               Reviewed
@@ -129,13 +102,7 @@ export default function PRActivity() {
             <Switch
               id="filter-commented"
               checked={selectedTypes.includes("commented")}
-              onCheckedChange={(checked) => {
-                setSelectedTypes((prev) =>
-                  checked
-                    ? [...prev, "commented"]
-                    : prev.filter((type) => type !== "commented")
-                );
-              }}
+              onCheckedChange={() => toggleActivityType("commented")}
             />
             <Label htmlFor="filter-commented" className="text-sm">
               Commented

--- a/src/lib/pr-activity-store.ts
+++ b/src/lib/pr-activity-store.ts
@@ -1,0 +1,31 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type ActivityType = 'opened' | 'closed' | 'merged' | 'reviewed' | 'commented';
+
+interface PRActivityState {
+  selectedTypes: ActivityType[];
+  includeBots: boolean;
+  setSelectedTypes: (types: ActivityType[]) => void;
+  setIncludeBots: (include: boolean) => void;
+  toggleActivityType: (type: ActivityType) => void;
+}
+
+export const usePRActivityStore = create<PRActivityState>()(
+  persist(
+    (set) => ({
+      selectedTypes: ['opened', 'merged', 'commented'],
+      includeBots: true,
+      setSelectedTypes: (types) => set({ selectedTypes: types }),
+      setIncludeBots: (include) => set({ includeBots: include }),
+      toggleActivityType: (type) => set((state) => ({
+        selectedTypes: state.selectedTypes.includes(type)
+          ? state.selectedTypes.filter((t) => t !== type)
+          : [...state.selectedTypes, type]
+      })),
+    }),
+    {
+      name: 'pr-activity-settings',
+    }
+  )
+);


### PR DESCRIPTION
Add persistent storage for PR activity filter settings using Zustand with localStorage.

## Changes
- Create PR activity store with localStorage persistence
- Update component to use store instead of local state
- Persist activity type toggles (opened, closed, merged, reviewed, commented)
- Persist "Show Bots" setting
- Maintain existing default values and behavior

Fixes #40

Generated with [Claude Code](https://claude.ai/code)