### PR TITLE
fix: changelog updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,14 +65,10 @@ jobs:
             conventional-changelog-conventionalcommits@7.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '18'
-          cache: 'npm'
 
-      - name: Install dependencies
-        run: npm ci
+      - name: Copy CHANGELOG to public directory
+        if: steps.release.outputs.released == 'true'
+        run: cp CHANGELOG.md public/CHANGELOG.md
 
       - name: Build for production
         run: npm run build
@@ -93,7 +89,7 @@ jobs:
   notify:
     name: Release Notification
     runs-on: ubuntu-latest
-    needs: [release, deploy]
+    needs: [release]
     if: needs.release.outputs.released == 'true'
     steps:
       - name: Create release summary


### PR DESCRIPTION
This pull request makes adjustments to the release workflow in `.github/workflows/release.yml` to streamline the process and improve clarity. The most notable changes involve removing redundant steps and modifying dependencies between jobs.

### Workflow adjustments:

* Removed the `Setup Node.js` and `Install dependencies` steps, simplifying the workflow by eliminating unnecessary setup. (`[.github/workflows/release.ymlL68-R71](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L68-R71)`)
* Added a step to copy the `CHANGELOG.md` file to the `public` directory, ensuring the changelog is accessible after a successful release. (`[.github/workflows/release.ymlL68-R71](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L68-R71)`)
* Updated the `notify` job to no longer depend on the `deploy` job, reducing inter-job dependencies and focusing solely on the `release` job. (`[.github/workflows/release.ymlL96-R92](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L96-R92)`)