### PR TITLE
feat: implement improved cascade delete behavior for database

### DIFF
--- a/supabase/migrations/20240615000000_improved_cascade_deletes.sql
+++ b/supabase/migrations/20240615000000_improved_cascade_deletes.sql
@@ -1,0 +1,289 @@
+-- Improved Cascade Delete Behavior Migration
+-- This migration updates foreign key constraints to implement better cascade delete behavior
+-- Based on the principle: preserve contribution history but allow anonymization
+
+-- =====================================================
+-- DROP EXISTING FOREIGN KEY CONSTRAINTS
+-- =====================================================
+
+-- Drop existing constraints from pull_requests table
+ALTER TABLE pull_requests 
+DROP CONSTRAINT IF EXISTS pull_requests_repository_id_fkey,
+DROP CONSTRAINT IF EXISTS pull_requests_author_id_fkey,
+DROP CONSTRAINT IF EXISTS pull_requests_assignee_id_fkey,
+DROP CONSTRAINT IF EXISTS pull_requests_merged_by_id_fkey;
+
+-- Drop existing constraints from reviews table
+ALTER TABLE reviews 
+DROP CONSTRAINT IF EXISTS reviews_pull_request_id_fkey,
+DROP CONSTRAINT IF EXISTS reviews_reviewer_id_fkey;
+
+-- Drop existing constraints from comments table
+ALTER TABLE comments 
+DROP CONSTRAINT IF EXISTS comments_pull_request_id_fkey,
+DROP CONSTRAINT IF EXISTS comments_commenter_id_fkey,
+DROP CONSTRAINT IF EXISTS comments_in_reply_to_id_fkey;
+
+-- Drop existing constraints from contributor_organizations table
+ALTER TABLE contributor_organizations 
+DROP CONSTRAINT IF EXISTS contributor_organizations_contributor_id_fkey,
+DROP CONSTRAINT IF EXISTS contributor_organizations_organization_id_fkey;
+
+-- Drop existing constraints from tracked_repositories table
+ALTER TABLE tracked_repositories 
+DROP CONSTRAINT IF EXISTS tracked_repositories_repository_id_fkey;
+
+-- Drop existing constraints from monthly_rankings table
+ALTER TABLE monthly_rankings 
+DROP CONSTRAINT IF EXISTS monthly_rankings_contributor_id_fkey,
+DROP CONSTRAINT IF EXISTS monthly_rankings_repository_id_fkey;
+
+-- Drop existing constraints from daily_activity_snapshots table
+ALTER TABLE daily_activity_snapshots 
+DROP CONSTRAINT IF EXISTS daily_activity_snapshots_contributor_id_fkey,
+DROP CONSTRAINT IF EXISTS daily_activity_snapshots_repository_id_fkey;
+
+-- Drop existing constraints from sync_logs table
+ALTER TABLE sync_logs 
+DROP CONSTRAINT IF EXISTS sync_logs_repository_id_fkey;
+
+-- =====================================================
+-- MODIFY COLUMNS TO ALLOW NULL WHERE NEEDED
+-- =====================================================
+
+-- Allow author_id to be NULL in pull_requests for anonymization
+ALTER TABLE pull_requests 
+ALTER COLUMN author_id DROP NOT NULL;
+
+-- Allow reviewer_id to be NULL in reviews for anonymization
+ALTER TABLE reviews 
+ALTER COLUMN reviewer_id DROP NOT NULL;
+
+-- Allow commenter_id to be NULL in comments for anonymization
+ALTER TABLE comments 
+ALTER COLUMN commenter_id DROP NOT NULL;
+
+-- Allow contributor_id to be NULL in monthly_rankings for anonymization
+ALTER TABLE monthly_rankings 
+ALTER COLUMN contributor_id DROP NOT NULL;
+
+-- Allow contributor_id to be NULL in daily_activity_snapshots for anonymization
+ALTER TABLE daily_activity_snapshots 
+ALTER COLUMN contributor_id DROP NOT NULL;
+
+-- =====================================================
+-- ADD IMPROVED FOREIGN KEY CONSTRAINTS
+-- =====================================================
+
+-- PULL REQUESTS TABLE
+-- When repository is deleted, remove all related PRs (CASCADE)
+ALTER TABLE pull_requests 
+ADD CONSTRAINT fk_pull_requests_repository 
+FOREIGN KEY (repository_id) REFERENCES repositories(id) 
+ON DELETE CASCADE;
+
+-- When contributor is deleted, preserve PR history but anonymize (SET NULL)
+ALTER TABLE pull_requests 
+ADD CONSTRAINT fk_pull_requests_author 
+FOREIGN KEY (author_id) REFERENCES contributors(id) 
+ON DELETE SET NULL;
+
+-- Optional assignee - set to NULL if contributor deleted
+ALTER TABLE pull_requests 
+ADD CONSTRAINT fk_pull_requests_assignee 
+FOREIGN KEY (assignee_id) REFERENCES contributors(id) 
+ON DELETE SET NULL;
+
+-- Optional merger - set to NULL if contributor deleted
+ALTER TABLE pull_requests 
+ADD CONSTRAINT fk_pull_requests_merged_by 
+FOREIGN KEY (merged_by_id) REFERENCES contributors(id) 
+ON DELETE SET NULL;
+
+-- REVIEWS TABLE
+-- When PR is deleted, remove all related reviews (CASCADE)
+ALTER TABLE reviews 
+ADD CONSTRAINT fk_reviews_pull_request 
+FOREIGN KEY (pull_request_id) REFERENCES pull_requests(id) 
+ON DELETE CASCADE;
+
+-- When reviewer is deleted, preserve review history but anonymize (SET NULL)
+ALTER TABLE reviews 
+ADD CONSTRAINT fk_reviews_reviewer 
+FOREIGN KEY (reviewer_id) REFERENCES contributors(id) 
+ON DELETE SET NULL;
+
+-- COMMENTS TABLE
+-- When PR is deleted, remove all related comments (CASCADE)
+ALTER TABLE comments 
+ADD CONSTRAINT fk_comments_pull_request 
+FOREIGN KEY (pull_request_id) REFERENCES pull_requests(id) 
+ON DELETE CASCADE;
+
+-- When commenter is deleted, preserve comment history but anonymize (SET NULL)
+ALTER TABLE comments 
+ADD CONSTRAINT fk_comments_commenter 
+FOREIGN KEY (commenter_id) REFERENCES contributors(id) 
+ON DELETE SET NULL;
+
+-- When parent comment is deleted, set reply reference to NULL
+ALTER TABLE comments 
+ADD CONSTRAINT fk_comments_in_reply_to 
+FOREIGN KEY (in_reply_to_id) REFERENCES comments(id) 
+ON DELETE SET NULL;
+
+-- CONTRIBUTOR ORGANIZATIONS TABLE
+-- When contributor is deleted, remove their organization associations (CASCADE)
+ALTER TABLE contributor_organizations 
+ADD CONSTRAINT fk_contributor_organizations_contributor 
+FOREIGN KEY (contributor_id) REFERENCES contributors(id) 
+ON DELETE CASCADE;
+
+-- When organization is deleted, remove all member associations (CASCADE)
+ALTER TABLE contributor_organizations 
+ADD CONSTRAINT fk_contributor_organizations_organization 
+FOREIGN KEY (organization_id) REFERENCES organizations(id) 
+ON DELETE CASCADE;
+
+-- TRACKED REPOSITORIES TABLE
+-- When repository is deleted, remove tracking record (CASCADE)
+ALTER TABLE tracked_repositories 
+ADD CONSTRAINT fk_tracked_repositories_repository 
+FOREIGN KEY (repository_id) REFERENCES repositories(id) 
+ON DELETE CASCADE;
+
+-- MONTHLY RANKINGS TABLE
+-- When contributor is deleted, preserve ranking history but anonymize (SET NULL)
+ALTER TABLE monthly_rankings 
+ADD CONSTRAINT fk_monthly_rankings_contributor 
+FOREIGN KEY (contributor_id) REFERENCES contributors(id) 
+ON DELETE SET NULL;
+
+-- When repository is deleted, remove repository-specific rankings (CASCADE)
+ALTER TABLE monthly_rankings 
+ADD CONSTRAINT fk_monthly_rankings_repository 
+FOREIGN KEY (repository_id) REFERENCES repositories(id) 
+ON DELETE CASCADE;
+
+-- DAILY ACTIVITY SNAPSHOTS TABLE
+-- When contributor is deleted, preserve activity history but anonymize (SET NULL)
+ALTER TABLE daily_activity_snapshots 
+ADD CONSTRAINT fk_daily_activity_snapshots_contributor 
+FOREIGN KEY (contributor_id) REFERENCES contributors(id) 
+ON DELETE SET NULL;
+
+-- When repository is deleted, remove repository-specific activity (CASCADE)
+ALTER TABLE daily_activity_snapshots 
+ADD CONSTRAINT fk_daily_activity_snapshots_repository 
+FOREIGN KEY (repository_id) REFERENCES repositories(id) 
+ON DELETE CASCADE;
+
+-- SYNC LOGS TABLE
+-- When repository is deleted, keep sync logs but set repository to NULL (SET NULL)
+ALTER TABLE sync_logs 
+ADD CONSTRAINT fk_sync_logs_repository 
+FOREIGN KEY (repository_id) REFERENCES repositories(id) 
+ON DELETE SET NULL;
+
+-- =====================================================
+-- UPDATE VIEWS TO HANDLE NULL CONTRIBUTORS
+-- =====================================================
+
+-- Update contributor_stats view to handle anonymized contributors
+DROP VIEW IF EXISTS contributor_stats;
+CREATE VIEW contributor_stats AS
+SELECT 
+    c.id,
+    c.username,
+    c.display_name,
+    c.avatar_url,
+    c.github_id,
+    COUNT(DISTINCT pr.id) as total_pull_requests,
+    COUNT(DISTINCT pr.id) FILTER (WHERE pr.state = 'closed' AND pr.merged = TRUE) as merged_pull_requests,
+    COUNT(DISTINCT r.id) as total_reviews,
+    COUNT(DISTINCT cm.id) as total_comments,
+    COUNT(DISTINCT pr.repository_id) as repositories_contributed,
+    SUM(pr.additions) as total_lines_added,
+    SUM(pr.deletions) as total_lines_removed,
+    MIN(pr.created_at) as first_contribution,
+    MAX(pr.created_at) as last_contribution,
+    c.first_seen_at,
+    c.last_updated_at,
+    c.is_active
+FROM contributors c
+LEFT JOIN pull_requests pr ON c.id = pr.author_id
+LEFT JOIN reviews r ON c.id = r.reviewer_id
+LEFT JOIN comments cm ON c.id = cm.commenter_id
+WHERE c.is_active = TRUE AND c.is_bot = FALSE
+GROUP BY c.id, c.username, c.display_name, c.avatar_url, c.github_id, c.first_seen_at, c.last_updated_at, c.is_active;
+
+-- Update recent_activity view to handle anonymized contributors
+DROP VIEW IF EXISTS recent_activity;
+CREATE VIEW recent_activity AS
+SELECT 
+    'pull_request' as activity_type,
+    pr.id,
+    pr.title as description,
+    pr.html_url as url,
+    pr.author_id as contributor_id,
+    COALESCE(c.username, '[deleted]') as username,
+    c.avatar_url,
+    pr.repository_id,
+    repo.full_name as repository_name,
+    pr.created_at as activity_date,
+    pr.state,
+    pr.merged
+FROM pull_requests pr
+LEFT JOIN contributors c ON pr.author_id = c.id
+JOIN repositories repo ON pr.repository_id = repo.id
+WHERE pr.created_at >= NOW() - INTERVAL '30 days'
+  AND (c.is_active = TRUE OR c.id IS NULL)
+  AND (c.is_bot = FALSE OR c.id IS NULL)
+  AND repo.is_active = TRUE
+
+UNION ALL
+
+SELECT 
+    'review' as activity_type,
+    r.id,
+    'Review: ' || COALESCE(r.state, 'PENDING') as description,
+    pr.html_url as url,
+    r.reviewer_id as contributor_id,
+    COALESCE(c.username, '[deleted]') as username,
+    c.avatar_url,
+    pr.repository_id,
+    repo.full_name as repository_name,
+    r.submitted_at as activity_date,
+    r.state,
+    NULL as merged
+FROM reviews r
+LEFT JOIN contributors c ON r.reviewer_id = c.id
+JOIN pull_requests pr ON r.pull_request_id = pr.id
+JOIN repositories repo ON pr.repository_id = repo.id
+WHERE r.submitted_at >= NOW() - INTERVAL '30 days'
+  AND (c.is_active = TRUE OR c.id IS NULL)
+  AND (c.is_bot = FALSE OR c.id IS NULL)
+  AND repo.is_active = TRUE
+
+ORDER BY activity_date DESC;
+
+-- =====================================================
+-- ADD HELPFUL COMMENTS
+-- =====================================================
+
+COMMENT ON CONSTRAINT fk_pull_requests_author ON pull_requests IS 'SET NULL to preserve PR history when contributor is deleted';
+COMMENT ON CONSTRAINT fk_pull_requests_repository ON pull_requests IS 'CASCADE to remove all PRs when repository is deleted';
+COMMENT ON CONSTRAINT fk_reviews_reviewer ON reviews IS 'SET NULL to preserve review history when reviewer is deleted';
+COMMENT ON CONSTRAINT fk_reviews_pull_request ON reviews IS 'CASCADE to remove reviews when PR is deleted';
+COMMENT ON CONSTRAINT fk_comments_commenter ON comments IS 'SET NULL to preserve comment history when commenter is deleted';
+COMMENT ON CONSTRAINT fk_comments_pull_request ON comments IS 'CASCADE to remove comments when PR is deleted';
+
+-- =====================================================
+-- MIGRATION COMPLETED
+-- =====================================================
+
+-- This migration implements the recommended cascade delete strategy:
+-- 1. Preserve contribution history when users are deleted (SET NULL)
+-- 2. Remove all related data when repositories are deleted (CASCADE)
+-- 3. Remove dependent data when parent records are deleted (CASCADE)
+-- 4. Updated views to handle anonymized contributors gracefully

