### PR TITLE
fix: bad json

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -148,7 +148,7 @@
       {
         "successComment": "🎉 This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version [${nextRelease.version}](${releases.filter(release => !!release.url).pop().url}) :tada:",
         "labels": ["released"],
-        "releasedLabels": ["released<%= nextRelease.channel ? \`-\${nextRelease.channel}\` : \"\" %>"]
+        "releasedLabels": ["released"]
       }
     ]
   ]


### PR DESCRIPTION
This pull request includes a small change to the `.releaserc.json` file. The change simplifies the `releasedLabels` configuration by removing the dynamic channel suffix from the label.