### PR TITLE
fix: protect the debug page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,7 @@ import CardLayout from "@/components/social-cards/card-layout";
 import HomeSocialCardWithData from "@/components/social-cards/home-card-with-data";
 import RepoCardWithData from "@/components/social-cards/repo-card-with-data";
 import SocialCardPreview from "@/components/social-cards/preview";
-import SyncTestPage from "@/pages/debug/sync-test";
+import { GitHubSyncDebug } from "@/components/debug/github-sync-debug";
 
 function App() {
   return (
@@ -31,7 +31,7 @@ function App() {
         <Routes>
           <Route path="/login" element={<LoginPage />} />
           <Route
-            path="/debug"
+            path="/dev"
             element={
               <ProtectedRoute>
                 <DebugMenu />
@@ -39,7 +39,7 @@ function App() {
             }
           />
           <Route
-            path="/test-insights"
+            path="/dev/test-insights"
             element={
               <ProtectedRoute>
                 <TestInsights />
@@ -47,7 +47,7 @@ function App() {
             }
           />
           <Route
-            path="/debug-auth"
+            path="/dev/debug-auth"
             element={
               <ProtectedRoute>
                 <DebugAuthPage />
@@ -62,7 +62,14 @@ function App() {
               </ProtectedRoute>
             }
           />
-          <Route path="/debug/sync-test" element={<SyncTestPage />} />
+          <Route
+            path="/dev/sync-test"
+            element={
+              <ProtectedRoute>
+                <GitHubSyncDebug />
+              </ProtectedRoute>
+            }
+          />
 
           {/* Social card routes */}
           <Route

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,8 +8,9 @@ import {
   ContributionsRoute,
   DistributionRoute,
 } from "@/components/features/repository";
-import { LoginPage, DebugAuthPage } from "@/components/features/auth";
+import { LoginPage, DebugAuthPage, ProtectedRoute } from "@/components/features/auth";
 import TestInsights from "@/components/features/auth/test-insights";
+import { DebugMenu } from "@/components/features/debug/debug-menu";
 import { ChangelogPage } from "@/components/features/changelog";
 import { DocsPage } from "@/components/features/docs";
 import { FeedPage } from "@/components/features/feed";
@@ -25,9 +26,10 @@ function App() {
       <Router>
         <Routes>
           <Route path="/login" element={<LoginPage />} />
-          <Route path="/test-insights" element={<TestInsights />} />
-          <Route path="/debug-auth" element={<DebugAuthPage />} />
-          <Route path="/dev/social-cards" element={<SocialCardPreview />} />
+          <Route path="/debug" element={<ProtectedRoute><DebugMenu /></ProtectedRoute>} />
+          <Route path="/test-insights" element={<ProtectedRoute><TestInsights /></ProtectedRoute>} />
+          <Route path="/debug-auth" element={<ProtectedRoute><DebugAuthPage /></ProtectedRoute>} />
+          <Route path="/dev/social-cards" element={<ProtectedRoute><SocialCardPreview /></ProtectedRoute>} />
           
           {/* Social card routes */}
           <Route path="/social-cards" element={<CardLayout><HomeSocialCardWithData /></CardLayout>} />

--- a/src/components/features/auth/index.ts
+++ b/src/components/features/auth/index.ts
@@ -1,5 +1,6 @@
 export { AuthButton } from './auth-button';
 export { LoginDialog } from './login-dialog';
+export { ProtectedRoute } from './protected-route';
 export { default as LoginPage } from './login-page';
 export { default as DebugAuthPage } from './debug-auth-page';
 export { default as LoginDialogTest } from './login-dialog-test';

--- a/src/components/features/auth/protected-route.tsx
+++ b/src/components/features/auth/protected-route.tsx
@@ -1,0 +1,42 @@
+import { useEffect } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+import { useGitHubAuth } from "@/hooks/use-github-auth";
+import { Loader2 } from "lucide-react";
+
+interface ProtectedRouteProps {
+  children: React.ReactNode;
+}
+
+export function ProtectedRoute({ children }: ProtectedRouteProps) {
+  const { isLoggedIn, loading } = useGitHubAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    if (!loading && !isLoggedIn) {
+      // Store the attempted URL for redirect after login
+      const redirectTo = location.pathname + location.search;
+      localStorage.setItem("redirectTo", redirectTo);
+      navigate("/login");
+    }
+  }, [isLoggedIn, loading, navigate, location]);
+
+  // Show loading spinner while checking authentication
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="flex flex-col items-center gap-4">
+          <Loader2 className="h-8 w-8 animate-spin" />
+          <p className="text-sm text-muted-foreground">Checking authentication...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Don't render children if not authenticated (navigation will handle redirect)
+  if (!isLoggedIn) {
+    return null;
+  }
+
+  return <>{children}</>;
+}

--- a/src/components/features/debug/debug-menu.tsx
+++ b/src/components/features/debug/debug-menu.tsx
@@ -1,0 +1,163 @@
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { 
+  Bug, 
+  Key, 
+  TestTube, 
+  Palette, 
+  Activity,
+  FileText,
+  Globe
+} from "lucide-react";
+
+interface DebugRoute {
+  path: string;
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+  category: "auth" | "testing" | "dev" | "insights" | "docs";
+}
+
+const debugRoutes: DebugRoute[] = [
+  {
+    path: "/debug-auth",
+    title: "Authentication Debug",
+    description: "Debug authentication issues, view session details, and test OAuth flow",
+    icon: <Key className="h-4 w-4" />,
+    category: "auth"
+  },
+  {
+    path: "/test-insights",
+    title: "Test Insights",
+    description: "Test insights functionality and data processing",
+    icon: <TestTube className="h-4 w-4" />,
+    category: "testing"
+  },
+  {
+    path: "/dev/social-cards",
+    title: "Social Card Preview",
+    description: "Preview and test social media card generation",
+    icon: <Palette className="h-4 w-4" />,
+    category: "dev"
+  },
+  {
+    path: "/changelog",
+    title: "Changelog",
+    description: "View application changelog and version history",
+    icon: <FileText className="h-4 w-4" />,
+    category: "docs"
+  },
+  {
+    path: "/docs",
+    title: "Documentation",
+    description: "Application documentation and API references",
+    icon: <Globe className="h-4 w-4" />,
+    category: "docs"
+  }
+];
+
+const categoryColors = {
+  auth: "bg-blue-100 text-blue-800",
+  testing: "bg-green-100 text-green-800",
+  dev: "bg-purple-100 text-purple-800",
+  insights: "bg-orange-100 text-orange-800",
+  docs: "bg-gray-100 text-gray-800"
+};
+
+export function DebugMenu() {
+  const navigate = useNavigate();
+
+  const groupedRoutes = debugRoutes.reduce((acc, route) => {
+    if (!acc[route.category]) {
+      acc[route.category] = [];
+    }
+    acc[route.category].push(route);
+    return acc;
+  }, {} as Record<string, DebugRoute[]>);
+
+  return (
+    <div className="container mx-auto py-8 px-4">
+      <div className="max-w-4xl mx-auto">
+        <div className="mb-8 text-center">
+          <h1 className="text-3xl font-bold mb-2 flex items-center justify-center gap-2">
+            <Bug className="h-8 w-8" />
+            Debug Menu
+          </h1>
+          <p className="text-muted-foreground">
+            Access debugging tools and development utilities
+          </p>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {Object.entries(groupedRoutes).map(([category, routes]) => (
+            <Card key={category} className="flex flex-col h-full">
+              <CardHeader className="pb-3">
+                <CardTitle className="flex items-center gap-2">
+                  <Badge className={categoryColors[category as keyof typeof categoryColors]}>
+                    {category.charAt(0).toUpperCase() + category.slice(1)}
+                  </Badge>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {routes.map((route) => (
+                  <div key={route.path}>
+                    <Button
+                      variant="outline"
+                      className="w-full justify-start gap-3 h-auto py-3 px-3 text-left"
+                      onClick={() => navigate(route.path)}
+                    >
+                      <div className="flex-shrink-0">
+                        {route.icon}
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <div className="font-medium text-sm mb-1">{route.title}</div>
+                        <div className="text-xs text-muted-foreground leading-relaxed break-words text-wrap">
+                          {route.description}
+                        </div>
+                      </div>
+                    </Button>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+
+        <div className="mt-8 p-6 bg-muted rounded-lg text-center">
+          <h3 className="font-semibold mb-4 flex items-center justify-center gap-2">
+            <Activity className="h-4 w-4" />
+            Quick Actions
+          </h3>
+          <div className="flex flex-wrap justify-center gap-3">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => window.location.reload()}
+              className="min-w-0"
+            >
+              Reload Page
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => localStorage.clear()}
+              className="min-w-0"
+            >
+              Clear LocalStorage
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => sessionStorage.clear()}
+              className="min-w-0"
+            >
+              Clear SessionStorage
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/debug/debug-menu.tsx
+++ b/src/components/features/debug/debug-menu.tsx
@@ -22,14 +22,14 @@ interface DebugRoute {
 
 const debugRoutes: DebugRoute[] = [
   {
-    path: "/debug-auth",
+    path: "/dev/debug-auth",
     title: "Authentication Debug",
     description: "Debug authentication issues, view session details, and test OAuth flow",
     icon: <Key className="h-4 w-4" />,
     category: "auth"
   },
   {
-    path: "/test-insights",
+    path: "/dev/test-insights",
     title: "Test Insights",
     description: "Test insights functionality and data processing",
     icon: <TestTube className="h-4 w-4" />,

--- a/src/pages/debug/sync-test.tsx
+++ b/src/pages/debug/sync-test.tsx
@@ -1,5 +1,0 @@
-import { GitHubSyncDebug } from '@/components/debug/github-sync-debug'
-
-export default function SyncTestPage() {
-  return <GitHubSyncDebug />
-}


### PR DESCRIPTION
Create a /debug route.

This pull request introduces a `ProtectedRoute` component to enforce authentication for specific routes and adds a new `DebugMenu` component to centralize debugging and development utilities. These changes improve security and provide a more structured interface for debugging tools.

### Authentication Enhancements:
* Introduced a `ProtectedRoute` component in `src/components/features/auth/protected-route.tsx` to restrict access to certain routes based on user authentication. It redirects unauthenticated users to the login page and displays a loading spinner during authentication checks.
* Updated `src/App.tsx` to wrap routes like `/debug`, `/test-insights`, `/debug-auth`, and `/dev/social-cards` with the `ProtectedRoute` component, ensuring only authenticated users can access these pages.
* Exported the `ProtectedRoute` component from `src/components/features/auth/index.ts` for reuse across the application.

### Debugging Tools:
* Added a new `DebugMenu` component in `src/components/features/debug/debug-menu.tsx`. This menu provides a categorized interface for accessing debugging tools and development utilities, such as authentication debugging, test insights, and social card previews.
* Updated imports in `src/App.tsx` to include the `DebugMenu` component, integrating it into the `/debug` route.