--- a/supabase/test-cascade-deletes.sql
+++ b/supabase/test-cascade-deletes.sql
@@ -1,0 +1,340 @@
+-- Test Cascade Delete Behavior
+-- This file contains test scenarios to verify the cascade delete behavior
+-- Run these tests in the Supabase SQL Editor to verify implementation
+
+-- =====================================================
+-- SETUP TEST DATA
+-- =====================================================
+
+-- Clean up any existing test data
+DELETE FROM pull_requests WHERE title LIKE 'TEST:%';
+DELETE FROM contributors WHERE username LIKE 'test-user-%';
+DELETE FROM repositories WHERE full_name LIKE 'test-org/%';
+DELETE FROM organizations WHERE login LIKE 'test-org-%';
+
+-- Insert test organization
+INSERT INTO organizations (
+    github_id, login, avatar_url, description, 
+    public_repos, followers, github_created_at
+) VALUES (
+    999991, 'test-org-cascade', 
+    'https://avatars.githubusercontent.com/u/999991?v=4',
+    'Test organization for cascade delete testing',
+    10, 100, '2020-01-01T00:00:00Z'
+) ON CONFLICT (github_id) DO UPDATE SET 
+    login = EXCLUDED.login,
+    description = EXCLUDED.description;
+
+-- Insert test repository
+INSERT INTO repositories (
+    github_id, full_name, owner, name, description,
+    language, stargazers_count, forks_count,
+    is_fork, github_created_at, github_updated_at
+) VALUES (
+    999992, 'test-org-cascade/test-repo', 'test-org-cascade', 'test-repo', 
+    'Test repository for cascade delete testing',
+    'JavaScript', 50, 10,
+    FALSE, '2020-01-01T00:00:00Z', NOW()
+) ON CONFLICT (github_id) DO UPDATE SET 
+    full_name = EXCLUDED.full_name,
+    description = EXCLUDED.description;
+
+-- Insert test contributors
+INSERT INTO contributors (
+    github_id, username, display_name, avatar_url, profile_url,
+    email, company, location, bio, public_repos, followers, following,
+    github_created_at
+) VALUES 
+(
+    999993, 'test-user-author', 'Test Author User', 
+    'https://avatars.githubusercontent.com/u/999993?v=4',
+    'https://github.com/test-user-author',
+    'test-author@example.com', 'Test Company', 'Test City',
+    'Test author for cascade delete testing', 5, 50, 25,
+    '2020-01-01T00:00:00Z'
+),
+(
+    999994, 'test-user-reviewer', 'Test Reviewer User', 
+    'https://avatars.githubusercontent.com/u/999994?v=4',
+    'https://github.com/test-user-reviewer',
+    'test-reviewer@example.com', 'Test Company', 'Test City',
+    'Test reviewer for cascade delete testing', 8, 75, 30,
+    '2020-01-01T00:00:00Z'
+),
+(
+    999995, 'test-user-commenter', 'Test Commenter User', 
+    'https://avatars.githubusercontent.com/u/999995?v=4',
+    'https://github.com/test-user-commenter',
+    'test-commenter@example.com', 'Test Company', 'Test City',
+    'Test commenter for cascade delete testing', 3, 25, 15,
+    '2020-01-01T00:00:00Z'
+)
+ON CONFLICT (github_id) DO UPDATE SET 
+    username = EXCLUDED.username,
+    display_name = EXCLUDED.display_name;
+
+-- Get the IDs for our test data
+DO $$
+DECLARE
+    test_repo_id UUID;
+    test_author_id UUID;
+    test_reviewer_id UUID;
+    test_commenter_id UUID;
+    test_pr_id UUID;
+    test_review_id UUID;
+BEGIN
+    -- Get test entity IDs
+    SELECT id INTO test_repo_id FROM repositories WHERE full_name = 'test-org-cascade/test-repo';
+    SELECT id INTO test_author_id FROM contributors WHERE username = 'test-user-author';
+    SELECT id INTO test_reviewer_id FROM contributors WHERE username = 'test-user-reviewer';
+    SELECT id INTO test_commenter_id FROM contributors WHERE username = 'test-user-commenter';
+    
+    -- Insert test pull request
+    INSERT INTO pull_requests (
+        github_id, number, title, body, state, repository_id, author_id,
+        base_branch, head_branch, draft, merged, created_at, updated_at,
+        additions, deletions, changed_files, commits, html_url
+    ) VALUES (
+        999996, 1, 'TEST: Sample pull request for cascade testing', 
+        'This is a test pull request to verify cascade delete behavior',
+        'open', test_repo_id, test_author_id,
+        'main', 'feature/test-cascade', FALSE, FALSE, 
+        '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z',
+        100, 50, 5, 3, 'https://github.com/test-org-cascade/test-repo/pull/1'
+    ) ON CONFLICT (github_id) DO UPDATE SET 
+        title = EXCLUDED.title,
+        body = EXCLUDED.body;
+    
+    -- Get the PR ID
+    SELECT id INTO test_pr_id FROM pull_requests WHERE github_id = 999996;
+    
+    -- Insert test review
+    INSERT INTO reviews (
+        github_id, pull_request_id, reviewer_id, state, body, submitted_at
+    ) VALUES (
+        999997, test_pr_id, test_reviewer_id, 'APPROVED', 
+        'This looks good to me! Great test case.', '2024-01-02T00:00:00Z'
+    ) ON CONFLICT (github_id) DO UPDATE SET 
+        state = EXCLUDED.state,
+        body = EXCLUDED.body;
+    
+    -- Insert test comments
+    INSERT INTO comments (
+        github_id, pull_request_id, commenter_id, body, created_at, updated_at,
+        comment_type
+    ) VALUES 
+    (
+        999998, test_pr_id, test_commenter_id, 
+        'Great work on this test case!', '2024-01-03T00:00:00Z', '2024-01-03T00:00:00Z',
+        'issue_comment'
+    ),
+    (
+        999999, test_pr_id, test_author_id, 
+        'Thanks for the review and feedback!', '2024-01-04T00:00:00Z', '2024-01-04T00:00:00Z',
+        'issue_comment'
+    )
+    ON CONFLICT (github_id) DO UPDATE SET 
+        body = EXCLUDED.body;
+    
+    -- Insert test monthly ranking
+    INSERT INTO monthly_rankings (
+        month, year, contributor_id, repository_id, rank, weighted_score,
+        pull_requests_count, reviews_count, comments_count, repositories_contributed,
+        lines_added, lines_removed, first_contribution_at, last_contribution_at
+    ) VALUES (
+        1, 2024, test_author_id, test_repo_id, 1, 150.5,
+        1, 0, 1, 1, 100, 50, '2024-01-01T00:00:00Z', '2024-01-04T00:00:00Z'
+    ) ON CONFLICT (month, year, contributor_id, repository_id) DO UPDATE SET 
+        rank = EXCLUDED.rank,
+        weighted_score = EXCLUDED.weighted_score;
+    
+    -- Insert test daily activity
+    INSERT INTO daily_activity_snapshots (
+        date, contributor_id, repository_id, pull_requests_opened, comments_made,
+        lines_added, lines_removed
+    ) VALUES (
+        '2024-01-01', test_author_id, test_repo_id, 1, 1, 100, 50
+    ) ON CONFLICT (date, contributor_id, repository_id) DO UPDATE SET 
+        pull_requests_opened = EXCLUDED.pull_requests_opened;
+    
+END $$;
+
+-- =====================================================
+-- TEST SCENARIOS
+-- =====================================================
+
+-- Test 1: Verify test data was created correctly
+SELECT 'TEST 1: Verify test data creation' as test_name;
+SELECT 
+    'Repositories' as entity_type,
+    COUNT(*) as count
+FROM repositories 
+WHERE full_name = 'test-org-cascade/test-repo'
+UNION ALL
+SELECT 
+    'Contributors' as entity_type,
+    COUNT(*) as count
+FROM contributors 
+WHERE username LIKE 'test-user-%'
+UNION ALL
+SELECT 
+    'Pull Requests' as entity_type,
+    COUNT(*) as count
+FROM pull_requests 
+WHERE title LIKE 'TEST:%'
+UNION ALL
+SELECT 
+    'Reviews' as entity_type,
+    COUNT(*) as count
+FROM reviews r
+JOIN pull_requests pr ON r.pull_request_id = pr.id
+WHERE pr.title LIKE 'TEST:%'
+UNION ALL
+SELECT 
+    'Comments' as entity_type,
+    COUNT(*) as count
+FROM comments c
+JOIN pull_requests pr ON c.pull_request_id = pr.id
+WHERE pr.title LIKE 'TEST:%';
+
+-- Test 2: Test contributor deletion (should SET NULL, preserve history)
+SELECT 'TEST 2: Testing contributor deletion behavior' as test_name;
+
+-- Before deletion counts
+SELECT 
+    'Before Deletion' as status,
+    COUNT(DISTINCT pr.id) as pull_requests,
+    COUNT(DISTINCT r.id) as reviews,
+    COUNT(DISTINCT c.id) as comments,
+    COUNT(DISTINCT mr.id) as monthly_rankings,
+    COUNT(DISTINCT das.id) as daily_activity
+FROM contributors cont
+LEFT JOIN pull_requests pr ON cont.id = pr.author_id
+LEFT JOIN reviews r ON cont.id = r.reviewer_id
+LEFT JOIN comments c ON cont.id = c.commenter_id
+LEFT JOIN monthly_rankings mr ON cont.id = mr.contributor_id
+LEFT JOIN daily_activity_snapshots das ON cont.id = das.contributor_id
+WHERE cont.username = 'test-user-author';
+
+-- Delete the test author
+DELETE FROM contributors WHERE username = 'test-user-author';
+
+-- After deletion counts (should preserve records but with NULL contributor_id)
+SELECT 
+    'After Author Deletion' as status,
+    COUNT(DISTINCT pr.id) as pull_requests_preserved,
+    COUNT(DISTINCT CASE WHEN pr.author_id IS NULL THEN pr.id END) as pull_requests_anonymized,
+    COUNT(DISTINCT c.id) as comments_preserved,
+    COUNT(DISTINCT CASE WHEN c.commenter_id IS NULL THEN c.id END) as comments_anonymized,
+    COUNT(DISTINCT mr.id) as monthly_rankings_preserved,
+    COUNT(DISTINCT CASE WHEN mr.contributor_id IS NULL THEN mr.id END) as monthly_rankings_anonymized
+FROM pull_requests pr
+LEFT JOIN comments c ON pr.id = c.pull_request_id
+LEFT JOIN monthly_rankings mr ON pr.id = mr.repository_id
+WHERE pr.title LIKE 'TEST:%';
+
+-- Test 3: Test repository deletion (should CASCADE delete everything)
+SELECT 'TEST 3: Testing repository deletion behavior' as test_name;
+
+-- Before deletion counts
+SELECT 
+    'Before Repository Deletion' as status,
+    COUNT(DISTINCT pr.id) as pull_requests,
+    COUNT(DISTINCT r.id) as reviews,
+    COUNT(DISTINCT c.id) as comments,
+    COUNT(DISTINCT mr.id) as monthly_rankings,
+    COUNT(DISTINCT das.id) as daily_activity
+FROM repositories repo
+LEFT JOIN pull_requests pr ON repo.id = pr.repository_id
+LEFT JOIN reviews r ON pr.id = r.pull_request_id
+LEFT JOIN comments c ON pr.id = c.pull_request_id
+LEFT JOIN monthly_rankings mr ON repo.id = mr.repository_id
+LEFT JOIN daily_activity_snapshots das ON repo.id = das.repository_id
+WHERE repo.full_name = 'test-org-cascade/test-repo';
+
+-- Delete the test repository
+DELETE FROM repositories WHERE full_name = 'test-org-cascade/test-repo';
+
+-- After deletion counts (should be zero due to CASCADE)
+SELECT 
+    'After Repository Deletion' as status,
+    COUNT(DISTINCT pr.id) as pull_requests_remaining,
+    COUNT(DISTINCT r.id) as reviews_remaining,
+    COUNT(DISTINCT c.id) as comments_remaining,
+    COUNT(DISTINCT mr.id) as monthly_rankings_remaining,
+    COUNT(DISTINCT das.id) as daily_activity_remaining
+FROM pull_requests pr
+LEFT JOIN reviews r ON pr.id = r.pull_request_id
+LEFT JOIN comments c ON pr.id = c.pull_request_id
+LEFT JOIN monthly_rankings mr ON pr.repository_id = mr.repository_id
+LEFT JOIN daily_activity_snapshots das ON pr.repository_id = das.repository_id
+WHERE pr.title LIKE 'TEST:%';
+
+-- Test 4: Test views with anonymized data
+SELECT 'TEST 4: Testing views with anonymized contributors' as test_name;
+
+-- Re-create test data for view testing
+INSERT INTO repositories (
+    github_id, full_name, owner, name, description,
+    language, stargazers_count, forks_count,
+    is_fork, github_created_at, github_updated_at
+) VALUES (
+    999992, 'test-org-cascade/test-repo', 'test-org-cascade', 'test-repo', 
+    'Test repository for cascade delete testing',
+    'JavaScript', 50, 10,
+    FALSE, '2020-01-01T00:00:00Z', NOW()
+) ON CONFLICT (github_id) DO UPDATE SET 
+    full_name = EXCLUDED.full_name,
+    description = EXCLUDED.description;
+
+-- Insert PR with NULL author (simulating anonymized contributor)
+INSERT INTO pull_requests (
+    github_id, number, title, body, state, repository_id, author_id,
+    base_branch, head_branch, draft, merged, created_at, updated_at,
+    additions, deletions, changed_files, commits, html_url
+) VALUES (
+    999996, 1, 'TEST: Sample pull request for cascade testing', 
+    'This is a test pull request to verify cascade delete behavior',
+    'open', (SELECT id FROM repositories WHERE full_name = 'test-org-cascade/test-repo'), NULL,
+    'main', 'feature/test-cascade', FALSE, FALSE, 
+    NOW() - INTERVAL '5 days', NOW() - INTERVAL '5 days',
+    100, 50, 5, 3, 'https://github.com/test-org-cascade/test-repo/pull/1'
+) ON CONFLICT (github_id) DO UPDATE SET 
+    title = EXCLUDED.title,
+    author_id = NULL;
+
+-- Test recent_activity view handles NULL contributors
+SELECT 
+    'View Test' as test_name,
+    activity_type,
+    username,
+    description,
+    CASE WHEN contributor_id IS NULL THEN 'ANONYMIZED' ELSE 'NORMAL' END as contributor_status
+FROM recent_activity
+WHERE description LIKE 'TEST:%'
+ORDER BY activity_date DESC;
+
+-- =====================================================
+-- CLEANUP
+-- =====================================================
+
+-- Clean up test data
+DELETE FROM pull_requests WHERE title LIKE 'TEST:%';
+DELETE FROM contributors WHERE username LIKE 'test-user-%';
+DELETE FROM repositories WHERE full_name LIKE 'test-org/%';
+DELETE FROM organizations WHERE login LIKE 'test-org-%';
+
+SELECT 'All cascade delete tests completed successfully!' as result;
+
+-- =====================================================
+-- SUMMARY OF EXPECTED RESULTS
+-- =====================================================
+
+-- TEST 1: Should show all test entities were created
+-- TEST 2: Should show PRs/comments/rankings preserved but anonymized after contributor deletion
+-- TEST 3: Should show all records CASCADE deleted when repository is deleted
+-- TEST 4: Should show views handle NULL contributors with '[deleted]' username
+-- CLEANUP: Should remove all test data
+
+-- If any test fails, investigate the foreign key constraints and ensure they match
+-- the expected cascade behavior defined in the migration.


### PR DESCRIPTION
Implements improved cascade delete behavior as described in issue #61

## Changes
- Replace CASCADE with SET NULL for contributor deletions to preserve history
- Maintain CASCADE for repository deletions to remove all related data
- Update views to handle anonymized contributors gracefully
- Add comprehensive test suite for all cascade delete scenarios

## Testing
To test the cascade behavior, run the SQL commands in `supabase/test-cascade-deletes.sql` in your Supabase Dashboard SQL Editor.

## Migration
Apply the migration by:
1. Copy contents of `supabase/migrations/20240615000000_improved_cascade_deletes.sql`
2. Run in Supabase Dashboard SQL Editor

Fixes #61

Generated with [Claude Code](https://claude.ai/code)