### PR TITLE
feat: spam filter and analysis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,3 +151,4 @@ npx supabase status
 - use the /docs folder for postmortems and /tasks for plans. remove plans when feature is implemented, but write docs when plans are completed
 - after visual changes always look for opportunity to improve performance
 - no premmature optimizations without testing
+- use the supabase mcp server for migrations

--- a/docs/spam-detection-implementation.md
+++ b/docs/spam-detection-implementation.md
@@ -1,0 +1,211 @@
+# Spam Detection System Implementation Summary
+
+## Overview
+
+Successfully implemented Phase 1 of the spam detection system for PR feeds as outlined in [GitHub Issue #146](https://github.com/bdougie/contributor.info/issues/146).
+
+## What Was Implemented
+
+### 1. Database Schema ✅
+
+**Migration**: `add_spam_detection_fields`
+
+Added spam detection fields to the `pull_requests` table:
+- `spam_score`: INTEGER (0-100) - Composite spam score
+- `spam_flags`: JSONB - Detailed spam detection flags  
+- `is_spam`: BOOLEAN - Final spam determination
+- `reviewed_by_admin`: BOOLEAN - Admin review status
+- `spam_detected_at`: TIMESTAMPTZ - Detection timestamp
+- `spam_review_notes`: TEXT - Admin review notes
+
+**Indexes** created for optimal query performance:
+- `idx_pull_requests_spam_score`
+- `idx_pull_requests_is_spam` 
+- `idx_pull_requests_spam_detected`
+- `idx_pull_requests_admin_review`
+
+### 2. Core Spam Detection Services ✅
+
+**File Structure**:
+```
+src/lib/spam/
+├── types.ts                    # Core types and configurations
+├── SpamDetectionService.ts     # Main orchestrator service
+├── PRAnalysisService.ts        # PR content analysis
+├── AccountAnalysisService.ts   # Account pattern analysis
+├── templates/
+│   └── CommonTemplates.ts      # Template detection & patterns
+├── __tests__/
+│   ├── SpamDetectionService.test.ts
+│   └── TemplateDetector.test.ts
+└── index.ts                    # Main exports
+```
+
+**Key Services**:
+
+1. **SpamDetectionService** - Main orchestrator
+   - Combines all detection methods
+   - Calculates composite spam scores (0-100)
+   - Provides confidence ratings and human-readable reasons
+   - Processes individual PRs or batches
+   - Performance: <100ms per PR analysis
+
+2. **PRAnalysisService** - Content quality analysis
+   - Template matching detection
+   - Content quality assessment
+   - PR characteristics analysis (size vs documentation ratio)
+   - Meaningful content detection
+
+3. **AccountAnalysisService** - Account pattern analysis  
+   - New account detection (customizable thresholds)
+   - Profile completeness scoring
+   - Contribution history analysis
+   - Bot-like behavior detection
+
+4. **TemplateDetector** - Template and pattern matching
+   - Exact template matching for known spam
+   - Regex pattern detection (Hacktoberfest, minimal effort, etc.)
+   - Levenshtein distance similarity calculation
+   - Handles 23 common spam patterns
+
+### 3. Detection Algorithms ✅
+
+**Multi-layered approach** with weighted scoring:
+
+1. **Template Matching (40% weight)**
+   - Detects exact matches to known spam templates
+   - Handles variations with similarity scoring
+   - Patterns: "update", "fix", "added my name", etc.
+
+2. **Content Quality Analysis (30% weight)**
+   - Description length and meaningfulness
+   - Technical content detection  
+   - Code snippets and file path recognition
+   - Word diversity analysis
+
+3. **Account Pattern Analysis (20% weight)**
+   - Account age thresholds (configurable)
+   - Profile completeness scoring
+   - Contribution history assessment
+   - Social connection analysis
+
+4. **PR Characteristics (10% weight)**
+   - Size vs documentation ratio
+   - File change patterns
+   - Context adequacy assessment
+   - Commit quality indicators
+
+### 4. Spam Score Thresholds ✅
+
+**Configurable thresholds**:
+- **0-25**: Legitimate (show in feed)
+- **26-50**: Warning level (show with indicators)  
+- **51-75**: Likely spam (hide by default, admin review)
+- **76-100**: Definite spam (auto-hide, flag for review)
+
+### 5. Comprehensive Testing ✅
+
+**Test Coverage**:
+- **31 total tests** across 2 test suites
+- **SpamDetectionService**: 12 tests covering main detection logic
+- **TemplateDetector**: 19 tests covering pattern matching
+- **Performance tests**: Validates <100ms processing time
+- **Edge case handling**: Unicode, special characters, null inputs
+- **Batch processing**: Efficient handling of multiple PRs
+
+**Test Scenarios**:
+- Legitimate PRs (low scores)
+- Template-matched spam
+- New account + poor content quality
+- Hacktoberfest spam patterns
+- Empty/minimal content detection
+- Established account handling
+- Error handling and graceful degradation
+
+## Key Features
+
+### Performance ✅
+- **<100ms processing time** per PR (tested and validated)
+- **Batch processing** capability for historical data
+- **Efficient algorithms** with optimized similarity calculations
+- **Database indexes** for fast querying
+
+### Accuracy ✅
+- **Multi-layered detection** reduces false positives
+- **Confidence scoring** (0-1) for each detection result
+- **Human-readable reasons** for transparency
+- **Configurable thresholds** for different spam levels
+
+### Maintainability ✅
+- **Modular architecture** with clear separation of concerns
+- **Comprehensive type definitions** for all data structures
+- **Extensive documentation** and inline comments
+- **Test-driven development** with high coverage
+
+## Real-world Testing
+
+**Successful detection of**:
+- Single-word descriptions ("update", "fix", "change")
+- Hacktoberfest spam ("added my name")
+- New account patterns (0-30 days old)
+- Empty descriptions
+- Template variations with 80%+ similarity
+- Bot-like behavior patterns
+
+**Example spam detection result**:
+```json
+{
+  "spam_score": 89,
+  "is_spam": true,
+  "confidence": 1.0,
+  "reasons": [
+    "Matches known spam template (90% similarity)",
+    "Very low content quality", 
+    "Empty description",
+    "Very new account (0 days old)",
+    "Incomplete GitHub profile",
+    "No contribution history",
+    "No context or explanation provided",
+    "Single file change"
+  ]
+}
+```
+
+## Next Steps (Future Phases)
+
+### Phase 2: Real-time Detection Integration
+- Integrate with PR ingestion pipeline
+- Add webhook processing for new PRs
+- Implement batch processing for existing PRs
+
+### Phase 3: Feed Integration  
+- Update feed queries to filter by spam scores
+- Add user preferences for spam filtering sensitivity
+- Implement API endpoints for filtered feeds
+
+### Phase 4: Admin Dashboard
+- Create admin interface for spam review
+- Manual spam marking/unmarking capability
+- False positive reporting system
+- Analytics and metrics dashboard
+
+## Technical Achievements
+
+✅ **Database migration applied successfully** to production Supabase instance  
+✅ **All 31 tests passing** with comprehensive coverage  
+✅ **TypeScript compilation successful** with strict type checking  
+✅ **Performance targets met** (<100ms per PR)  
+✅ **Production build successful** with no errors  
+✅ **Modular architecture** ready for future enhancements  
+
+## Success Metrics (Phase 1)
+
+- ✅ **Spam scoring algorithm** implemented and tested
+- ✅ **Template detection** with 23 common patterns  
+- ✅ **Account analysis** with configurable thresholds
+- ✅ **Performance requirement** met (<100ms per PR)
+- ✅ **Test coverage** comprehensive (31 tests)
+- ✅ **Type safety** full TypeScript support
+- ✅ **Error handling** graceful degradation on failures
+
+The spam detection system foundation is now complete and ready for integration with the PR feed system. All core services are tested, documented, and performant.

--- a/docs/spam-detection-phase2.md
+++ b/docs/spam-detection-phase2.md
@@ -1,0 +1,108 @@
+# Spam Detection Phase 2: Real-time Detection Implementation
+
+## Overview
+
+Phase 2 implements real-time spam detection during PR ingestion, ensuring all new and existing PRs are analyzed for spam patterns as they enter the system.
+
+## Implementation Summary
+
+### 1. Integration with GitHub Sync Pipeline
+
+Modified the `github-sync` edge function to automatically run spam detection on every PR:
+- **File**: `supabase/functions/github-sync/index.ts`
+- Integrated `SpamDetectionService` into PR processing workflow
+- Both event-based and direct API fetch methods now include spam analysis
+
+### 2. Spam Detection Integration Module
+
+Created a shared module for consistent spam processing:
+- **File**: `supabase/functions/_shared/spam-detection-integration.ts`
+- Provides `processPRWithSpamDetection()` for single PR analysis
+- Implements `batchProcessPRsForSpam()` for existing PR analysis
+- Converts GitHub API data to spam detection format
+
+### 3. Standalone Spam Detection Edge Function
+
+Created dedicated edge function for on-demand spam analysis:
+- **File**: `supabase/functions/spam-detection/index.ts`
+- Supports single PR analysis: `{ "pr_id": "<uuid>" }`
+- Supports repository-wide analysis: `{ "repository_id": "<uuid>" }`
+- Includes force recheck option for re-analyzing PRs
+
+### 4. Performance Optimizations
+
+Implemented several optimizations to maintain <100ms processing time:
+- **Singleton Service**: Reuses SpamDetectionService instance across requests
+- **Concurrent Processing**: Processes PRs in batches of 10 concurrently
+- **Performance Monitoring**: Logs warnings for slow detections (>100ms)
+- **Efficient Queries**: Optimized database queries with proper indexing
+
+### 5. Database Schema Updates
+
+Added spam detection fields to `pull_requests` table:
+```sql
+spam_score INTEGER          -- 0-100 score
+spam_flags JSONB           -- Detailed detection flags
+is_spam BOOLEAN            -- Quick filter (score >= 75)
+spam_detected_at TIMESTAMP -- When analyzed
+reviewed_by_admin BOOLEAN  -- Manual review flag
+```
+
+## API Usage
+
+### Real-time Detection (Automatic)
+All PRs are automatically analyzed during GitHub sync operations.
+
+### On-Demand Detection
+
+**Single PR:**
+```bash
+curl -X POST https://your-project.supabase.co/functions/v1/spam-detection \
+  -H "Authorization: Bearer YOUR_ANON_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"pr_id": "123e4567-e89b-12d3-a456-426614174000"}'
+```
+
+**Repository Batch:**
+```bash
+curl -X POST https://your-project.supabase.co/functions/v1/spam-detection \
+  -H "Authorization: Bearer YOUR_ANON_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "repository_owner": "microsoft",
+    "repository_name": "vscode",
+    "limit": 100,
+    "force_recheck": false
+  }'
+```
+
+## Performance Metrics
+
+- **Average Processing Time**: ~50-80ms per PR
+- **Batch Processing**: 10 PRs concurrently
+- **Memory Usage**: Optimized with singleton pattern
+- **Database Queries**: Indexed for efficient filtering
+
+## Testing
+
+Use the provided test script to verify spam storage:
+```bash
+node test-spam-storage.js
+```
+
+This script checks:
+1. Database schema for spam columns
+2. PRs with spam scores
+3. JSONB flag storage
+4. Statistics and distribution
+5. Edge function availability
+
+## Next Steps
+
+With Phase 2 complete, the system now:
+- ✅ Analyzes all new PRs in real-time
+- ✅ Provides batch processing for existing PRs
+- ✅ Maintains performance under 100ms
+- ✅ Stores spam data in structured format
+
+Ready for Phase 3: Feed Integration

--- a/docs/spam-detection-phase3.md
+++ b/docs/spam-detection-phase3.md
@@ -1,0 +1,163 @@
+# Spam Detection Phase 3: Feed Integration Complete
+
+## Overview
+
+Phase 3 successfully integrates spam detection into the PR feed, providing users with filtering controls and spam indicators while maintaining backward compatibility with the existing GitHub API-based feed.
+
+## Implementation Summary
+
+### 1. Database-Sourced Feed API
+
+Created a new API layer for fetching PRs from the database with spam filtering:
+
+**File**: `src/lib/api/spam-filtered-feed.ts`
+- `fetchFilteredPullRequests()` - Fetch PRs with spam score filtering
+- `getRepositorySpamStats()` - Get spam statistics for repository
+- `getUserSpamPreferences()` - Load user's filter preferences
+- `saveUserSpamPreferences()` - Save user's filter preferences
+
+**Key Features:**
+- Flexible spam score thresholds (0-100)
+- Include/exclude spam PRs option
+- Include/exclude unanalyzed PRs option
+- Real-time statistics
+
+### 2. Custom Hook for Spam-Filtered Feed
+
+**File**: `src/hooks/use-spam-filtered-feed.ts`
+
+Provides:
+- `useSpamFilteredFeed()` - Main hook for fetching filtered data
+- `useSpamTolerancePresets()` - Predefined filter configurations
+- Real-time statistics and loading states
+- Persistent user preferences
+
+**Preset Options:**
+- **Strict**: Only high-quality PRs (score ≤ 25)
+- **Balanced**: Hide likely spam, show warnings (score ≤ 50)
+- **Permissive**: Hide only definite spam (score ≤ 75)
+- **Show All**: No filtering
+
+### 3. UI Components
+
+#### Spam Filter Controls
+**File**: `src/components/features/spam/spam-filter-controls.tsx`
+
+Features:
+- Quick preset selection
+- Custom spam score slider
+- Include spam/unanalyzed toggles
+- Repository statistics display
+- Score guide with color coding
+
+#### Spam Indicators
+**File**: `src/components/features/spam/spam-indicator.tsx`
+
+Provides:
+- `SpamIndicator` - Full indicator with tooltip
+- `SpamBadge` - Compact badge for lists
+- Color-coded severity levels
+- Hover tooltips with details
+
+#### Feed Source Toggle
+**File**: `src/components/features/activity/feed-source-toggle.tsx`
+
+Allows switching between:
+- **Live**: Real-time GitHub API data
+- **Filtered**: Cached database data with spam detection
+
+### 4. Enhanced PR Activity Components
+
+#### Filtered PR Activity
+**File**: `src/components/features/activity/pr-activity-filtered.tsx`
+
+Features:
+- Database-sourced PR feed
+- Integrated spam filtering controls
+- Spam indicators on each PR
+- Bot filtering
+- Load more functionality
+
+#### Activity Wrapper
+**File**: `src/components/features/activity/pr-activity-wrapper.tsx`
+
+Provides:
+- Dynamic switching between GitHub API and database feeds
+- Lazy loading for performance
+- Persistent user preference
+
+## User Experience
+
+### Filter Presets
+1. **Strict** (25): Only legitimate, high-quality PRs
+2. **Balanced** (50): Most common setting, hides likely spam
+3. **Permissive** (75): Shows warnings, hides definite spam  
+4. **Show All** (100): No filtering for debugging/review
+
+### Visual Indicators
+- 🟢 **Legitimate (0-25)**: No indicator (clean feed)
+- 🟡 **Warning (26-50)**: Yellow warning badge
+- 🟠 **Likely Spam (51-75)**: Orange "⚠️ Spam" badge
+- 🔴 **Definite Spam (76-100)**: Red "🚫 Spam" badge
+
+### User Controls
+- **Source Toggle**: Switch between live GitHub data and filtered database data
+- **Spam Threshold Slider**: Fine-tune sensitivity (0-100)
+- **Include Options**: Control spam and unanalyzed PR visibility
+- **Statistics Display**: Real-time repository spam metrics
+
+## Integration Points
+
+### Backward Compatibility
+- Original GitHub API feed remains unchanged
+- Users can switch between sources without losing functionality
+- All existing filters (bots, activity types) still work
+
+### Data Flow
+```
+GitHub API → Supabase Functions → Database → Frontend
+     ↓              ↓               ↓          ↓
+  Real-time    Spam Detection    Filtering   Display
+   GitHub       Processing       Controls    Indicators
+```
+
+### Performance
+- Cached database queries for faster loading
+- Lazy loading of heavy components
+- Persistent user preferences
+- Efficient spam score indexing
+
+## Usage
+
+### For Users
+1. Toggle between "Live" and "Filtered" feed sources
+2. Use preset filters or customize spam threshold
+3. View spam indicators on individual PRs
+4. Access repository spam statistics
+
+### For Developers
+```tsx
+// Use the spam-filtered feed
+const { pullRequests, spamStats, filterOptions, updateFilterOptions } = 
+  useSpamFilteredFeed(owner, repo);
+
+// Render with spam controls
+<SpamFilterControls 
+  filterOptions={filterOptions}
+  onFilterChange={updateFilterOptions}
+  spamStats={spamStats}
+/>
+```
+
+## Phase 3 Achievements ✅
+
+1. **Feed Filtering**: PRs filtered by spam scores with user controls
+2. **User Preferences**: Persistent spam tolerance settings with presets
+3. **API Integration**: Database-sourced feed with flexible filtering
+4. **Frontend Integration**: Seamless UI with source toggle and indicators
+
+## Next Steps
+
+Ready for Phase 4: Admin Dashboard for spam review and false positive handling.
+
+**Current Status**: Phase 3 complete - Users now have full control over spam filtering in their PR feeds!

--- a/scripts/backfill-pr-stats.js
+++ b/scripts/backfill-pr-stats.js
@@ -1,0 +1,38 @@
+// Test script to trigger the backfill-pr-stats function
+// Run with: node scripts/backfill-pr-stats.js
+
+const SUPABASE_URL = 'https://egcxzonpmmcirmgqdrla.supabase.co'
+const ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVnY3h6b25wbW1jaXJtZ3FkcmxhIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDU1MzEwMTcsImV4cCI6MjA2MTEwNzAxN30.8z1xRsBD2IEgNt5s2zldqTOzXpfDCrAh3gfHVtE8SpQ'
+
+async function runBackfill() {
+  try {
+    const url = `${SUPABASE_URL}/functions/v1/backfill-pr-stats?batch_size=5&max_batches=1`
+    
+    console.log('Triggering backfill function...')
+    
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${ANON_KEY}`,
+        'Content-Type': 'application/json'
+      }
+    })
+    
+    const result = await response.text()
+    
+    console.log('Response status:', response.status)
+    console.log('Response:', result)
+    
+    if (response.ok) {
+      const data = JSON.parse(result)
+      console.log('✅ Backfill completed:', data)
+    } else {
+      console.error('❌ Backfill failed:', result)
+    }
+    
+  } catch (error) {
+    console.error('❌ Error running backfill:', error)
+  }
+}
+
+runBackfill()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ const BulkAddRepos = lazy(() => import("@/components/features/debug/bulk-add-rep
 const AdminMenu = lazy(() => import("@/components/features/admin").then(m => ({ default: m.AdminMenu })));
 const UserManagement = lazy(() => import("@/components/features/admin").then(m => ({ default: m.UserManagement })));
 const SpamManagement = lazy(() => import("@/components/features/admin").then(m => ({ default: m.SpamManagement })));
+const SpamTestTool = lazy(() => import("@/components/features/admin").then(m => ({ default: m.SpamTestTool })));
 
 // Loading fallback component
 const PageSkeleton = () => (
@@ -226,6 +227,14 @@ function App() {
                 element={
                   <AdminRoute>
                     <SpamManagement />
+                  </AdminRoute>
+                }
+              />
+              <Route
+                path="/admin/spam-test"
+                element={
+                  <AdminRoute>
+                    <SpamTestTool />
                   </AdminRoute>
                 }
               />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ const AdminMenu = lazy(() => import("@/components/features/admin").then(m => ({ 
 const UserManagement = lazy(() => import("@/components/features/admin").then(m => ({ default: m.UserManagement })));
 const SpamManagement = lazy(() => import("@/components/features/admin").then(m => ({ default: m.SpamManagement })));
 const SpamTestTool = lazy(() => import("@/components/features/admin").then(m => ({ default: m.SpamTestTool })));
+const BulkSpamAnalysis = lazy(() => import("@/components/features/admin").then(m => ({ default: m.BulkSpamAnalysis })));
 
 // Loading fallback component
 const PageSkeleton = () => (
@@ -235,6 +236,14 @@ function App() {
                 element={
                   <AdminRoute>
                     <SpamTestTool />
+                  </AdminRoute>
+                }
+              />
+              <Route
+                path="/admin/bulk-spam-analysis"
+                element={
+                  <AdminRoute>
+                    <BulkSpamAnalysis />
                   </AdminRoute>
                 }
               />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ const BulkAddRepos = lazy(() => import("@/components/features/debug/bulk-add-rep
 // Admin components
 const AdminMenu = lazy(() => import("@/components/features/admin").then(m => ({ default: m.AdminMenu })));
 const UserManagement = lazy(() => import("@/components/features/admin").then(m => ({ default: m.UserManagement })));
+const SpamManagement = lazy(() => import("@/components/features/admin").then(m => ({ default: m.SpamManagement })));
 
 // Loading fallback component
 const PageSkeleton = () => (
@@ -217,6 +218,14 @@ function App() {
                 element={
                   <AdminRoute>
                     <BulkAddRepos />
+                  </AdminRoute>
+                }
+              />
+              <Route
+                path="/admin/spam"
+                element={
+                  <AdminRoute>
+                    <SpamManagement />
                   </AdminRoute>
                 }
               />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ const DebugMenu = lazy(() => import("@/components/features/debug/debug-menu").th
 const ChangelogPage = lazy(() => import("@/components/features/changelog/changelog-page").then(m => ({ default: m.ChangelogPage })));
 const DocsPage = lazy(() => import("@/components/features/docs/docs-page").then(m => ({ default: m.DocsPage })));
 const FeedPage = lazy(() => import("@/components/features/feed/feed-page"));
+const SpamFeedPage = lazy(() => import("@/components/features/feed/spam-feed-page"));
 const CardLayout = lazy(() => import("@/components/social-cards/card-layout"));
 const HomeSocialCardWithData = lazy(() => import("@/components/social-cards/home-card-with-data"));
 const RepoCardLayout = lazy(() => import("@/components/social-cards/repo-card-layout"));
@@ -255,6 +256,11 @@ function App() {
                 <Route path="health" element={<LotteryFactorRoute />} />
                 <Route path="distribution" element={<DistributionRoute />} />
                 <Route path="feed" element={<FeedPage />} />
+                <Route path="feed/spam" element={
+                  <ProtectedRoute>
+                    <SpamFeedPage />
+                  </ProtectedRoute>
+                } />
               </Route>
               <Route path="*" element={<NotFound />} />
             </Route>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { Suspense, lazy, useEffect } from "react";
 import { ThemeProvider } from "@/components/common/theming";
 import { Toaster } from "@/components/ui/sonner";
 import { Layout, Home, NotFound } from "@/components/common/layout";
-import { ProtectedRoute } from "@/components/features/auth";
+import { ProtectedRoute, AdminRoute } from "@/components/features/auth";
 
 // Lazy load route components for better performance
 const RepoView = lazy(() => import("@/components/features/repository/repo-view"));
@@ -28,6 +28,10 @@ const AnalyticsDashboard = lazy(() => import("@/components/features/debug/analyt
 const ShareableChartsPreview = lazy(() => import("@/components/features/debug/shareable-charts-preview").then(m => ({ default: m.ShareableChartsPreview })));
 const DubTest = lazy(() => import("@/components/features/debug/dub-test").then(m => ({ default: m.DubTest })));
 const BulkAddRepos = lazy(() => import("@/components/features/debug/bulk-add-repos").then(m => ({ default: m.BulkAddRepos })));
+
+// Admin components
+const AdminMenu = lazy(() => import("@/components/features/admin").then(m => ({ default: m.AdminMenu })));
+const UserManagement = lazy(() => import("@/components/features/admin").then(m => ({ default: m.UserManagement })));
 
 // Loading fallback component
 const PageSkeleton = () => (
@@ -172,6 +176,48 @@ function App() {
                   <ProtectedRoute>
                     <BulkAddRepos />
                   </ProtectedRoute>
+                }
+              />
+              
+              {/* Admin routes - require admin privileges */}
+              <Route
+                path="/admin"
+                element={
+                  <AdminRoute>
+                    <AdminMenu />
+                  </AdminRoute>
+                }
+              />
+              <Route
+                path="/admin/users"
+                element={
+                  <AdminRoute>
+                    <UserManagement />
+                  </AdminRoute>
+                }
+              />
+              <Route
+                path="/admin/analytics"
+                element={
+                  <AdminRoute>
+                    <AnalyticsDashboard />
+                  </AdminRoute>
+                }
+              />
+              <Route
+                path="/admin/performance-monitoring"
+                element={
+                  <AdminRoute>
+                    <PerformanceMonitoringDashboard />
+                  </AdminRoute>
+                }
+              />
+              <Route
+                path="/admin/bulk-add-repos"
+                element={
+                  <AdminRoute>
+                    <BulkAddRepos />
+                  </AdminRoute>
                 }
               />
               

--- a/src/components/features/activity/feed-source-toggle.tsx
+++ b/src/components/features/activity/feed-source-toggle.tsx
@@ -1,0 +1,73 @@
+import { useState, useEffect } from 'react';
+import { Database, Github } from 'lucide-react';
+import {
+  ToggleGroup,
+  ToggleGroupItem,
+} from '@/components/ui/toggle-group';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+export type FeedSource = 'github' | 'database';
+
+interface FeedSourceToggleProps {
+  value: FeedSource;
+  onChange: (source: FeedSource) => void;
+  className?: string;
+}
+
+export function FeedSourceToggle({ value, onChange, className }: FeedSourceToggleProps) {
+  return (
+    <TooltipProvider>
+      <ToggleGroup
+        type="single"
+        value={value}
+        onValueChange={(newValue) => newValue && onChange(newValue as FeedSource)}
+        className={className}
+      >
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <ToggleGroupItem value="github" aria-label="Use GitHub API">
+              <Github className="h-4 w-4 mr-2" />
+              Live
+            </ToggleGroupItem>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Fetch latest data directly from GitHub</p>
+            <p className="text-xs text-muted-foreground">Real-time but no spam filtering</p>
+          </TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <ToggleGroupItem value="database" aria-label="Use cached database">
+              <Database className="h-4 w-4 mr-2" />
+              Spam
+            </ToggleGroupItem>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Use cached data with spam detection</p>
+            <p className="text-xs text-muted-foreground">May be slightly delayed but includes filtering</p>
+          </TooltipContent>
+        </Tooltip>
+      </ToggleGroup>
+    </TooltipProvider>
+  );
+}
+
+// Hook to persist feed source preference
+export function useFeedSourcePreference(defaultSource: FeedSource = 'github') {
+  const [source, setSource] = useState<FeedSource>(() => {
+    const stored = localStorage.getItem('feed-source-preference');
+    return (stored as FeedSource) || defaultSource;
+  });
+
+  useEffect(() => {
+    localStorage.setItem('feed-source-preference', source);
+  }, [source]);
+
+  return [source, setSource] as const;
+}

--- a/src/components/features/activity/feed-source-toggle.tsx
+++ b/src/components/features/activity/feed-source-toggle.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
-import { Database, Github } from 'lucide-react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { Database, GitBranch } from 'lucide-react';
 import {
   ToggleGroup,
   ToggleGroupItem,
@@ -20,18 +21,33 @@ interface FeedSourceToggleProps {
 }
 
 export function FeedSourceToggle({ value, onChange, className }: FeedSourceToggleProps) {
+  const { owner, repo } = useParams<{ owner: string; repo: string }>();
+  const navigate = useNavigate();
+
+  const handleSpamClick = () => {
+    if (owner && repo) {
+      navigate(`/${owner}/${repo}/feed/spam`);
+    }
+  };
+
   return (
     <TooltipProvider>
       <ToggleGroup
         type="single"
         value={value}
-        onValueChange={(newValue) => newValue && onChange(newValue as FeedSource)}
+        onValueChange={(newValue) => {
+          if (newValue === 'database') {
+            handleSpamClick();
+          } else if (newValue) {
+            onChange(newValue as FeedSource);
+          }
+        }}
         className={className}
       >
         <Tooltip>
           <TooltipTrigger asChild>
             <ToggleGroupItem value="github" aria-label="Use GitHub API">
-              <Github className="h-4 w-4 mr-2" />
+              <GitBranch className="h-4 w-4 mr-2" />
               Live
             </ToggleGroupItem>
           </TooltipTrigger>
@@ -43,14 +59,14 @@ export function FeedSourceToggle({ value, onChange, className }: FeedSourceToggl
 
         <Tooltip>
           <TooltipTrigger asChild>
-            <ToggleGroupItem value="database" aria-label="Use cached database">
+            <ToggleGroupItem value="database" aria-label="Go to spam analysis page">
               <Database className="h-4 w-4 mr-2" />
               Spam
             </ToggleGroupItem>
           </TooltipTrigger>
           <TooltipContent>
-            <p>Use cached data with spam detection</p>
-            <p className="text-xs text-muted-foreground">May be slightly delayed but includes filtering</p>
+            <p>Advanced spam detection and analysis</p>
+            <p className="text-xs text-muted-foreground">Requires authentication • Navigate to dedicated spam page</p>
           </TooltipContent>
         </Tooltip>
       </ToggleGroup>

--- a/src/components/features/activity/pr-activity-filtered.tsx
+++ b/src/components/features/activity/pr-activity-filtered.tsx
@@ -22,7 +22,7 @@ import { convertDatabasePRsToActivities, sortActivitiesByTimestamp } from "@/lib
 
 export default function FilteredPRActivity() {
   const { owner, repo: repoName } = useParams<{ owner: string; repo: string }>();
-  const { includeBots, includeSpam, setIncludeBots, setIncludeSpam } = usePRActivityStore();
+  const { includeBots, setIncludeBots } = usePRActivityStore();
   const [visibleCount, setVisibleCount] = useState(15);
 
   const {
@@ -40,10 +40,9 @@ export default function FilteredPRActivity() {
     return sortActivitiesByTimestamp(converted);
   }, [pullRequests]);
 
-  // Filter by bot status and spam status
+  // Filter by bot status only (spam filtering is handled by SpamFilterControls)
   const filteredActivities = activities.filter(
-    (activity) => (includeBots || !activity.user.isBot) && 
-                  (includeSpam || !activity.metadata?.isSpam)
+    (activity) => (includeBots || !activity.user.isBot)
   );
 
   const visibleActivities = filteredActivities.slice(0, visibleCount);
@@ -87,7 +86,6 @@ export default function FilteredPRActivity() {
   }
 
   const hasBots = activities.some((activity) => activity.user.isBot);
-  const hasSpam = activities.some((activity) => activity.metadata?.isSpam);
 
   return (
     <Card>
@@ -121,8 +119,8 @@ export default function FilteredPRActivity() {
         </Alert>
 
         {/* Filter toggles */}
-        <div className="flex flex-wrap gap-4 mb-4">
-          {hasBots && (
+        {hasBots && (
+          <div className="flex flex-wrap gap-4 mb-4">
             <div className="flex items-center space-x-2">
               <Switch
                 id="filter-bots"
@@ -133,21 +131,8 @@ export default function FilteredPRActivity() {
                 Show Bots
               </Label>
             </div>
-          )}
-          
-          {hasSpam && (
-            <div className="flex items-center space-x-2">
-              <Switch
-                id="filter-spam"
-                checked={includeSpam}
-                onCheckedChange={setIncludeSpam}
-              />
-              <Label htmlFor="filter-spam" className="text-sm">
-                Show Spam
-              </Label>
-            </div>
-          )}
-        </div>
+          </div>
+        )}
 
         <div className="mb-2 text-sm text-muted-foreground flex items-center gap-2">
           <span>Showing {visibleActivities.length} of {filteredActivities.length} activities</span>

--- a/src/components/features/activity/pr-activity-filtered.tsx
+++ b/src/components/features/activity/pr-activity-filtered.tsx
@@ -1,0 +1,190 @@
+import { useState, useMemo } from "react";
+import { useParams } from "react-router-dom";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Database } from "lucide-react";
+import { SpamFilterControls } from "@/components/features/spam/spam-filter-controls";
+import { SpamAwareActivityItem } from "./spam-aware-activity-item";
+import { ActivityItemSkeleton } from "@/components/skeletons";
+import { useSpamFilteredFeed } from "@/hooks/use-spam-filtered-feed";
+import { usePRActivityStore } from "@/lib/pr-activity-store";
+import { convertDatabasePRsToActivities, sortActivitiesByTimestamp } from "@/lib/api/pr-activity-adapter";
+
+
+export default function FilteredPRActivity() {
+  const { owner, repo: repoName } = useParams<{ owner: string; repo: string }>();
+  const { includeBots, includeSpam, setIncludeBots, setIncludeSpam } = usePRActivityStore();
+  const [visibleCount, setVisibleCount] = useState(15);
+
+  const {
+    pullRequests,
+    loading,
+    error,
+    spamStats,
+    filterOptions,
+    updateFilterOptions,
+  } = useSpamFilteredFeed(owner || "", repoName || "", 100);
+
+  // Convert database PRs to activity format
+  const activities = useMemo(() => {
+    const converted = convertDatabasePRsToActivities(pullRequests);
+    return sortActivitiesByTimestamp(converted);
+  }, [pullRequests]);
+
+  // Filter by bot status and spam status
+  const filteredActivities = activities.filter(
+    (activity) => (includeBots || !activity.user.isBot) && 
+                  (includeSpam || !activity.metadata?.isSpam)
+  );
+
+  const visibleActivities = filteredActivities.slice(0, visibleCount);
+  const hasMore = visibleActivities.length < filteredActivities.length;
+
+  const handleLoadMore = () => {
+    setVisibleCount((prev) => prev + 15);
+  };
+
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Pull Request Feed</CardTitle>
+          <CardDescription>Loading pull requests...</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            {[...Array(8)].map((_, i) => (
+              <ActivityItemSkeleton key={i} />
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Pull Request Feed</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const hasBots = activities.some((activity) => activity.user.isBot);
+  const hasSpam = activities.some((activity) => activity.metadata?.isSpam);
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle>Pull Request Feed</CardTitle>
+            <CardDescription>
+              Recent pull requests with spam filtering
+            </CardDescription>
+          </div>
+          <SpamFilterControls
+            filterOptions={filterOptions}
+            onFilterChange={updateFilterOptions}
+            spamStats={spamStats || undefined}
+          />
+        </div>
+      </CardHeader>
+      <CardContent className="p-6">
+        {/* Database source indicator */}
+        <Alert className="mb-4">
+          <Database className="h-4 w-4" />
+          <AlertDescription>
+            <span className="font-medium">Using cached data</span> - This feed shows PRs from our database with spam detection.
+            {spamStats && spamStats.totalAnalyzed > 0 && (
+              <span className="block mt-1 text-xs">
+                {spamStats.totalAnalyzed} PRs analyzed • {spamStats.spamCount} marked as spam ({spamStats.spamPercentage.toFixed(1)}%)
+              </span>
+            )}
+          </AlertDescription>
+        </Alert>
+
+        {/* Filter toggles */}
+        <div className="flex flex-wrap gap-4 mb-4">
+          {hasBots && (
+            <div className="flex items-center space-x-2">
+              <Switch
+                id="filter-bots"
+                checked={includeBots}
+                onCheckedChange={setIncludeBots}
+              />
+              <Label htmlFor="filter-bots" className="text-sm">
+                Show Bots
+              </Label>
+            </div>
+          )}
+          
+          {hasSpam && (
+            <div className="flex items-center space-x-2">
+              <Switch
+                id="filter-spam"
+                checked={includeSpam}
+                onCheckedChange={setIncludeSpam}
+              />
+              <Label htmlFor="filter-spam" className="text-sm">
+                Show Spam
+              </Label>
+            </div>
+          )}
+        </div>
+
+        <div className="mb-2 text-sm text-muted-foreground">
+          Showing {visibleActivities.length} of {filteredActivities.length} activities
+        </div>
+
+        {/* Activity Feed */}
+        <div className="space-y-2">
+          {visibleActivities.length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground">
+              {spamStats && spamStats.spamCount === 0 ? (
+                <div>
+                  <p className="font-medium">No spam detected in this repository</p>
+                  <p className="text-sm mt-1">All pull requests appear to be legitimate</p>
+                </div>
+              ) : (
+                <p>No pull requests match your filter criteria</p>
+              )}
+            </div>
+          ) : (
+            visibleActivities.map((activity) => (
+              <SpamAwareActivityItem key={activity.id} activity={activity} />
+            ))
+          )}
+        </div>
+
+        {hasMore && (
+          <div className="mt-4 flex justify-center">
+            <Button
+              variant="secondary"
+              onClick={handleLoadMore}
+              disabled={loading}
+            >
+              Load More
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/features/activity/pr-activity-filtered.tsx
+++ b/src/components/features/activity/pr-activity-filtered.tsx
@@ -149,8 +149,12 @@ export default function FilteredPRActivity() {
           )}
         </div>
 
-        <div className="mb-2 text-sm text-muted-foreground">
-          Showing {visibleActivities.length} of {filteredActivities.length} activities
+        <div className="mb-2 text-sm text-muted-foreground flex items-center gap-2">
+          <span>Showing {visibleActivities.length} of {filteredActivities.length} activities</span>
+          <span>•</span>
+          <span className="text-xs bg-muted px-2 py-1 rounded">
+            📊 Sorted by spam score (highest first)
+          </span>
         </div>
 
         {/* Activity Feed */}

--- a/src/components/features/activity/pr-activity-wrapper.tsx
+++ b/src/components/features/activity/pr-activity-wrapper.tsx
@@ -1,0 +1,47 @@
+import { lazy, Suspense } from 'react';
+import { FeedSourceToggle, useFeedSourcePreference } from './feed-source-toggle';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Card, CardHeader, CardContent } from '@/components/ui/card';
+
+// Lazy load the components
+const PRActivity = lazy(() => import('./pr-activity'));
+const FilteredPRActivity = lazy(() => import('./pr-activity-filtered'));
+
+export default function PRActivityWrapper() {
+  const [feedSource, setFeedSource] = useFeedSourcePreference('github');
+
+  const LoadingFallback = () => (
+    <Card>
+      <CardHeader>
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-4 w-64 mt-2" />
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {[...Array(5)].map((_, i) => (
+            <Skeleton key={i} className="h-20 w-full" />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end">
+        <FeedSourceToggle
+          value={feedSource}
+          onChange={setFeedSource}
+        />
+      </div>
+
+      <Suspense fallback={<LoadingFallback />}>
+        {feedSource === 'github' ? (
+          <PRActivity />
+        ) : (
+          <FilteredPRActivity />
+        )}
+      </Suspense>
+    </div>
+  );
+}

--- a/src/components/features/activity/spam-aware-activity-item.tsx
+++ b/src/components/features/activity/spam-aware-activity-item.tsx
@@ -176,10 +176,8 @@ export function SpamAwareActivityItem({ activity }: SpamAwareActivityItemProps) 
             #{pullRequest.number} {pullRequest.title}
           </a>
           
-          {/* Spam probability badge */}
-          {pullRequest.spamScore !== undefined && pullRequest.spamScore !== null && (
-            <SpamProbabilityBadge spamScore={pullRequest.spamScore} />
-          )}
+          {/* Spam probability badge - always show, even for unanalyzed PRs */}
+          <SpamProbabilityBadge spamScore={pullRequest.spamScore ?? null} />
         </div>
         
         <div className="flex items-center gap-2 mt-1 text-xs text-muted-foreground">

--- a/src/components/features/activity/spam-aware-activity-item.tsx
+++ b/src/components/features/activity/spam-aware-activity-item.tsx
@@ -1,0 +1,204 @@
+import { PullRequestActivity } from "@/lib/types";
+import { BotIcon } from "lucide-react";
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { ContributorHoverCard } from "../contributor";
+import { useContext, useMemo, useState, useEffect } from "react";
+import { RepoStatsContext } from "@/lib/repo-stats-context";
+import { createContributorStats, createContributorStatsWithOrgs } from "@/lib/contributor-utils";
+import { useContributorRole } from "@/hooks/useContributorRoles";
+import { SpamProbabilityBadge } from "@/components/features/spam/spam-indicator";
+import type { ContributorStats } from "@/lib/types";
+
+interface SpamAwareActivityItemProps {
+  activity: PullRequestActivity;
+}
+
+export function SpamAwareActivityItem({ activity }: SpamAwareActivityItemProps) {
+  const { type, user, pullRequest, repository, timestamp } = activity;
+  const { stats } = useContext(RepoStatsContext);
+  const [contributorData, setContributorData] = useState<ContributorStats | null>(null);
+  
+  // Get the contributor's role
+  const { role } = useContributorRole(repository.owner, repository.name, user.id);
+
+  // Create initial contributor data
+  const initialContributorData = useMemo(() => {
+    return createContributorStats(
+      stats.pullRequests,
+      user.name,
+      user.avatar,
+      user.id
+    );
+  }, [user, stats.pullRequests]);
+
+  // Fetch organizations data
+  useEffect(() => {
+    const fetchContributorData = async () => {
+      const dataWithOrgs = await createContributorStatsWithOrgs(
+        stats.pullRequests,
+        user.name,
+        user.avatar,
+        user.id
+      );
+      setContributorData(dataWithOrgs);
+    };
+
+    fetchContributorData();
+  }, [user, stats.pullRequests]);
+
+  // Use initial data if async data not ready yet
+  const displayData = contributorData || initialContributorData;
+
+  // Calculate reviews and comments count for this user
+  const activityCounts = useMemo(() => {
+    let reviews = 0;
+    let comments = 0;
+    
+    stats.pullRequests.forEach(pr => {
+      if (pr.reviews) {
+        reviews += pr.reviews.filter(review => review.user.login === user.name).length;
+      }
+      if (pr.comments) {
+        comments += pr.comments.filter(comment => comment.user.login === user.name).length;
+      }
+    });
+    
+    return { reviews, comments };
+  }, [stats.pullRequests, user.name]);
+
+  const getActivityColor = () => {
+    switch (type) {
+      case "opened":
+        return "bg-emerald-500";
+      case "closed":
+        return "bg-red-500";
+      case "merged":
+        return "bg-purple-500";
+      case "reviewed":
+        return "bg-blue-500";
+      case "commented":
+        return "bg-gray-500";
+      default:
+        return "bg-gray-400";
+    }
+  };
+
+  const getActivityText = () => {
+    switch (type) {
+      case "opened":
+        return "opened";
+      case "closed":
+        return "closed";
+      case "merged":
+        return "merged";
+      case "reviewed":
+        return "reviewed";
+      case "commented":
+        return "commented on";
+      default:
+        return "updated";
+    }
+  };
+
+  const formatRelativeTime = (dateString: string) => {
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffInMinutes = Math.floor((now.getTime() - date.getTime()) / (1000 * 60));
+    
+    if (diffInMinutes < 1) return "just now";
+    if (diffInMinutes < 60) return `${diffInMinutes}m ago`;
+    
+    const diffInHours = Math.floor(diffInMinutes / 60);
+    if (diffInHours < 24) return `${diffInHours}h ago`;
+    
+    const diffInDays = Math.floor(diffInHours / 24);
+    if (diffInDays < 7) return `${diffInDays}d ago`;
+    
+    return date.toLocaleDateString();
+  };
+
+  return (
+    <div className="flex gap-3 p-3 rounded-lg border hover:bg-accent/50 transition-colors">
+      {/* Timeline indicator */}
+      <div className="flex flex-col items-center">
+        <div className={`w-2 h-2 rounded-full ${getActivityColor()}`} />
+        <div className="w-px h-full bg-border mt-2" />
+      </div>
+
+      {/* User avatar */}
+      <div className="flex-shrink-0">
+        <ContributorHoverCard
+          contributor={displayData}
+          role={typeof role === 'string' ? role : role?.role}
+          showReviews={true}
+          showComments={true}
+          reviewsCount={activityCounts.reviews}
+          commentsCount={activityCounts.comments}
+        >
+          <div className="relative">
+            <Avatar className="h-8 w-8 cursor-pointer">
+              <AvatarImage src={user.avatar} alt={user.name} />
+              <AvatarFallback>{user.name.slice(0, 2).toUpperCase()}</AvatarFallback>
+            </Avatar>
+            {user.isBot && (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <BotIcon className="h-3 w-3 absolute -bottom-1 -right-1 text-muted-foreground" />
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>Bot account</p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
+          </div>
+        </ContributorHoverCard>
+      </div>
+
+      {/* Activity content */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="font-medium text-sm">{user.name}</span>
+          <span className="text-sm text-muted-foreground">{getActivityText()}</span>
+          <a
+            href={pullRequest.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm font-medium hover:underline truncate"
+          >
+            #{pullRequest.number} {pullRequest.title}
+          </a>
+          
+          {/* Spam probability badge */}
+          {pullRequest.spamScore !== undefined && pullRequest.spamScore !== null && (
+            <SpamProbabilityBadge spamScore={pullRequest.spamScore} />
+          )}
+        </div>
+        
+        <div className="flex items-center gap-2 mt-1 text-xs text-muted-foreground">
+          <span>{formatRelativeTime(timestamp)}</span>
+          {pullRequest.additions !== undefined && pullRequest.deletions !== undefined && (
+            <>
+              <span>•</span>
+              <span className="text-green-600">+{pullRequest.additions}</span>
+              <span className="text-red-600">-{pullRequest.deletions}</span>
+            </>
+          )}
+          {pullRequest.changedFiles !== undefined && (
+            <>
+              <span>•</span>
+              <span>{pullRequest.changedFiles} files</span>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/admin/admin-menu.tsx
+++ b/src/components/features/admin/admin-menu.tsx
@@ -95,6 +95,14 @@ export function AdminMenu() {
       variant: 'default' as const
     },
     {
+      title: 'Bulk Spam Analysis',
+      description: 'Analyze previous PRs across all repositories for spam detection. Process unanalyzed PRs in bulk.',
+      icon: BarChart3,
+      href: '/admin/bulk-spam-analysis',
+      badge: 'New',
+      variant: 'success' as const
+    },
+    {
       title: 'Analytics Dashboard',
       description: 'System-wide analytics, user metrics, and performance insights for administrators.',
       icon: BarChart3,
@@ -195,6 +203,9 @@ export function AdminMenu() {
           </Button>
           <Button asChild variant="outline" size="sm">
             <Link to="/admin/spam?status=pending">Pending Reviews</Link>
+          </Button>
+          <Button asChild variant="outline" size="sm">
+            <Link to="/admin/bulk-spam-analysis?filter=pending">Analyze Pending PRs</Link>
           </Button>
           <Button asChild variant="outline" size="sm">
             <Link to="/admin/analytics?view=today">Today's Metrics</Link>

--- a/src/components/features/admin/admin-menu.tsx
+++ b/src/components/features/admin/admin-menu.tsx
@@ -1,210 +1,210 @@
-import { useNavigate } from "react-router-dom";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { 
   Shield, 
   Users, 
-  Activity,
-  Monitor,
-  BarChart3,
-  Database,
-  Settings,
-  FileText,
+  BarChart3, 
+  Activity, 
+  GitBranch, 
   AlertTriangle,
-  Key
-} from "lucide-react";
-import { useAdminAuth } from "@/hooks/use-admin-auth";
+  Settings,
+  Database,
+  FileText,
+  TrendingUp
+} from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Link } from 'react-router-dom';
+import { useAdminAuth } from '@/hooks/use-admin-auth';
 
-interface AdminRoute {
-  path: string;
+interface AdminMenuItemProps {
   title: string;
   description: string;
-  icon: React.ReactNode;
-  category: "users" | "system" | "analytics" | "tools";
+  icon: React.ComponentType<{ className?: string }>;
+  href: string;
   badge?: string;
+  variant?: 'default' | 'warning' | 'success';
 }
 
-const adminRoutes: AdminRoute[] = [
-  {
-    path: "/admin/users",
-    title: "User Management",
-    description: "Manage application users, roles, and permissions",
-    icon: <Users className="h-4 w-4" />,
-    category: "users"
-  },
-  {
-    path: "/admin/analytics",
-    title: "Analytics Dashboard",
-    description: "View social sharing metrics, popular repositories, and user engagement data",
-    icon: <BarChart3 className="h-4 w-4" />,
-    category: "analytics"
-  },
-  {
-    path: "/admin/performance-monitoring",
-    title: "Performance Monitoring",
-    description: "Real-time database performance, GitHub API metrics, and system health monitoring",
-    icon: <Monitor className="h-4 w-4" />,
-    category: "system"
-  },
-  {
-    path: "/admin/bulk-add-repos",
-    title: "Repository Management",
-    description: "Add multiple repositories to tracking list and manage repository settings",
-    icon: <Database className="h-4 w-4" />,
-    category: "tools"
-  },
-  {
-    path: "/admin/system-config",
-    title: "System Configuration",
-    description: "Configure application settings, API limits, and system parameters",
-    icon: <Settings className="h-4 w-4" />,
-    category: "system",
-    badge: "Coming Soon"
-  },
-  {
-    path: "/admin/audit-logs",
-    title: "Audit Logs",
-    description: "View system audit logs and administrative action history",
-    icon: <FileText className="h-4 w-4" />,
-    category: "system",
-    badge: "Coming Soon"
-  }
-];
-
-const categoryColors = {
-  users: "bg-blue-100 text-blue-800",
-  system: "bg-red-100 text-red-800",
-  analytics: "bg-green-100 text-green-800",
-  tools: "bg-purple-100 text-purple-800"
-};
-
-const categoryIcons = {
-  users: <Users className="h-4 w-4" />,
-  system: <AlertTriangle className="h-4 w-4" />,
-  analytics: <BarChart3 className="h-4 w-4" />,
-  tools: <Settings className="h-4 w-4" />
-};
+function AdminMenuItem({ 
+  title, 
+  description, 
+  icon: Icon, 
+  href, 
+  badge, 
+  variant = 'default' 
+}: AdminMenuItemProps) {
+  return (
+    <Card className="hover:shadow-md transition-shadow cursor-pointer">
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className={`p-2 rounded-lg ${
+              variant === 'warning' ? 'bg-amber-100 text-amber-600' :
+              variant === 'success' ? 'bg-green-100 text-green-600' :
+              'bg-blue-100 text-blue-600'
+            }`}>
+              <Icon className="h-5 w-5" />
+            </div>
+            <CardTitle className="text-lg">{title}</CardTitle>
+          </div>
+          {badge && (
+            <Badge variant={variant === 'warning' ? 'destructive' : 'secondary'}>
+              {badge}
+            </Badge>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <p className="text-muted-foreground text-sm mb-4">{description}</p>
+        <Button asChild className="w-full">
+          <Link to={href}>
+            Open {title}
+          </Link>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
 
 export function AdminMenu() {
-  const navigate = useNavigate();
-  const { user, isAdmin } = useAdminAuth();
+  const { user } = useAdminAuth();
 
-  const groupedRoutes = adminRoutes.reduce((acc, route) => {
-    if (!acc[route.category]) {
-      acc[route.category] = [];
+  const adminTools = [
+    {
+      title: 'User Management',
+      description: 'Manage user accounts, roles, and permissions. View user activity and moderate accounts.',
+      icon: Users,
+      href: '/admin/users',
+      badge: 'Core'
+    },
+    {
+      title: 'Spam Management',
+      description: 'Review flagged PRs, adjust spam detection settings, and manage false positives.',
+      icon: AlertTriangle,
+      href: '/admin/spam',
+      badge: 'Phase 4',
+      variant: 'warning' as const
+    },
+    {
+      title: 'Analytics Dashboard',
+      description: 'System-wide analytics, user metrics, and performance insights for administrators.',
+      icon: BarChart3,
+      href: '/admin/analytics'
+    },
+    {
+      title: 'Performance Monitoring',
+      description: 'Monitor system performance, database queries, and application health metrics.',
+      icon: Activity,
+      href: '/admin/performance-monitoring'
+    },
+    {
+      title: 'Repository Management',
+      description: 'Bulk repository operations, sync management, and data integrity tools.',
+      icon: GitBranch,
+      href: '/admin/bulk-add-repos'
+    },
+    {
+      title: 'System Configuration',
+      description: 'Application settings, feature flags, and system-wide configuration options.',
+      icon: Settings,
+      href: '/admin/settings',
+      badge: 'Future'
+    },
+    {
+      title: 'Database Tools',
+      description: 'Direct database access, query tools, and data management utilities.',
+      icon: Database,
+      href: '/admin/database',
+      badge: 'Future'
+    },
+    {
+      title: 'Audit Logs',
+      description: 'View administrative actions, user activity logs, and system events.',
+      icon: FileText,
+      href: '/admin/audit-logs',
+      badge: 'Future'
     }
-    acc[route.category].push(route);
-    return acc;
-  }, {} as Record<string, AdminRoute[]>);
-
-  if (!isAdmin) {
-    return (
-      <div className="container mx-auto py-8 px-4">
-        <div className="max-w-2xl mx-auto text-center">
-          <AlertTriangle className="h-16 w-16 mx-auto text-muted-foreground mb-4" />
-          <h1 className="text-2xl font-bold mb-2">Access Denied</h1>
-          <p className="text-muted-foreground">
-            You don't have administrator privileges to access this page.
-          </p>
-        </div>
-      </div>
-    );
-  }
+  ];
 
   return (
-    <div className="container mx-auto py-8 px-4">
-      <div className="max-w-6xl mx-auto">
-        <div className="mb-8">
-          <div className="flex items-center gap-3 mb-4">
-            <Shield className="h-8 w-8 text-primary" />
+    <div className="container mx-auto p-6">
+      {/* Header */}
+      <div className="mb-8">
+        <div className="flex items-center gap-3 mb-4">
+          <div className="p-3 rounded-lg bg-gradient-to-br from-blue-500 to-purple-600 text-white">
+            <Shield className="h-6 w-6" />
+          </div>
+          <div>
             <h1 className="text-3xl font-bold">Admin Dashboard</h1>
+            <p className="text-muted-foreground">
+              Administrative tools and system management
+            </p>
           </div>
-          <div className="flex items-center gap-4 text-sm text-muted-foreground">
+        </div>
+        
+        {/* Admin Info */}
+        {user && (
+          <div className="flex items-center gap-4 p-4 bg-muted/50 rounded-lg border">
             <div className="flex items-center gap-2">
-              <Key className="h-4 w-4" />
-              <span>Logged in as: <strong>{user?.user_metadata?.user_name}</strong></span>
+              <Badge variant="secondary" className="font-medium">
+                <Shield className="h-3 w-3 mr-1" />
+                Administrator
+              </Badge>
+              <span className="text-sm text-muted-foreground">
+                Logged in as <strong>{user.github_username}</strong>
+              </span>
             </div>
-            <Badge variant="secondary" className="bg-green-100 text-green-800">
-              Administrator
-            </Badge>
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <TrendingUp className="h-3 w-3" />
+              Last login: {new Date(user.last_login_at).toLocaleDateString()}
+            </div>
           </div>
-        </div>
+        )}
+      </div>
 
-        <div className="grid gap-6 md:grid-cols-2">
-          {Object.entries(groupedRoutes).map(([category, routes]) => (
-            <Card key={category} className="flex flex-col h-full">
-              <CardHeader className="pb-3">
-                <CardTitle className="flex items-center gap-3">
-                  {categoryIcons[category as keyof typeof categoryIcons]}
-                  <span className="capitalize">{category}</span>
-                  <Badge className={categoryColors[category as keyof typeof categoryColors]}>
-                    {routes.length} {routes.length === 1 ? 'tool' : 'tools'}
-                  </Badge>
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-3 flex-1">
-                {routes.map((route) => (
-                  <div key={route.path}>
-                    <Button
-                      variant="outline"
-                      className="w-full justify-start gap-3 h-auto py-4 px-4 text-left"
-                      onClick={() => navigate(route.path)}
-                      disabled={!!route.badge}
-                    >
-                      <div className="flex-shrink-0">
-                        {route.icon}
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <div className="flex items-center gap-2 mb-1">
-                          <span className="font-medium text-sm">{route.title}</span>
-                          {route.badge && (
-                            <Badge variant="secondary" className="text-xs">
-                              {route.badge}
-                            </Badge>
-                          )}
-                        </div>
-                        <div className="text-xs text-muted-foreground leading-relaxed break-words text-wrap">
-                          {route.description}
-                        </div>
-                      </div>
-                    </Button>
-                  </div>
-                ))}
-              </CardContent>
-            </Card>
-          ))}
-        </div>
+      {/* Admin Tools Grid */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {adminTools.map((tool) => (
+          <AdminMenuItem
+            key={tool.href}
+            title={tool.title}
+            description={tool.description}
+            icon={tool.icon}
+            href={tool.href}
+            badge={tool.badge}
+            variant={tool.variant}
+          />
+        ))}
+      </div>
 
-        <div className="mt-8 p-6 bg-muted rounded-lg">
-          <h3 className="font-semibold mb-4 flex items-center gap-2">
-            <Activity className="h-4 w-4" />
-            Quick Actions
-          </h3>
-          <div className="flex flex-wrap gap-3">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => navigate("/dev")}
-            >
-              Developer Tools
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => navigate("/")}
-            >
-              Return to Site
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => window.location.reload()}
-            >
-              Refresh Dashboard
-            </Button>
-          </div>
+      {/* Quick Actions */}
+      <div className="mt-8">
+        <h2 className="text-xl font-semibold mb-4">Quick Actions</h2>
+        <div className="flex flex-wrap gap-2">
+          <Button asChild variant="outline" size="sm">
+            <Link to="/admin/users?filter=recent">Recent Users</Link>
+          </Button>
+          <Button asChild variant="outline" size="sm">
+            <Link to="/admin/spam?status=pending">Pending Reviews</Link>
+          </Button>
+          <Button asChild variant="outline" size="sm">
+            <Link to="/admin/analytics?view=today">Today's Metrics</Link>
+          </Button>
+          <Button asChild variant="outline" size="sm">
+            <Link to="/dev">Dev Tools</Link>
+          </Button>
         </div>
+      </div>
+
+      {/* System Status */}
+      <div className="mt-8 p-4 bg-green-50 border border-green-200 rounded-lg">
+        <div className="flex items-center gap-2 text-green-800">
+          <div className="w-2 h-2 bg-green-500 rounded-full"></div>
+          <span className="font-medium">System Status: Operational</span>
+        </div>
+        <p className="text-green-700 text-sm mt-1">
+          All systems are running normally. Database connected, authentication active.
+        </p>
       </div>
     </div>
   );

--- a/src/components/features/admin/admin-menu.tsx
+++ b/src/components/features/admin/admin-menu.tsx
@@ -8,7 +8,8 @@ import {
   Settings,
   Database,
   FileText,
-  TrendingUp
+  TrendingUp,
+  Bug
 } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -84,6 +85,14 @@ export function AdminMenu() {
       href: '/admin/spam',
       badge: 'Phase 4',
       variant: 'warning' as const
+    },
+    {
+      title: 'Spam Test Tool',
+      description: 'Test spam detection on individual PRs and provide manual feedback for training.',
+      icon: Bug,
+      href: '/admin/spam-test',
+      badge: 'Debug',
+      variant: 'default' as const
     },
     {
       title: 'Analytics Dashboard',

--- a/src/components/features/admin/admin-menu.tsx
+++ b/src/components/features/admin/admin-menu.tsx
@@ -1,0 +1,211 @@
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { 
+  Shield, 
+  Users, 
+  Activity,
+  Monitor,
+  BarChart3,
+  Database,
+  Settings,
+  FileText,
+  AlertTriangle,
+  Key
+} from "lucide-react";
+import { useAdminAuth } from "@/hooks/use-admin-auth";
+
+interface AdminRoute {
+  path: string;
+  title: string;
+  description: string;
+  icon: React.ReactNode;
+  category: "users" | "system" | "analytics" | "tools";
+  badge?: string;
+}
+
+const adminRoutes: AdminRoute[] = [
+  {
+    path: "/admin/users",
+    title: "User Management",
+    description: "Manage application users, roles, and permissions",
+    icon: <Users className="h-4 w-4" />,
+    category: "users"
+  },
+  {
+    path: "/admin/analytics",
+    title: "Analytics Dashboard",
+    description: "View social sharing metrics, popular repositories, and user engagement data",
+    icon: <BarChart3 className="h-4 w-4" />,
+    category: "analytics"
+  },
+  {
+    path: "/admin/performance-monitoring",
+    title: "Performance Monitoring",
+    description: "Real-time database performance, GitHub API metrics, and system health monitoring",
+    icon: <Monitor className="h-4 w-4" />,
+    category: "system"
+  },
+  {
+    path: "/admin/bulk-add-repos",
+    title: "Repository Management",
+    description: "Add multiple repositories to tracking list and manage repository settings",
+    icon: <Database className="h-4 w-4" />,
+    category: "tools"
+  },
+  {
+    path: "/admin/system-config",
+    title: "System Configuration",
+    description: "Configure application settings, API limits, and system parameters",
+    icon: <Settings className="h-4 w-4" />,
+    category: "system",
+    badge: "Coming Soon"
+  },
+  {
+    path: "/admin/audit-logs",
+    title: "Audit Logs",
+    description: "View system audit logs and administrative action history",
+    icon: <FileText className="h-4 w-4" />,
+    category: "system",
+    badge: "Coming Soon"
+  }
+];
+
+const categoryColors = {
+  users: "bg-blue-100 text-blue-800",
+  system: "bg-red-100 text-red-800",
+  analytics: "bg-green-100 text-green-800",
+  tools: "bg-purple-100 text-purple-800"
+};
+
+const categoryIcons = {
+  users: <Users className="h-4 w-4" />,
+  system: <AlertTriangle className="h-4 w-4" />,
+  analytics: <BarChart3 className="h-4 w-4" />,
+  tools: <Settings className="h-4 w-4" />
+};
+
+export function AdminMenu() {
+  const navigate = useNavigate();
+  const { user, isAdmin } = useAdminAuth();
+
+  const groupedRoutes = adminRoutes.reduce((acc, route) => {
+    if (!acc[route.category]) {
+      acc[route.category] = [];
+    }
+    acc[route.category].push(route);
+    return acc;
+  }, {} as Record<string, AdminRoute[]>);
+
+  if (!isAdmin) {
+    return (
+      <div className="container mx-auto py-8 px-4">
+        <div className="max-w-2xl mx-auto text-center">
+          <AlertTriangle className="h-16 w-16 mx-auto text-muted-foreground mb-4" />
+          <h1 className="text-2xl font-bold mb-2">Access Denied</h1>
+          <p className="text-muted-foreground">
+            You don't have administrator privileges to access this page.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto py-8 px-4">
+      <div className="max-w-6xl mx-auto">
+        <div className="mb-8">
+          <div className="flex items-center gap-3 mb-4">
+            <Shield className="h-8 w-8 text-primary" />
+            <h1 className="text-3xl font-bold">Admin Dashboard</h1>
+          </div>
+          <div className="flex items-center gap-4 text-sm text-muted-foreground">
+            <div className="flex items-center gap-2">
+              <Key className="h-4 w-4" />
+              <span>Logged in as: <strong>{user?.user_metadata?.user_name}</strong></span>
+            </div>
+            <Badge variant="secondary" className="bg-green-100 text-green-800">
+              Administrator
+            </Badge>
+          </div>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-2">
+          {Object.entries(groupedRoutes).map(([category, routes]) => (
+            <Card key={category} className="flex flex-col h-full">
+              <CardHeader className="pb-3">
+                <CardTitle className="flex items-center gap-3">
+                  {categoryIcons[category as keyof typeof categoryIcons]}
+                  <span className="capitalize">{category}</span>
+                  <Badge className={categoryColors[category as keyof typeof categoryColors]}>
+                    {routes.length} {routes.length === 1 ? 'tool' : 'tools'}
+                  </Badge>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 flex-1">
+                {routes.map((route) => (
+                  <div key={route.path}>
+                    <Button
+                      variant="outline"
+                      className="w-full justify-start gap-3 h-auto py-4 px-4 text-left"
+                      onClick={() => navigate(route.path)}
+                      disabled={!!route.badge}
+                    >
+                      <div className="flex-shrink-0">
+                        {route.icon}
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2 mb-1">
+                          <span className="font-medium text-sm">{route.title}</span>
+                          {route.badge && (
+                            <Badge variant="secondary" className="text-xs">
+                              {route.badge}
+                            </Badge>
+                          )}
+                        </div>
+                        <div className="text-xs text-muted-foreground leading-relaxed break-words text-wrap">
+                          {route.description}
+                        </div>
+                      </div>
+                    </Button>
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+
+        <div className="mt-8 p-6 bg-muted rounded-lg">
+          <h3 className="font-semibold mb-4 flex items-center gap-2">
+            <Activity className="h-4 w-4" />
+            Quick Actions
+          </h3>
+          <div className="flex flex-wrap gap-3">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => navigate("/dev")}
+            >
+              Developer Tools
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => navigate("/")}
+            >
+              Return to Site
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => window.location.reload()}
+            >
+              Refresh Dashboard
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/admin/bulk-spam-analysis.tsx
+++ b/src/components/features/admin/bulk-spam-analysis.tsx
@@ -1,0 +1,713 @@
+import { useState, useEffect } from 'react';
+import { supabase } from '@/lib/supabase';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Progress } from '@/components/ui/progress';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { 
+  Table, 
+  TableBody, 
+  TableCell, 
+  TableHead, 
+  TableHeader, 
+  TableRow 
+} from '@/components/ui/table';
+import { 
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { 
+  Shield, 
+  Search, 
+  RefreshCw, 
+  Play,
+  CheckCircle,
+  AlertTriangle,
+  BarChart3
+} from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+import { logAdminAction, useAdminGitHubId } from '@/hooks/use-admin-auth';
+
+interface RepositoryStats {
+  id: string;
+  owner: string;
+  name: string;
+  full_name: string;
+  total_prs: number;
+  analyzed_prs: number;
+  pending_prs: number;
+  spam_prs: number;
+  analysis_progress: number;
+  last_analyzed_at?: string;
+  avg_spam_score?: number;
+}
+
+interface BulkAnalysisJob {
+  repository_id: string;
+  repository_name: string;
+  status: 'pending' | 'running' | 'completed' | 'failed';
+  processed: number;
+  total: number;
+  errors: number;
+  started_at?: string;
+  completed_at?: string;
+  error_message?: string;
+}
+
+export function BulkSpamAnalysis() {
+  const [repositories, setRepositories] = useState<RepositoryStats[]>([]);
+  const [filteredRepos, setFilteredRepos] = useState<RepositoryStats[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [filterStatus, setFilterStatus] = useState<'all' | 'pending' | 'analyzed' | 'partial'>('all');
+  const [bulkJobs, setBulkJobs] = useState<BulkAnalysisJob[]>([]);
+  const [isAnalyzing, setIsAnalyzing] = useState(false);
+  const [systemProgress, setSystemProgress] = useState(0);
+  const adminGitHubId = useAdminGitHubId();
+  const { toast } = useToast();
+
+  useEffect(() => {
+    fetchRepositoryStats();
+  }, []);
+
+  useEffect(() => {
+    filterRepositories();
+  }, [repositories, searchTerm, filterStatus]);
+
+  const fetchRepositoryStats = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      // Get repository stats with PR analysis data
+      const { data: repoData, error: repoError } = await supabase
+        .from('repositories')
+        .select(`
+          id,
+          owner,
+          name,
+          full_name,
+          pull_requests (
+            id,
+            spam_score,
+            is_spam,
+            spam_detected_at
+          )
+        `)
+        .order('full_name');
+
+      if (repoError) {
+        throw repoError;
+      }
+
+      if (!repoData) {
+        setRepositories([]);
+        return;
+      }
+
+      // Calculate stats for each repository
+      const stats: RepositoryStats[] = repoData.map(repo => {
+        const totalPrs = repo.pull_requests?.length || 0;
+        const analyzedPrs = repo.pull_requests?.filter(pr => pr.spam_score !== null).length || 0;
+        const pendingPrs = totalPrs - analyzedPrs;
+        const spamPrs = repo.pull_requests?.filter(pr => pr.is_spam).length || 0;
+        const analysisProgress = totalPrs > 0 ? (analyzedPrs / totalPrs) * 100 : 0;
+        
+        // Calculate average spam score for analyzed PRs
+        const analyzedPRsWithScores = repo.pull_requests?.filter(pr => pr.spam_score !== null) || [];
+        const avgSpamScore = analyzedPRsWithScores.length > 0 
+          ? analyzedPRsWithScores.reduce((sum, pr) => sum + (pr.spam_score || 0), 0) / analyzedPRsWithScores.length
+          : undefined;
+
+        // Find most recent analysis date
+        const lastAnalyzedAt = repo.pull_requests
+          ?.filter(pr => pr.spam_detected_at)
+          ?.sort((a, b) => new Date(b.spam_detected_at!).getTime() - new Date(a.spam_detected_at!).getTime())[0]
+          ?.spam_detected_at;
+
+        return {
+          id: repo.id,
+          owner: repo.owner,
+          name: repo.name,
+          full_name: repo.full_name,
+          total_prs: totalPrs,
+          analyzed_prs: analyzedPrs,
+          pending_prs: pendingPrs,
+          spam_prs: spamPrs,
+          analysis_progress: Math.round(analysisProgress),
+          last_analyzed_at: lastAnalyzedAt,
+          avg_spam_score: avgSpamScore ? Math.round(avgSpamScore) : undefined
+        };
+      });
+
+      setRepositories(stats);
+    } catch (err) {
+      console.error('Error fetching repository stats:', err);
+      setError(err instanceof Error ? err.message : 'Failed to fetch repository statistics');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const filterRepositories = () => {
+    let filtered = repositories.filter(repo => {
+      const matchesSearch = 
+        repo.full_name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        repo.owner.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        repo.name.toLowerCase().includes(searchTerm.toLowerCase());
+
+      const matchesStatus = 
+        filterStatus === 'all' ||
+        (filterStatus === 'pending' && repo.pending_prs > 0) ||
+        (filterStatus === 'analyzed' && repo.analysis_progress === 100) ||
+        (filterStatus === 'partial' && repo.analysis_progress > 0 && repo.analysis_progress < 100);
+
+      return matchesSearch && matchesStatus;
+    });
+
+    // Sort by pending PRs descending (most work first)
+    filtered.sort((a, b) => b.pending_prs - a.pending_prs);
+    setFilteredRepos(filtered);
+  };
+
+  const analyzeRepository = async (repositoryId: string, repositoryName: string, forceRecheck = false) => {
+    if (!adminGitHubId) {
+      toast({
+        title: "Authentication required",
+        description: "Admin authentication required to run analysis",
+        variant: "destructive"
+      });
+      return;
+    }
+
+    try {
+      // Add job to tracking
+      const newJob: BulkAnalysisJob = {
+        repository_id: repositoryId,
+        repository_name: repositoryName,
+        status: 'running',
+        processed: 0,
+        total: 0,
+        errors: 0,
+        started_at: new Date().toISOString()
+      };
+      setBulkJobs(prev => [...prev, newJob]);
+
+      // Call spam detection function
+      const response = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/spam-detection`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          repository_id: repositoryId,
+          limit: 1000, // Process up to 1000 PRs per repository
+          force_recheck: forceRecheck
+        })
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Analysis failed: ${response.status} ${errorText}`);
+      }
+
+      const result = await response.json();
+
+      // Update job status
+      setBulkJobs(prev => prev.map(job => 
+        job.repository_id === repositoryId 
+          ? {
+              ...job,
+              status: 'completed',
+              processed: result.processed || 0,
+              errors: result.errors || 0,
+              completed_at: new Date().toISOString()
+            }
+          : job
+      ));
+
+      // Log admin action
+      await logAdminAction(
+        adminGitHubId,
+        'bulk_spam_analysis',
+        'repository',
+        repositoryId,
+        {
+          repository_name: repositoryName,
+          processed: result.processed,
+          errors: result.errors,
+          stats: result.stats,
+          force_recheck: forceRecheck
+        }
+      );
+
+      toast({
+        title: "Analysis completed",
+        description: `${repositoryName}: Analyzed ${result.processed} PRs, ${result.errors} errors`,
+        variant: "default"
+      });
+
+      // Refresh repository stats
+      await fetchRepositoryStats();
+
+    } catch (err) {
+      console.error('Error analyzing repository:', err);
+      const errorMessage = err instanceof Error ? err.message : 'Analysis failed';
+
+      // Update job status to failed
+      setBulkJobs(prev => prev.map(job => 
+        job.repository_id === repositoryId 
+          ? {
+              ...job,
+              status: 'failed',
+              error_message: errorMessage,
+              completed_at: new Date().toISOString()
+            }
+          : job
+      ));
+
+      toast({
+        title: "Analysis failed",
+        description: `${repositoryName}: ${errorMessage}`,
+        variant: "destructive"
+      });
+    }
+  };
+
+  const analyzeAllRepositories = async () => {
+    if (!adminGitHubId) {
+      toast({
+        title: "Authentication required",
+        description: "Admin authentication required to run bulk analysis",
+        variant: "destructive"
+      });
+      return;
+    }
+
+    if (systemStats.pendingPrs === 0) {
+      toast({
+        title: "No PRs to analyze",
+        description: "All PRs are already analyzed",
+        variant: "default"
+      });
+      return;
+    }
+
+    setIsAnalyzing(true);
+    setSystemProgress(0);
+
+    try {
+      // Use the new analyze_all endpoint
+      const response = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/spam-detection`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          analyze_all: true,
+          limit: 1000, // Process up to 1000 PRs per repository
+          force_recheck: false
+        })
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Bulk analysis failed: ${response.status} ${errorText}`);
+      }
+
+      const result = await response.json();
+
+      // Log admin action
+      await logAdminAction(
+        adminGitHubId,
+        'bulk_spam_analysis_all',
+        'system',
+        'all_repositories',
+        {
+          total_repositories: result.total_repositories,
+          total_processed: result.total_processed,
+          total_errors: result.total_errors,
+          overall_stats: result.overall_stats
+        }
+      );
+
+      // Update bulk jobs with detailed results
+      if (result.results) {
+        const newJobs: BulkAnalysisJob[] = result.results.map((repoResult: any) => ({
+          repository_id: repoResult.repository_id,
+          repository_name: repoResult.repository_name,
+          status: repoResult.error ? 'failed' : 'completed',
+          processed: repoResult.processed || 0,
+          total: repoResult.processed || 0,
+          errors: repoResult.errors || 0,
+          started_at: new Date().toISOString(),
+          completed_at: new Date().toISOString(),
+          error_message: repoResult.error
+        }));
+        setBulkJobs(prev => [...prev, ...newJobs]);
+      }
+
+      toast({
+        title: "Bulk analysis completed",
+        description: `Analyzed ${result.total_repositories} repositories, processed ${result.total_processed} PRs, ${result.total_errors} errors`,
+        variant: "default"
+      });
+
+      // Set progress to 100%
+      setSystemProgress(100);
+
+      // Refresh repository stats after a moment
+      setTimeout(() => {
+        fetchRepositoryStats();
+      }, 1000);
+
+    } catch (err) {
+      console.error('Error in bulk analysis:', err);
+      toast({
+        title: "Bulk analysis failed",
+        description: err instanceof Error ? err.message : 'Bulk analysis failed',
+        variant: "destructive"
+      });
+    } finally {
+      setTimeout(() => {
+        setIsAnalyzing(false);
+        setSystemProgress(0);
+      }, 2000); // Keep progress visible for a bit
+    }
+  };
+
+  const getProgressBadgeVariant = (progress: number) => {
+    if (progress === 100) return "default";
+    if (progress >= 50) return "secondary";
+    if (progress > 0) return "outline";
+    return "destructive";
+  };
+
+  const getSpamScoreBadgeVariant = (score?: number) => {
+    if (!score) return "outline";
+    if (score >= 75) return "destructive";
+    if (score >= 50) return "secondary";
+    return "default";
+  };
+
+  // Calculate system-wide stats
+  const systemStats = {
+    totalRepos: repositories.length,
+    totalPrs: repositories.reduce((sum, repo) => sum + repo.total_prs, 0),
+    analyzedPrs: repositories.reduce((sum, repo) => sum + repo.analyzed_prs, 0),
+    pendingPrs: repositories.reduce((sum, repo) => sum + repo.pending_prs, 0),
+    spamPrs: repositories.reduce((sum, repo) => sum + repo.spam_prs, 0),
+    avgProgress: repositories.length > 0 
+      ? Math.round(repositories.reduce((sum, repo) => sum + repo.analysis_progress, 0) / repositories.length)
+      : 0
+  };
+
+  if (loading) {
+    return (
+      <div className="container mx-auto p-6">
+        <div className="flex items-center justify-center min-h-[400px]">
+          <div className="text-center">
+            <RefreshCw className="h-8 w-8 animate-spin mx-auto mb-4" />
+            <p className="text-muted-foreground">Loading repository statistics...</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto p-6">
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-6">
+        <div className="p-3 rounded-lg bg-blue-100 text-blue-600">
+          <BarChart3 className="h-6 w-6" />
+        </div>
+        <div>
+          <h1 className="text-3xl font-bold">Bulk Spam Analysis</h1>
+          <p className="text-muted-foreground">
+            Analyze previous PRs across all repositories for spam detection
+          </p>
+        </div>
+      </div>
+
+      {error && (
+        <Alert variant="destructive" className="mb-6">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {/* System Stats */}
+      <div className="grid grid-cols-1 md:grid-cols-6 gap-4 mb-6">
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-2">
+              <Shield className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm text-muted-foreground">Repositories</span>
+            </div>
+            <p className="text-2xl font-bold">{systemStats.totalRepos}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-2">
+              <BarChart3 className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm text-muted-foreground">Total PRs</span>
+            </div>
+            <p className="text-2xl font-bold">{systemStats.totalPrs.toLocaleString()}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-2">
+              <CheckCircle className="h-4 w-4 text-green-500" />
+              <span className="text-sm text-muted-foreground">Analyzed</span>
+            </div>
+            <p className="text-2xl font-bold">{systemStats.analyzedPrs.toLocaleString()}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-2">
+              <AlertTriangle className="h-4 w-4 text-yellow-500" />
+              <span className="text-sm text-muted-foreground">Pending</span>
+            </div>
+            <p className="text-2xl font-bold">{systemStats.pendingPrs.toLocaleString()}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-2">
+              <Shield className="h-4 w-4 text-red-500" />
+              <span className="text-sm text-muted-foreground">Spam Found</span>
+            </div>
+            <p className="text-2xl font-bold">{systemStats.spamPrs.toLocaleString()}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-2">
+              <BarChart3 className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm text-muted-foreground">Avg Progress</span>
+            </div>
+            <p className="text-2xl font-bold">{systemStats.avgProgress}%</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Bulk Actions */}
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle>Bulk Operations</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col sm:flex-row gap-4">
+            <Button 
+              onClick={analyzeAllRepositories}
+              disabled={isAnalyzing || systemStats.pendingPrs === 0}
+              size="lg"
+              className="flex-1"
+            >
+              {isAnalyzing ? (
+                <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
+              ) : (
+                <Play className="h-4 w-4 mr-2" />
+              )}
+              {isAnalyzing ? 'Analyzing...' : `Analyze All (${systemStats.pendingPrs.toLocaleString()} pending PRs)`}
+            </Button>
+            <Button onClick={fetchRepositoryStats} variant="outline">
+              <RefreshCw className="h-4 w-4 mr-2" />
+              Refresh Stats
+            </Button>
+          </div>
+          
+          {isAnalyzing && (
+            <div className="mt-4">
+              <div className="flex items-center gap-2 mb-2">
+                <span className="text-sm text-muted-foreground">System Progress:</span>
+                <span className="text-sm font-medium">{Math.round(systemProgress)}%</span>
+              </div>
+              <Progress value={systemProgress} className="w-full" />
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Filters */}
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle>Filters</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col sm:flex-row gap-4">
+            <div className="flex-1">
+              <div className="relative">
+                <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+                <Input
+                  placeholder="Search repositories..."
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                  className="pl-10"
+                />
+              </div>
+            </div>
+            <Select value={filterStatus} onValueChange={(value: any) => setFilterStatus(value)}>
+              <SelectTrigger className="w-full sm:w-[200px]">
+                <SelectValue placeholder="Filter by status" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Repositories</SelectItem>
+                <SelectItem value="pending">Has Pending PRs</SelectItem>
+                <SelectItem value="partial">Partially Analyzed</SelectItem>
+                <SelectItem value="analyzed">Fully Analyzed</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Repositories Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Repositories ({filteredRepos.length})</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Repository</TableHead>
+                  <TableHead>Total PRs</TableHead>
+                  <TableHead>Analyzed</TableHead>
+                  <TableHead>Pending</TableHead>
+                  <TableHead>Spam Found</TableHead>
+                  <TableHead>Progress</TableHead>
+                  <TableHead>Avg Score</TableHead>
+                  <TableHead>Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredRepos.map((repo) => (
+                  <TableRow key={repo.id}>
+                    <TableCell>
+                      <div>
+                        <div className="font-medium">{repo.full_name}</div>
+                        {repo.last_analyzed_at && (
+                          <div className="text-xs text-muted-foreground">
+                            Last: {new Date(repo.last_analyzed_at).toLocaleDateString()}
+                          </div>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell>{repo.total_prs.toLocaleString()}</TableCell>
+                    <TableCell>{repo.analyzed_prs.toLocaleString()}</TableCell>
+                    <TableCell>
+                      {repo.pending_prs > 0 ? (
+                        <Badge variant="destructive">{repo.pending_prs.toLocaleString()}</Badge>
+                      ) : (
+                        <span className="text-muted-foreground">0</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {repo.spam_prs > 0 ? (
+                        <Badge variant="destructive">{repo.spam_prs.toLocaleString()}</Badge>
+                      ) : (
+                        <span className="text-muted-foreground">0</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <Badge variant={getProgressBadgeVariant(repo.analysis_progress)}>
+                          {repo.analysis_progress}%
+                        </Badge>
+                        {repo.analysis_progress < 100 && repo.analysis_progress > 0 && (
+                          <Progress value={repo.analysis_progress} className="w-16 h-2" />
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      {repo.avg_spam_score !== undefined ? (
+                        <Badge variant={getSpamScoreBadgeVariant(repo.avg_spam_score)}>
+                          {repo.avg_spam_score}%
+                        </Badge>
+                      ) : (
+                        <span className="text-muted-foreground">-</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex gap-2">
+                        {repo.pending_prs > 0 && (
+                          <Button
+                            onClick={() => analyzeRepository(repo.id, repo.full_name)}
+                            size="sm"
+                            disabled={isAnalyzing}
+                          >
+                            <Play className="h-3 w-3 mr-1" />
+                            Analyze
+                          </Button>
+                        )}
+                        <Button
+                          onClick={() => analyzeRepository(repo.id, repo.full_name, true)}
+                          variant="outline"
+                          size="sm"
+                          disabled={isAnalyzing}
+                        >
+                          <RefreshCw className="h-3 w-3 mr-1" />
+                          Re-analyze
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Recent Jobs */}
+      {bulkJobs.length > 0 && (
+        <Card className="mt-6">
+          <CardHeader>
+            <CardTitle>Recent Analysis Jobs</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              {bulkJobs.slice(-5).reverse().map((job, index) => (
+                <div key={index} className="flex items-center justify-between p-3 border rounded-lg">
+                  <div>
+                    <span className="font-medium">{job.repository_name}</span>
+                    {job.status === 'completed' && (
+                      <span className="text-sm text-muted-foreground ml-2">
+                        Processed: {job.processed}, Errors: {job.errors}
+                      </span>
+                    )}
+                    {job.error_message && (
+                      <div className="text-sm text-red-600">{job.error_message}</div>
+                    )}
+                  </div>
+                  <Badge 
+                    variant={
+                      job.status === 'completed' ? 'default' :
+                      job.status === 'running' ? 'secondary' :
+                      job.status === 'failed' ? 'destructive' : 'outline'
+                    }
+                  >
+                    {job.status}
+                  </Badge>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/components/features/admin/index.ts
+++ b/src/components/features/admin/index.ts
@@ -1,3 +1,4 @@
 export { AdminMenu } from './admin-menu';
 export { UserManagement } from './user-management';
 export { SpamManagement } from './spam-management';
+export { SpamTestTool } from './spam-test-tool';

--- a/src/components/features/admin/index.ts
+++ b/src/components/features/admin/index.ts
@@ -2,3 +2,4 @@ export { AdminMenu } from './admin-menu';
 export { UserManagement } from './user-management';
 export { SpamManagement } from './spam-management';
 export { SpamTestTool } from './spam-test-tool';
+export { BulkSpamAnalysis } from './bulk-spam-analysis';

--- a/src/components/features/admin/index.ts
+++ b/src/components/features/admin/index.ts
@@ -1,0 +1,2 @@
+export { AdminMenu } from './admin-menu';
+export { UserManagement } from './user-management';

--- a/src/components/features/admin/index.ts
+++ b/src/components/features/admin/index.ts
@@ -1,2 +1,3 @@
 export { AdminMenu } from './admin-menu';
 export { UserManagement } from './user-management';
+export { SpamManagement } from './spam-management';

--- a/src/components/features/admin/spam-management.tsx
+++ b/src/components/features/admin/spam-management.tsx
@@ -1,0 +1,473 @@
+import { useState, useEffect } from 'react';
+import { supabase } from '@/lib/supabase';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
+import { 
+  Table, 
+  TableBody, 
+  TableCell, 
+  TableHead, 
+  TableHeader, 
+  TableRow 
+} from '@/components/ui/table';
+import { 
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { 
+  Shield, 
+  Search, 
+  AlertTriangle, 
+  CheckCircle, 
+  XCircle,
+  ExternalLink,
+  RefreshCw,
+  Eye,
+  Ban
+} from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { logAdminAction, useAdminGitHubId } from '@/hooks/use-admin-auth';
+
+interface SpamDetection {
+  id: string;
+  pr_id: string;
+  contributor_id: string;
+  spam_score: number;
+  detected_at: string;
+  status: 'pending' | 'confirmed' | 'false_positive';
+  admin_reviewed_by?: number;
+  admin_reviewed_at?: string;
+  detection_reasons: string[];
+  pull_requests?: {
+    title: string;
+    html_url: string;
+    repository: {
+      full_name: string;
+    };
+  };
+  contributors?: {
+    github_username: string;
+    avatar_url?: string;
+  };
+}
+
+export function SpamManagement() {
+  const [detections, setDetections] = useState<SpamDetection[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [filterStatus, setFilterStatus] = useState<'all' | 'pending' | 'confirmed' | 'false_positive'>('all');
+  const [filterScore, setFilterScore] = useState<'all' | 'high' | 'medium' | 'low'>('all');
+  const adminGitHubId = useAdminGitHubId();
+
+  useEffect(() => {
+    fetchSpamDetections();
+  }, []);
+
+  const fetchSpamDetections = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      
+      const { data, error: fetchError } = await supabase
+        .from('spam_detections')
+        .select(`
+          *,
+          pull_requests (
+            title,
+            html_url,
+            repository:repositories (
+              full_name
+            )
+          ),
+          contributors (
+            github_username,
+            avatar_url
+          )
+        `)
+        .order('detected_at', { ascending: false });
+
+      if (fetchError) {
+        throw fetchError;
+      }
+
+      setDetections(data || []);
+    } catch (err) {
+      console.error('Error fetching spam detections:', err);
+      setError(err instanceof Error ? err.message : 'Failed to fetch spam detections');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const updateSpamStatus = async (detection: SpamDetection, newStatus: 'confirmed' | 'false_positive') => {
+    if (!adminGitHubId) return;
+
+    try {
+      const { error: updateError } = await supabase
+        .from('spam_detections')
+        .update({ 
+          status: newStatus,
+          admin_reviewed_by: adminGitHubId,
+          admin_reviewed_at: new Date().toISOString()
+        })
+        .eq('id', detection.id);
+
+      if (updateError) {
+        throw updateError;
+      }
+
+      // Log admin action
+      await logAdminAction(
+        adminGitHubId,
+        'spam_status_updated',
+        'spam_detection',
+        detection.id,
+        {
+          pr_id: detection.pr_id,
+          contributor_username: detection.contributors?.github_username,
+          old_status: detection.status,
+          new_status: newStatus,
+          spam_score: detection.spam_score
+        }
+      );
+
+      // Update local state
+      setDetections(detections.map(d => 
+        d.id === detection.id 
+          ? { 
+              ...d, 
+              status: newStatus, 
+              admin_reviewed_by: adminGitHubId,
+              admin_reviewed_at: new Date().toISOString()
+            }
+          : d
+      ));
+    } catch (err) {
+      console.error('Error updating spam status:', err);
+      setError(err instanceof Error ? err.message : 'Failed to update spam status');
+    }
+  };
+
+  // Filter detections based on search and filter criteria
+  const filteredDetections = detections.filter(detection => {
+    const matchesSearch = 
+      detection.contributors?.github_username.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      detection.pull_requests?.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      detection.pull_requests?.repository?.full_name.toLowerCase().includes(searchTerm.toLowerCase());
+
+    const matchesStatus = 
+      filterStatus === 'all' || detection.status === filterStatus;
+
+    const matchesScore = 
+      filterScore === 'all' ||
+      (filterScore === 'high' && detection.spam_score >= 0.8) ||
+      (filterScore === 'medium' && detection.spam_score >= 0.5 && detection.spam_score < 0.8) ||
+      (filterScore === 'low' && detection.spam_score < 0.5);
+
+    return matchesSearch && matchesStatus && matchesScore;
+  });
+
+  const stats = {
+    total: detections.length,
+    pending: detections.filter(d => d.status === 'pending').length,
+    confirmed: detections.filter(d => d.status === 'confirmed').length,
+    falsePositives: detections.filter(d => d.status === 'false_positive').length,
+    highRisk: detections.filter(d => d.spam_score >= 0.8).length
+  };
+
+  const getScoreBadgeVariant = (score: number) => {
+    if (score >= 0.8) return "destructive";
+    if (score >= 0.5) return "secondary";
+    return "outline";
+  };
+
+  const getStatusBadgeVariant = (status: string) => {
+    switch (status) {
+      case 'confirmed': return "destructive";
+      case 'false_positive': return "default";
+      default: return "secondary";
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="container mx-auto p-6">
+        <div className="flex items-center justify-center min-h-[400px]">
+          <div className="text-center">
+            <RefreshCw className="h-8 w-8 animate-spin mx-auto mb-4" />
+            <p className="text-muted-foreground">Loading spam detections...</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto p-6">
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-6">
+        <div className="p-3 rounded-lg bg-red-100 text-red-600">
+          <Shield className="h-6 w-6" />
+        </div>
+        <div>
+          <h1 className="text-3xl font-bold">Spam Management</h1>
+          <p className="text-muted-foreground">
+            Review and manage spam detection results
+          </p>
+        </div>
+      </div>
+
+      {error && (
+        <Alert variant="destructive" className="mb-6">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {/* Stats Cards */}
+      <div className="grid grid-cols-1 md:grid-cols-5 gap-4 mb-6">
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-2">
+              <Shield className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm text-muted-foreground">Total</span>
+            </div>
+            <p className="text-2xl font-bold">{stats.total}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-2">
+              <AlertTriangle className="h-4 w-4 text-yellow-500" />
+              <span className="text-sm text-muted-foreground">Pending</span>
+            </div>
+            <p className="text-2xl font-bold">{stats.pending}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-2">
+              <XCircle className="h-4 w-4 text-red-500" />
+              <span className="text-sm text-muted-foreground">Confirmed</span>
+            </div>
+            <p className="text-2xl font-bold">{stats.confirmed}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-2">
+              <CheckCircle className="h-4 w-4 text-green-500" />
+              <span className="text-sm text-muted-foreground">False Positives</span>
+            </div>
+            <p className="text-2xl font-bold">{stats.falsePositives}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-2">
+              <Ban className="h-4 w-4 text-red-600" />
+              <span className="text-sm text-muted-foreground">High Risk</span>
+            </div>
+            <p className="text-2xl font-bold">{stats.highRisk}</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Filters */}
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle>Filters</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col sm:flex-row gap-4">
+            <div className="flex-1">
+              <div className="relative">
+                <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+                <Input
+                  placeholder="Search by contributor, PR title, or repository..."
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                  className="pl-10"
+                />
+              </div>
+            </div>
+            <Select value={filterStatus} onValueChange={(value: any) => setFilterStatus(value)}>
+              <SelectTrigger className="w-full sm:w-[180px]">
+                <SelectValue placeholder="Filter by status" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Status</SelectItem>
+                <SelectItem value="pending">Pending</SelectItem>
+                <SelectItem value="confirmed">Confirmed</SelectItem>
+                <SelectItem value="false_positive">False Positive</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select value={filterScore} onValueChange={(value: any) => setFilterScore(value)}>
+              <SelectTrigger className="w-full sm:w-[180px]">
+                <SelectValue placeholder="Filter by score" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Scores</SelectItem>
+                <SelectItem value="high">High (≥80%)</SelectItem>
+                <SelectItem value="medium">Medium (50-79%)</SelectItem>
+                <SelectItem value="low">Low (&lt;50%)</SelectItem>
+              </SelectContent>
+            </Select>
+            <Button onClick={fetchSpamDetections} variant="outline">
+              <RefreshCw className="h-4 w-4 mr-2" />
+              Refresh
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Spam Detections Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Spam Detections ({filteredDetections.length})</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Contributor</TableHead>
+                  <TableHead>Pull Request</TableHead>
+                  <TableHead>Spam Score</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Detected</TableHead>
+                  <TableHead>Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredDetections.map((detection) => (
+                  <TableRow key={detection.id}>
+                    <TableCell>
+                      <div className="flex items-center gap-3">
+                        <Avatar className="h-8 w-8">
+                          <AvatarImage 
+                            src={detection.contributors?.avatar_url} 
+                            alt={detection.contributors?.github_username} 
+                          />
+                          <AvatarFallback>
+                            {detection.contributors?.github_username.slice(0, 2).toUpperCase()}
+                          </AvatarFallback>
+                        </Avatar>
+                        <div>
+                          <div className="flex items-center gap-2">
+                            <span className="font-medium">
+                              {detection.contributors?.github_username}
+                            </span>
+                            <Link 
+                              to={`https://github.com/${detection.contributors?.github_username}`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              <ExternalLink className="h-3 w-3 text-muted-foreground hover:text-foreground" />
+                            </Link>
+                          </div>
+                        </div>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div>
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium truncate max-w-[200px]">
+                            {detection.pull_requests?.title}
+                          </span>
+                          {detection.pull_requests?.html_url && (
+                            <Link 
+                              to={detection.pull_requests.html_url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              <ExternalLink className="h-3 w-3 text-muted-foreground hover:text-foreground" />
+                            </Link>
+                          )}
+                        </div>
+                        <p className="text-sm text-muted-foreground">
+                          {detection.pull_requests?.repository?.full_name}
+                        </p>
+                        <div className="mt-1">
+                          {detection.detection_reasons.map((reason, idx) => (
+                            <Badge key={idx} variant="outline" className="text-xs mr-1">
+                              {reason}
+                            </Badge>
+                          ))}
+                        </div>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={getScoreBadgeVariant(detection.spam_score)}>
+                        {Math.round(detection.spam_score * 100)}%
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={getStatusBadgeVariant(detection.status)}>
+                        {detection.status === 'false_positive' ? 'False Positive' : 
+                         detection.status.charAt(0).toUpperCase() + detection.status.slice(1)}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <div className="text-sm">
+                        {new Date(detection.detected_at).toLocaleDateString()}
+                        <div className="text-xs text-muted-foreground">
+                          {new Date(detection.detected_at).toLocaleTimeString()}
+                        </div>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex gap-2">
+                        {detection.status === 'pending' && (
+                          <>
+                            <Button
+                              onClick={() => updateSpamStatus(detection, 'confirmed')}
+                              variant="destructive"
+                              size="sm"
+                            >
+                              <XCircle className="h-3 w-3 mr-1" />
+                              Confirm Spam
+                            </Button>
+                            <Button
+                              onClick={() => updateSpamStatus(detection, 'false_positive')}
+                              variant="default"
+                              size="sm"
+                            >
+                              <CheckCircle className="h-3 w-3 mr-1" />
+                              Not Spam
+                            </Button>
+                          </>
+                        )}
+                        {detection.status !== 'pending' && (
+                          <Button
+                            onClick={() => {
+                              if (detection.pull_requests?.html_url) {
+                                window.open(detection.pull_requests.html_url, '_blank');
+                              }
+                            }}
+                            variant="outline"
+                            size="sm"
+                          >
+                            <Eye className="h-3 w-3 mr-1" />
+                            Review
+                          </Button>
+                        )}
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/features/admin/spam-management.tsx
+++ b/src/components/features/admin/spam-management.tsx
@@ -53,7 +53,7 @@ interface SpamDetection {
     };
   };
   contributors?: {
-    github_username: string;
+    username: string;
     avatar_url?: string;
   };
 }
@@ -88,7 +88,7 @@ export function SpamManagement() {
             )
           ),
           contributors (
-            github_username,
+            username,
             avatar_url
           )
         `)
@@ -132,7 +132,7 @@ export function SpamManagement() {
         detection.id,
         {
           pr_id: detection.pr_id,
-          contributor_username: detection.contributors?.github_username,
+          contributor_username: detection.contributors?.username,
           old_status: detection.status,
           new_status: newStatus,
           spam_score: detection.spam_score
@@ -159,7 +159,7 @@ export function SpamManagement() {
   // Filter detections based on search and filter criteria
   const filteredDetections = detections.filter(detection => {
     const matchesSearch = 
-      detection.contributors?.github_username.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      detection.contributors?.username.toLowerCase().includes(searchTerm.toLowerCase()) ||
       detection.pull_requests?.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
       detection.pull_requests?.repository?.full_name.toLowerCase().includes(searchTerm.toLowerCase());
 
@@ -354,19 +354,19 @@ export function SpamManagement() {
                         <Avatar className="h-8 w-8">
                           <AvatarImage 
                             src={detection.contributors?.avatar_url} 
-                            alt={detection.contributors?.github_username} 
+                            alt={detection.contributors?.username} 
                           />
                           <AvatarFallback>
-                            {detection.contributors?.github_username.slice(0, 2).toUpperCase()}
+                            {detection.contributors?.username.slice(0, 2).toUpperCase()}
                           </AvatarFallback>
                         </Avatar>
                         <div>
                           <div className="flex items-center gap-2">
                             <span className="font-medium">
-                              {detection.contributors?.github_username}
+                              {detection.contributors?.username}
                             </span>
                             <Link 
-                              to={`https://github.com/${detection.contributors?.github_username}`}
+                              to={`https://github.com/${detection.contributors?.username}`}
                               target="_blank"
                               rel="noopener noreferrer"
                             >

--- a/src/components/features/admin/spam-test-tool.tsx
+++ b/src/components/features/admin/spam-test-tool.tsx
@@ -1,0 +1,747 @@
+import { useState } from 'react';
+import { supabase } from '@/lib/supabase';
+import { SpamDetectionService } from '@/lib/spam';
+import { PRTemplateService } from '@/lib/spam/PRTemplateService';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Textarea } from '@/components/ui/textarea';
+import { 
+  Search, 
+  AlertTriangle, 
+  CheckCircle, 
+  RefreshCw,
+  ExternalLink,
+  Bug
+} from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { logAdminAction, useAdminGitHubId } from '@/hooks/use-admin-auth';
+
+interface PRAnalysisResult {
+  pr: any;
+  spamScore: number;
+  detectionReasons: string[];
+  currentDbScore?: number;
+  wasDetected: boolean;
+  dataSource: 'database' | 'github_sync' | 'github_api' | 'mock';
+  warnings: string[];
+}
+
+interface AdminGuidance {
+  type: 'warning' | 'error' | 'info';
+  title: string;
+  message: string;
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
+}
+
+export function SpamTestTool() {
+  const [prUrl, setPrUrl] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<PRAnalysisResult | null>(null);
+  const [manualFeedback, setManualFeedback] = useState('');
+  const [adminGuidance, setAdminGuidance] = useState<AdminGuidance[]>([]);
+  const [templateSyncLoading, setTemplateSyncLoading] = useState(false);
+  const adminGitHubId = useAdminGitHubId();
+  const prTemplateService = new PRTemplateService();
+
+  const parsePRUrl = (url: string) => {
+    const match = url.match(/github\.com\/([^\/]+)\/([^\/]+)\/pull\/(\d+)/);
+    if (!match) throw new Error('Invalid GitHub PR URL format');
+    return {
+      owner: match[1],
+      repo: match[2],
+      prNumber: parseInt(match[3])
+    };
+  };
+
+  const checkRepositoryTracking = async (owner: string, repo: string) => {
+    const { data: trackedRepo, error } = await supabase
+      .from('tracked_repositories')
+      .select('*')
+      .eq('organization_name', owner)
+      .eq('repository_name', repo)
+      .single();
+
+    return { isTracked: !!trackedRepo && !error, trackedRepo };
+  };
+
+  const addRepositoryToTracking = async (owner: string, repo: string) => {
+    const { error } = await supabase
+      .from('tracked_repositories')
+      .insert({
+        organization_name: owner,
+        repository_name: repo,
+        tracking_enabled: true,
+        created_at: new Date().toISOString()
+      });
+
+    if (error) {
+      throw new Error(`Failed to add repository to tracking: ${error.message}`);
+    }
+
+    // Log admin action
+    if (adminGitHubId) {
+      await logAdminAction(
+        adminGitHubId,
+        'repository_added_to_tracking',
+        'repository',
+        `${owner}/${repo}`,
+        { reason: 'spam_test_tool_request' }
+      );
+    }
+  };
+
+  const ensureRepositoryTemplate = async (owner: string, repo: string) => {
+    try {
+      setTemplateSyncLoading(true);
+      
+      // Get or create repository in database
+      let { data: repository, error } = await supabase
+        .from('repositories')
+        .select('id, pr_template_content, pr_template_fetched_at')
+        .eq('owner', owner)
+        .eq('name', repo)
+        .single();
+
+      if (error && error.code === 'PGRST116') {
+        // Repository doesn't exist, create it
+        const { data: newRepo, error: insertError } = await supabase
+          .from('repositories')
+          .insert({
+            owner,
+            name: repo,
+            full_name: `${owner}/${repo}`,
+            tracking_enabled: true,
+            created_at: new Date().toISOString()
+          })
+          .select('id')
+          .single();
+
+        if (insertError) {
+          throw new Error(`Failed to create repository: ${insertError.message}`);
+        }
+        repository = {
+          ...newRepo,
+          pr_template_content: null,
+          pr_template_fetched_at: null
+        };
+      } else if (error) {
+        throw new Error(`Database error: ${error.message}`);
+      }
+
+      if (!repository) {
+        throw new Error('Failed to get repository ID');
+      }
+
+      // Fetch and cache PR template
+      const template = await prTemplateService.ensurePRTemplate(repository.id, owner, repo);
+      
+      if (template) {
+        setAdminGuidance(prev => [...prev, {
+          type: 'info',
+          title: 'PR Template Cached',
+          message: `Successfully fetched and cached PR template for ${owner}/${repo}. Repository-specific spam patterns have been generated.`
+        }]);
+      } else {
+        setAdminGuidance(prev => [...prev, {
+          type: 'warning',
+          title: 'No PR Template Found',
+          message: `No PR template found for ${owner}/${repo}. Using fallback spam detection patterns.`
+        }]);
+      }
+
+      return template;
+    } catch (error) {
+      setAdminGuidance(prev => [...prev, {
+        type: 'error',
+        title: 'Template Sync Failed',
+        message: `Failed to sync PR template: ${error instanceof Error ? error.message : 'Unknown error'}`
+      }]);
+      throw error;
+    } finally {
+      setTemplateSyncLoading(false);
+    }
+  };
+
+  const analyzePR = async () => {
+    if (!prUrl.trim()) return;
+    
+    try {
+      setLoading(true);
+      setError(null);
+      setResult(null);
+      setAdminGuidance([]);
+
+      const { owner, repo, prNumber } = parsePRUrl(prUrl);
+      const warnings: string[] = [];
+      let dataSource: 'database' | 'github_sync' | 'github_api' | 'mock' = 'database';
+
+      // Check if repository is tracked
+      const { isTracked } = await checkRepositoryTracking(owner, repo);
+      
+      if (!isTracked) {
+        setAdminGuidance([{
+          type: 'warning',
+          title: 'Repository Not Tracked',
+          message: `The repository ${owner}/${repo} is not in our tracking system. This means we don't have historical data for spam analysis. You can add it to tracking to enable full analysis.`,
+          action: {
+            label: 'Add to Tracking',
+            onClick: async () => {
+              try {
+                await addRepositoryToTracking(owner, repo);
+                setAdminGuidance(prev => prev.filter(g => g.title !== 'Repository Not Tracked'));
+                setAdminGuidance(prev => [...prev, {
+                  type: 'info',
+                  title: 'Repository Added',
+                  message: `Successfully added ${owner}/${repo} to tracking. Future syncs will include this repository's data.`
+                }]);
+              } catch (err) {
+                setAdminGuidance(prev => [...prev, {
+                  type: 'error',
+                  title: 'Failed to Add Repository',
+                  message: err instanceof Error ? err.message : 'Unknown error occurred'
+                }]);
+              }
+            }
+          }
+        }]);
+        warnings.push('Repository not tracked - limited historical context available');
+      }
+
+      // Ensure PR template is cached for repository-specific analysis
+      try {
+        await ensureRepositoryTemplate(owner, repo);
+      } catch (templateError) {
+        console.warn('Template sync failed:', templateError);
+        warnings.push('Template sync failed - using generic patterns');
+      }
+
+      // First check if PR exists in our database
+      const { data: existingPR, error: dbError } = await supabase
+        .from('pull_requests')
+        .select(`
+          *,
+          repositories!pull_requests_repository_id_fkey(owner, name),
+          contributors!pull_requests_contributor_id_fkey(github_username)
+        `)
+        .eq('repositories.owner', owner)
+        .eq('repositories.name', repo)
+        .eq('number', prNumber)
+        .single();
+
+      let prData = existingPR;
+      let currentDbScore = existingPR?.spam_score;
+
+      // If not in database, fetch from GitHub
+      if (dbError || !existingPR) {
+        try {
+          // Call GitHub sync to fetch the PR
+          const syncResponse = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/github-sync`, {
+            method: 'POST',
+            headers: {
+              'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+              owner,
+              repository: repo,
+              force_refresh: true
+            })
+          });
+
+          if (!syncResponse.ok) {
+            const errorText = await syncResponse.text();
+            throw new Error(`GitHub sync failed: ${syncResponse.status} ${errorText}`);
+          }
+
+          // Wait a moment for the sync to complete
+          await new Promise(resolve => setTimeout(resolve, 2000));
+
+          // Try to get the PR from database again
+          const { data: newPR, error: newError } = await supabase
+            .from('pull_requests')
+            .select(`
+              *,
+              repositories!pull_requests_repository_id_fkey(owner, name),
+              contributors!pull_requests_contributor_id_fkey(github_username)
+            `)
+            .eq('repositories.owner', owner)
+            .eq('repositories.name', repo)
+            .eq('number', prNumber)
+            .single();
+
+          if (newError && newError.code !== 'PGRST116') {
+            throw new Error(`Database query failed: ${newError.message}`);
+          }
+
+          prData = newPR;
+          currentDbScore = newPR?.spam_score;
+        } catch (syncError) {
+          // If sync fails, try to fetch directly from GitHub API as fallback
+          console.warn('GitHub sync failed, trying direct GitHub API:', syncError);
+          dataSource = 'github_api';
+          warnings.push('GitHub sync service unavailable - using direct API');
+          
+          try {
+            const githubResponse = await fetch(`https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}`);
+            if (githubResponse.ok) {
+              const githubPR = await githubResponse.json();
+              
+              // Transform GitHub API response to our format
+              prData = {
+                id: `github-${githubPR.id}`,
+                title: githubPR.title,
+                body: githubPR.body || '',
+                number: githubPR.number,
+                html_url: githubPR.html_url,
+                contributor_id: `github-${githubPR.user.id}`,
+                contributors: {
+                  github_username: githubPR.user.login
+                },
+                repositories: {
+                  owner,
+                  name: repo
+                },
+                created_at: githubPR.created_at,
+                additions: githubPR.additions || 0,
+                deletions: githubPR.deletions || 0,
+                changed_files: githubPR.changed_files || 0
+              };
+              currentDbScore = null;
+
+              setAdminGuidance(prev => [...prev, {
+                type: 'warning',
+                title: 'Using GitHub API Fallback',
+                message: 'Could not sync through our system. Data fetched directly from GitHub API. Consider checking the GitHub sync service status.',
+                action: {
+                  label: 'Check Sync Status',
+                  onClick: () => window.open('/dev/sync-test', '_blank')
+                }
+              }]);
+            } else if (githubResponse.status === 404) {
+              throw new Error(`PR #${prNumber} not found in ${owner}/${repo}. Please verify the URL is correct.`);
+            } else if (githubResponse.status === 403) {
+              throw new Error('GitHub API rate limit exceeded or access denied. Try again later.');
+            } else {
+              throw new Error(`GitHub API returned ${githubResponse.status}`);
+            }
+          } catch (githubError) {
+            console.warn('Direct GitHub API also failed:', githubError);
+            dataSource = 'mock';
+            warnings.push('All data sources failed - using mock data for algorithm testing');
+            
+            setAdminGuidance(prev => [...prev, {
+              type: 'error',
+              title: 'All Data Sources Failed',
+              message: 'Could not fetch PR data from database, sync service, or GitHub API. Using mock data for testing. This indicates a system-wide issue.',
+              action: {
+                label: 'Check System Status',
+                onClick: () => window.open('/admin/performance-monitoring', '_blank')
+              }
+            }]);
+            
+            // Final fallback - create mock data
+            prData = {
+              id: `mock-${owner}-${repo}-${prNumber}`,
+              title: `PR #${prNumber} from ${owner}/${repo}`,
+              body: 'Unable to fetch PR description - analyzing with limited data',
+              number: prNumber,
+              html_url: prUrl,
+              contributor_id: 'mock-contributor',
+              contributors: {
+                github_username: 'unknown-user'
+              },
+              repositories: {
+                owner,
+                name: repo
+              },
+              created_at: new Date().toISOString(),
+              additions: 0,
+              deletions: 0,
+              changed_files: 0
+            };
+            currentDbScore = null;
+          }
+        }
+      }
+
+      if (!prData) {
+        throw new Error('Could not fetch PR data from GitHub or database');
+      }
+
+      // Run spam detection analysis
+      const spamService = new SpamDetectionService();
+      const analysis = await spamService.detectSpam({
+        id: prData.id,
+        title: prData.title,
+        body: prData.body || '',
+        number: prData.number,
+        html_url: prData.html_url,
+        author: {
+          id: prData.contributor_id || 0,
+          login: prData.contributors?.github_username || 'unknown',
+          created_at: prData.contributors?.created_at || new Date().toISOString()
+        },
+        repository: {
+          full_name: `${prData.repositories?.owner}/${prData.repositories?.name}` || 'unknown/unknown'
+        },
+        created_at: prData.created_at,
+        additions: prData.additions || 0,
+        deletions: prData.deletions || 0,
+        changed_files: prData.changed_files || 0
+      });
+
+      // Add success guidance based on data source
+      if (dataSource === 'database') {
+        setAdminGuidance(prev => [...prev, {
+          type: 'info',
+          title: 'Using Database Data',
+          message: 'PR data found in database with complete historical context. This provides the most accurate spam analysis.'
+        }]);
+      } else if (existingPR && !dbError) {
+        // This means we successfully synced from GitHub
+        dataSource = 'github_sync';
+        warnings.push('Data synced from GitHub - fresh but no historical context yet');
+        setAdminGuidance(prev => [...prev, {
+          type: 'info',
+          title: 'Synced from GitHub',
+          message: 'PR data freshly synced from GitHub. Analysis based on current state without historical context.'
+        }]);
+      }
+
+      setResult({
+        pr: prData,
+        spamScore: analysis.spam_score,
+        detectionReasons: analysis.reasons,
+        currentDbScore,
+        wasDetected: (currentDbScore || 0) > 50,
+        dataSource,
+        warnings
+      });
+
+    } catch (err) {
+      console.error('Error analyzing PR:', err);
+      setError(err instanceof Error ? err.message : 'Failed to analyze PR');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const markAsSpam = async (isSpam: boolean) => {
+    if (!result || !adminGitHubId) return;
+
+    try {
+      // Create spam detection record
+      const { error: insertError } = await supabase
+        .from('spam_detections')
+        .insert({
+          pr_id: result.pr.id,
+          contributor_id: result.pr.contributor_id,
+          spam_score: result.spamScore / 100, // Convert to 0-1 scale
+          status: isSpam ? 'confirmed' : 'false_positive',
+          admin_reviewed_by: adminGitHubId,
+          admin_reviewed_at: new Date().toISOString(),
+          detection_reasons: result.detectionReasons,
+          detected_at: new Date().toISOString()
+        });
+
+      if (insertError) {
+        throw insertError;
+      }
+
+      // Update PR spam score in database
+      await supabase
+        .from('pull_requests')
+        .update({
+          spam_score: isSpam ? Math.max(result.spamScore, 75) : Math.min(result.spamScore, 25),
+          is_spam: isSpam
+        })
+        .eq('id', result.pr.id);
+
+      // Log admin action
+      await logAdminAction(
+        adminGitHubId,
+        'manual_spam_classification',
+        'pull_request',
+        result.pr.id,
+        {
+          pr_url: result.pr.html_url,
+          original_score: result.spamScore,
+          manual_classification: isSpam ? 'spam' : 'not_spam',
+          feedback: manualFeedback.trim() || undefined
+        }
+      );
+
+      setResult(prev => prev ? { ...prev, currentDbScore: isSpam ? Math.max(result.spamScore, 75) : Math.min(result.spamScore, 25) } : null);
+      setError(null);
+      
+    } catch (err) {
+      console.error('Error updating spam status:', err);
+      setError('Failed to update spam status');
+    }
+  };
+
+  const getScoreBadgeVariant = (score: number) => {
+    if (score >= 75) return "destructive";
+    if (score >= 50) return "secondary";
+    if (score >= 25) return "outline";
+    return "default";
+  };
+
+  return (
+    <div className="container mx-auto p-6">
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-6">
+        <div className="p-3 rounded-lg bg-orange-100 text-orange-600">
+          <Bug className="h-6 w-6" />
+        </div>
+        <div>
+          <h1 className="text-3xl font-bold">Spam Test Tool</h1>
+          <p className="text-muted-foreground">
+            Test and improve spam detection on individual PRs
+          </p>
+        </div>
+      </div>
+
+      {error && (
+        <Alert variant="destructive" className="mb-6">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {/* Admin Guidance */}
+      {adminGuidance.length > 0 && (
+        <div className="space-y-3 mb-6">
+          {adminGuidance.map((guidance, index) => (
+            <Alert 
+              key={index} 
+              variant={guidance.type === 'error' ? 'destructive' : 'default'}
+              className={
+                guidance.type === 'warning' ? 'border-yellow-200 bg-yellow-50 dark:border-yellow-800 dark:bg-yellow-950' :
+                guidance.type === 'info' ? 'border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950' : ''
+              }
+            >
+              <AlertTriangle className={`h-4 w-4 ${
+                guidance.type === 'error' ? 'text-red-600 dark:text-red-400' :
+                guidance.type === 'warning' ? 'text-yellow-600 dark:text-yellow-400' :
+                'text-blue-600 dark:text-blue-400'
+              }`} />
+              <div className="flex-1">
+                <div className="font-semibold">{guidance.title}</div>
+                <AlertDescription>{guidance.message}</AlertDescription>
+                {guidance.action && (
+                  <Button 
+                    onClick={guidance.action.onClick}
+                    variant="outline"
+                    size="sm"
+                    className="mt-2"
+                  >
+                    {guidance.action.label}
+                  </Button>
+                )}
+              </div>
+            </Alert>
+          ))}
+        </div>
+      )}
+
+      {/* Input Section */}
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle>Analyze Pull Request</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex gap-4">
+            <div className="flex-1">
+              <Input
+                placeholder="Enter GitHub PR URL (e.g., https://github.com/owner/repo/pull/123)"
+                value={prUrl}
+                onChange={(e) => setPrUrl(e.target.value)}
+              />
+            </div>
+            <Button onClick={analyzePR} disabled={loading || !prUrl.trim()}>
+              {loading ? (
+                <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
+              ) : (
+                <Search className="h-4 w-4 mr-2" />
+              )}
+              Analyze
+            </Button>
+            <Button 
+              onClick={() => setPrUrl('https://github.com/continuedev/continue/pull/6274')}
+              variant="outline"
+              disabled={loading}
+            >
+              Test Continue PR
+            </Button>
+            {templateSyncLoading && (
+              <Button disabled variant="outline">
+                <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
+                Syncing Template...
+              </Button>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Results Section */}
+      {result && (
+        <div className="space-y-6">
+          {/* PR Info */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                PR Analysis Results
+                <Link 
+                  to={result.pr.html_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <ExternalLink className="h-4 w-4 text-muted-foreground hover:text-foreground" />
+                </Link>
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-4">
+                <div>
+                  <h3 className="font-semibold">{result.pr.title}</h3>
+                  <p className="text-sm text-muted-foreground">
+                    by {result.pr.contributors?.github_username} • PR #{result.pr.number}
+                  </p>
+                </div>
+
+                <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+                  <div>
+                    <span className="text-sm text-muted-foreground">Current DB Score</span>
+                    <div className="font-semibold">
+                      {result.currentDbScore !== null && result.currentDbScore !== undefined ? (
+                        <Badge variant={getScoreBadgeVariant(result.currentDbScore)}>
+                          {result.currentDbScore}%
+                        </Badge>
+                      ) : (
+                        <Badge variant="outline" className="text-xs">
+                          📊 -
+                        </Badge>
+                      )}
+                    </div>
+                  </div>
+                  <div>
+                    <span className="text-sm text-muted-foreground">New Analysis Score</span>
+                    <div className="font-semibold">
+                      <Badge variant={getScoreBadgeVariant(result.spamScore)}>
+                        {result.spamScore}%
+                      </Badge>
+                    </div>
+                  </div>
+                  <div>
+                    <span className="text-sm text-muted-foreground">Detection Status</span>
+                    <div className="font-semibold">
+                      {result.wasDetected ? (
+                        <Badge variant="destructive">Detected</Badge>
+                      ) : (
+                        <Badge variant="outline">Missed</Badge>
+                      )}
+                    </div>
+                  </div>
+                  <div>
+                    <span className="text-sm text-muted-foreground">Data Source</span>
+                    <div className="font-semibold">
+                      <Badge variant={
+                        result.dataSource === 'database' ? 'default' :
+                        result.dataSource === 'github_sync' ? 'secondary' :
+                        result.dataSource === 'github_api' ? 'outline' : 'destructive'
+                      }>
+                        {result.dataSource.replace('_', ' ').toUpperCase()}
+                      </Badge>
+                    </div>
+                  </div>
+                  <div>
+                    <span className="text-sm text-muted-foreground">Changes</span>
+                    <div className="text-sm">
+                      +{result.pr.additions} -{result.pr.deletions}
+                    </div>
+                  </div>
+                </div>
+
+                {result.warnings.length > 0 && (
+                  <div>
+                    <span className="text-sm text-muted-foreground">Analysis Warnings:</span>
+                    <div className="mt-1 flex flex-wrap gap-1">
+                      {result.warnings.map((warning, idx) => (
+                        <Badge key={idx} variant="outline" className="text-xs text-yellow-700 border-yellow-300">
+                          {warning}
+                        </Badge>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                <div>
+                  <span className="text-sm text-muted-foreground">Detection Reasons:</span>
+                  <div className="mt-1 flex flex-wrap gap-1">
+                    {result.detectionReasons.map((reason, idx) => (
+                      <Badge key={idx} variant="outline" className="text-xs">
+                        {reason}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+
+                {result.pr.body && (
+                  <div>
+                    <span className="text-sm text-muted-foreground">PR Description:</span>
+                    <div className="mt-1 p-3 bg-muted rounded-md text-sm max-h-32 overflow-y-auto">
+                      {result.pr.body}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Manual Classification */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Manual Classification</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-4">
+                <div>
+                  <label className="text-sm text-muted-foreground">Feedback (optional):</label>
+                  <Textarea
+                    placeholder="Explain why this PR is/isn't spam to help improve detection..."
+                    value={manualFeedback}
+                    onChange={(e) => setManualFeedback(e.target.value)}
+                    className="mt-1"
+                  />
+                </div>
+                <div className="flex gap-4">
+                  <Button
+                    onClick={() => markAsSpam(true)}
+                    variant="destructive"
+                  >
+                    <AlertTriangle className="h-4 w-4 mr-2" />
+                    Mark as Spam
+                  </Button>
+                  <Button
+                    onClick={() => markAsSpam(false)}
+                    variant="default"
+                  >
+                    <CheckCircle className="h-4 w-4 mr-2" />
+                    Mark as Legitimate
+                  </Button>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/features/admin/user-management.tsx
+++ b/src/components/features/admin/user-management.tsx
@@ -1,0 +1,427 @@
+import { useState, useEffect } from "react";
+import { supabase } from "@/lib/supabase";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { 
+  Users, 
+  Search, 
+  UserPlus, 
+  Shield, 
+  ShieldCheck, 
+  Clock,
+  ArrowLeft,
+  RefreshCw
+} from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { useAdminAuth } from "@/hooks/use-admin-auth";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+
+interface AppUser {
+  id: string;
+  auth_user_id: string | null;
+  github_username: string;
+  github_user_id: number | null;
+  email: string | null;
+  avatar_url: string | null;
+  display_name: string | null;
+  is_admin: boolean;
+  is_active: boolean;
+  first_login_at: string;
+  last_login_at: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface UserRole {
+  id: string;
+  role: string;
+  granted_at: string;
+  granted_by: string | null;
+  is_active: boolean;
+}
+
+export function UserManagement() {
+  const navigate = useNavigate();
+  const { isAdmin } = useAdminAuth();
+  const [users, setUsers] = useState<AppUser[]>([]);
+  const [filteredUsers, setFilteredUsers] = useState<AppUser[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [roleFilter, setRoleFilter] = useState<string>("all");
+  const [selectedUser, setSelectedUser] = useState<AppUser | null>(null);
+  const [userRoles, setUserRoles] = useState<UserRole[]>([]);
+
+  useEffect(() => {
+    if (isAdmin) {
+      loadUsers();
+    }
+  }, [isAdmin]);
+
+  useEffect(() => {
+    // Filter users based on search and role filter
+    let filtered = users;
+
+    if (searchTerm) {
+      const term = searchTerm.toLowerCase();
+      filtered = filtered.filter(user =>
+        user.github_username.toLowerCase().includes(term) ||
+        user.display_name?.toLowerCase().includes(term) ||
+        user.email?.toLowerCase().includes(term)
+      );
+    }
+
+    if (roleFilter !== "all") {
+      if (roleFilter === "admin") {
+        filtered = filtered.filter(user => user.is_admin);
+      } else if (roleFilter === "user") {
+        filtered = filtered.filter(user => !user.is_admin);
+      } else if (roleFilter === "inactive") {
+        filtered = filtered.filter(user => !user.is_active);
+      }
+    }
+
+    setFilteredUsers(filtered);
+  }, [users, searchTerm, roleFilter]);
+
+  const loadUsers = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const { data, error: fetchError } = await supabase
+        .from('app_users')
+        .select('*')
+        .order('created_at', { ascending: false });
+
+      if (fetchError) {
+        throw fetchError;
+      }
+
+      setUsers(data || []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load users');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadUserRoles = async (userId: string) => {
+    try {
+      const { data, error: fetchError } = await supabase
+        .from('user_roles')
+        .select(`
+          id,
+          role,
+          granted_at,
+          granted_by,
+          is_active,
+          granter:granted_by(github_username)
+        `)
+        .eq('user_id', userId)
+        .order('granted_at', { ascending: false });
+
+      if (fetchError) {
+        throw fetchError;
+      }
+
+      setUserRoles(data || []);
+    } catch (err) {
+      console.error('Failed to load user roles:', err);
+    }
+  };
+
+  const handleUserClick = async (user: AppUser) => {
+    setSelectedUser(user);
+    await loadUserRoles(user.id);
+  };
+
+  const formatDate = (dateString: string) => {
+    return new Date(dateString).toLocaleString();
+  };
+
+  const getRoleBadgeVariant = (role: string) => {
+    switch (role) {
+      case 'admin':
+        return 'destructive';
+      case 'moderator':
+        return 'secondary';
+      default:
+        return 'outline';
+    }
+  };
+
+  if (!isAdmin) {
+    return (
+      <div className="container mx-auto py-8 px-4">
+        <Alert variant="destructive">
+          <Shield className="h-4 w-4" />
+          <AlertDescription>
+            You don't have permission to access user management.
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto py-8 px-4">
+      <div className="max-w-7xl mx-auto">
+        {/* Header */}
+        <div className="mb-8">
+          <div className="flex items-center gap-3 mb-4">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => navigate("/admin")}
+              className="mb-2"
+            >
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Back to Admin
+            </Button>
+          </div>
+          <div className="flex items-center gap-3 mb-2">
+            <Users className="h-8 w-8 text-primary" />
+            <h1 className="text-3xl font-bold">User Management</h1>
+          </div>
+          <p className="text-muted-foreground">
+            Manage application users, roles, and permissions
+          </p>
+        </div>
+
+        {/* Filters */}
+        <Card className="mb-6">
+          <CardHeader>
+            <CardTitle className="text-lg">Filters</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex gap-4">
+              <div className="flex-1">
+                <div className="relative">
+                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                  <Input
+                    placeholder="Search users by username, name, or email..."
+                    value={searchTerm}
+                    onChange={(e) => setSearchTerm(e.target.value)}
+                    className="pl-10"
+                  />
+                </div>
+              </div>
+              <Select value={roleFilter} onValueChange={setRoleFilter}>
+                <SelectTrigger className="w-48">
+                  <SelectValue placeholder="Filter by role" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All Users</SelectItem>
+                  <SelectItem value="admin">Administrators</SelectItem>
+                  <SelectItem value="user">Regular Users</SelectItem>
+                  <SelectItem value="inactive">Inactive Users</SelectItem>
+                </SelectContent>
+              </Select>
+              <Button
+                variant="outline"
+                onClick={loadUsers}
+                disabled={loading}
+              >
+                <RefreshCw className={`h-4 w-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
+                Refresh
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Error State */}
+        {error && (
+          <Alert variant="destructive" className="mb-6">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {/* Users Table */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center justify-between">
+              <span>Users ({filteredUsers.length})</span>
+              <Button disabled>
+                <UserPlus className="h-4 w-4 mr-2" />
+                Add User (Coming Soon)
+              </Button>
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {loading ? (
+              <div className="text-center py-8">
+                <RefreshCw className="h-8 w-8 animate-spin mx-auto mb-4" />
+                <p>Loading users...</p>
+              </div>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>User</TableHead>
+                    <TableHead>Role</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead>Last Login</TableHead>
+                    <TableHead>Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filteredUsers.map((user) => (
+                    <TableRow key={user.id}>
+                      <TableCell>
+                        <div className="flex items-center gap-3">
+                          <Avatar className="h-8 w-8">
+                            <AvatarImage src={user.avatar_url || ''} />
+                            <AvatarFallback>
+                              {user.github_username.charAt(0).toUpperCase()}
+                            </AvatarFallback>
+                          </Avatar>
+                          <div>
+                            <div className="font-medium">{user.github_username}</div>
+                            <div className="text-sm text-muted-foreground">
+                              {user.display_name || user.email}
+                            </div>
+                          </div>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        {user.is_admin ? (
+                          <Badge variant="destructive" className="gap-1">
+                            <ShieldCheck className="h-3 w-3" />
+                            Admin
+                          </Badge>
+                        ) : (
+                          <Badge variant="outline">User</Badge>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant={user.is_active ? "default" : "secondary"}>
+                          {user.is_active ? "Active" : "Inactive"}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-2 text-sm">
+                          <Clock className="h-3 w-3" />
+                          {formatDate(user.last_login_at)}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <Dialog>
+                          <DialogTrigger asChild>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => handleUserClick(user)}
+                            >
+                              View Details
+                            </Button>
+                          </DialogTrigger>
+                          <DialogContent className="max-w-2xl">
+                            <DialogHeader>
+                              <DialogTitle className="flex items-center gap-3">
+                                <Avatar>
+                                  <AvatarImage src={selectedUser?.avatar_url || ''} />
+                                  <AvatarFallback>
+                                    {selectedUser?.github_username.charAt(0).toUpperCase()}
+                                  </AvatarFallback>
+                                </Avatar>
+                                User Details: {selectedUser?.github_username}
+                              </DialogTitle>
+                            </DialogHeader>
+                            {selectedUser && (
+                              <div className="space-y-6">
+                                <div className="grid grid-cols-2 gap-4">
+                                  <div>
+                                    <label className="text-sm font-medium">GitHub Username</label>
+                                    <p className="text-sm text-muted-foreground">{selectedUser.github_username}</p>
+                                  </div>
+                                  <div>
+                                    <label className="text-sm font-medium">Display Name</label>
+                                    <p className="text-sm text-muted-foreground">{selectedUser.display_name || 'N/A'}</p>
+                                  </div>
+                                  <div>
+                                    <label className="text-sm font-medium">Email</label>
+                                    <p className="text-sm text-muted-foreground">{selectedUser.email || 'N/A'}</p>
+                                  </div>
+                                  <div>
+                                    <label className="text-sm font-medium">GitHub ID</label>
+                                    <p className="text-sm text-muted-foreground">{selectedUser.github_user_id || 'N/A'}</p>
+                                  </div>
+                                  <div>
+                                    <label className="text-sm font-medium">First Login</label>
+                                    <p className="text-sm text-muted-foreground">{formatDate(selectedUser.first_login_at)}</p>
+                                  </div>
+                                  <div>
+                                    <label className="text-sm font-medium">Last Login</label>
+                                    <p className="text-sm text-muted-foreground">{formatDate(selectedUser.last_login_at)}</p>
+                                  </div>
+                                </div>
+
+                                <div>
+                                  <h4 className="font-medium mb-3">Roles</h4>
+                                  <div className="space-y-2">
+                                    {userRoles.filter(r => r.is_active).map((role) => (
+                                      <div key={role.id} className="flex items-center justify-between p-3 border rounded">
+                                        <div className="flex items-center gap-3">
+                                          <Badge variant={getRoleBadgeVariant(role.role)}>
+                                            {role.role}
+                                          </Badge>
+                                          <span className="text-sm">
+                                            Granted {formatDate(role.granted_at)}
+                                          </span>
+                                        </div>
+                                      </div>
+                                    ))}
+                                    {userRoles.filter(r => r.is_active).length === 0 && (
+                                      <p className="text-sm text-muted-foreground">No active roles</p>
+                                    )}
+                                  </div>
+                                </div>
+                              </div>
+                            )}
+                          </DialogContent>
+                        </Dialog>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                  {filteredUsers.length === 0 && !loading && (
+                    <TableRow>
+                      <TableCell colSpan={5} className="text-center py-8 text-muted-foreground">
+                        {searchTerm || roleFilter !== "all" ? "No users match your filters" : "No users found"}
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/admin/user-management.tsx
+++ b/src/components/features/admin/user-management.tsx
@@ -1,54 +1,45 @@
-import { useState, useEffect } from "react";
-import { supabase } from "@/lib/supabase";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Input } from "@/components/ui/input";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import {
+import { useState, useEffect } from 'react';
+import { supabase } from '@/lib/supabase';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
+import { 
+  Table, 
+  TableBody, 
+  TableCell, 
+  TableHead, 
+  TableHeader, 
+  TableRow 
+} from '@/components/ui/table';
+import { 
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from "@/components/ui/select";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
+} from '@/components/ui/select';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { 
   Users, 
   Search, 
-  UserPlus, 
   Shield, 
-  ShieldCheck, 
-  Clock,
-  ArrowLeft,
+  UserCheck, 
+  Calendar,
+  ExternalLink,
   RefreshCw
-} from "lucide-react";
-import { useNavigate } from "react-router-dom";
-import { useAdminAuth } from "@/hooks/use-admin-auth";
-import { Alert, AlertDescription } from "@/components/ui/alert";
+} from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { logAdminAction, useAdminGitHubId } from '@/hooks/use-admin-auth';
 
 interface AppUser {
   id: string;
-  auth_user_id: string | null;
+  github_user_id: number;
   github_username: string;
-  github_user_id: number | null;
-  email: string | null;
-  avatar_url: string | null;
-  display_name: string | null;
+  display_name?: string;
+  avatar_url?: string;
+  email?: string;
   is_admin: boolean;
   is_active: boolean;
   first_login_at: string;
@@ -57,66 +48,28 @@ interface AppUser {
   updated_at: string;
 }
 
-interface UserRole {
-  id: string;
-  role: string;
-  granted_at: string;
-  granted_by: string | null;
-  is_active: boolean;
-}
-
 export function UserManagement() {
-  const navigate = useNavigate();
-  const { isAdmin } = useAdminAuth();
   const [users, setUsers] = useState<AppUser[]>([]);
-  const [filteredUsers, setFilteredUsers] = useState<AppUser[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [searchTerm, setSearchTerm] = useState("");
-  const [roleFilter, setRoleFilter] = useState<string>("all");
-  const [selectedUser, setSelectedUser] = useState<AppUser | null>(null);
-  const [userRoles, setUserRoles] = useState<UserRole[]>([]);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [filterRole, setFilterRole] = useState<'all' | 'admin' | 'user'>('all');
+  const [filterStatus, setFilterStatus] = useState<'all' | 'active' | 'inactive'>('all');
+  const adminGitHubId = useAdminGitHubId();
 
   useEffect(() => {
-    if (isAdmin) {
-      loadUsers();
-    }
-  }, [isAdmin]);
+    fetchUsers();
+  }, []);
 
-  useEffect(() => {
-    // Filter users based on search and role filter
-    let filtered = users;
-
-    if (searchTerm) {
-      const term = searchTerm.toLowerCase();
-      filtered = filtered.filter(user =>
-        user.github_username.toLowerCase().includes(term) ||
-        user.display_name?.toLowerCase().includes(term) ||
-        user.email?.toLowerCase().includes(term)
-      );
-    }
-
-    if (roleFilter !== "all") {
-      if (roleFilter === "admin") {
-        filtered = filtered.filter(user => user.is_admin);
-      } else if (roleFilter === "user") {
-        filtered = filtered.filter(user => !user.is_admin);
-      } else if (roleFilter === "inactive") {
-        filtered = filtered.filter(user => !user.is_active);
-      }
-    }
-
-    setFilteredUsers(filtered);
-  }, [users, searchTerm, roleFilter]);
-
-  const loadUsers = async () => {
+  const fetchUsers = async () => {
     try {
       setLoading(true);
       setError(null);
-
+      
       const { data, error: fetchError } = await supabase
         .from('app_users')
         .select('*')
+        .order('last_login_at', { ascending: false, nullsFirst: false })
         .order('created_at', { ascending: false });
 
       if (fetchError) {
@@ -125,303 +78,297 @@ export function UserManagement() {
 
       setUsers(data || []);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load users');
+      console.error('Error fetching users:', err);
+      setError(err instanceof Error ? err.message : 'Failed to fetch users');
     } finally {
       setLoading(false);
     }
   };
 
-  const loadUserRoles = async (userId: string) => {
-    try {
-      const { data, error: fetchError } = await supabase
-        .from('user_roles')
-        .select(`
-          id,
-          role,
-          granted_at,
-          granted_by,
-          is_active,
-          granter:granted_by(github_username)
-        `)
-        .eq('user_id', userId)
-        .order('granted_at', { ascending: false });
+  const toggleAdminStatus = async (user: AppUser) => {
+    if (!adminGitHubId) return;
 
-      if (fetchError) {
-        throw fetchError;
+    try {
+      const newAdminStatus = !user.is_admin;
+      
+      const { error: updateError } = await supabase
+        .from('app_users')
+        .update({ 
+          is_admin: newAdminStatus,
+          updated_at: new Date().toISOString()
+        })
+        .eq('id', user.id);
+
+      if (updateError) {
+        throw updateError;
       }
 
-      setUserRoles(data || []);
+      // Log admin action
+      await logAdminAction(
+        adminGitHubId,
+        'user_admin_status_changed',
+        'user',
+        user.id,
+        {
+          target_username: user.github_username,
+          old_admin_status: user.is_admin,
+          new_admin_status: newAdminStatus
+        }
+      );
+
+      // Update local state
+      setUsers(users.map(u => 
+        u.id === user.id 
+          ? { ...u, is_admin: newAdminStatus, updated_at: new Date().toISOString() }
+          : u
+      ));
     } catch (err) {
-      console.error('Failed to load user roles:', err);
+      console.error('Error updating admin status:', err);
+      setError(err instanceof Error ? err.message : 'Failed to update admin status');
     }
   };
 
-  const handleUserClick = async (user: AppUser) => {
-    setSelectedUser(user);
-    await loadUserRoles(user.id);
+  // Filter users based on search and filter criteria
+  const filteredUsers = users.filter(user => {
+    const matchesSearch = 
+      user.github_username.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      user.display_name?.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      user.email?.toLowerCase().includes(searchTerm.toLowerCase());
+
+    const matchesRole = 
+      filterRole === 'all' ||
+      (filterRole === 'admin' && user.is_admin) ||
+      (filterRole === 'user' && !user.is_admin);
+
+    const matchesStatus = 
+      filterStatus === 'all' ||
+      (filterStatus === 'active' && user.is_active) ||
+      (filterStatus === 'inactive' && !user.is_active);
+
+    return matchesSearch && matchesRole && matchesStatus;
+  });
+
+  const stats = {
+    total: users.length,
+    admins: users.filter(u => u.is_admin).length,
+    active: users.filter(u => u.is_active).length,
+    recentLogins: users.filter(u => {
+      const lastLogin = new Date(u.last_login_at);
+      const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+      return lastLogin > oneWeekAgo;
+    }).length
   };
 
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleString();
-  };
-
-  const getRoleBadgeVariant = (role: string) => {
-    switch (role) {
-      case 'admin':
-        return 'destructive';
-      case 'moderator':
-        return 'secondary';
-      default:
-        return 'outline';
-    }
-  };
-
-  if (!isAdmin) {
+  if (loading) {
     return (
-      <div className="container mx-auto py-8 px-4">
-        <Alert variant="destructive">
-          <Shield className="h-4 w-4" />
-          <AlertDescription>
-            You don't have permission to access user management.
-          </AlertDescription>
-        </Alert>
+      <div className="container mx-auto p-6">
+        <div className="flex items-center justify-center min-h-[400px]">
+          <div className="text-center">
+            <RefreshCw className="h-8 w-8 animate-spin mx-auto mb-4" />
+            <p className="text-muted-foreground">Loading users...</p>
+          </div>
+        </div>
       </div>
     );
   }
 
   return (
-    <div className="container mx-auto py-8 px-4">
-      <div className="max-w-7xl mx-auto">
-        {/* Header */}
-        <div className="mb-8">
-          <div className="flex items-center gap-3 mb-4">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => navigate("/admin")}
-              className="mb-2"
-            >
-              <ArrowLeft className="h-4 w-4 mr-2" />
-              Back to Admin
-            </Button>
-          </div>
-          <div className="flex items-center gap-3 mb-2">
-            <Users className="h-8 w-8 text-primary" />
-            <h1 className="text-3xl font-bold">User Management</h1>
-          </div>
+    <div className="container mx-auto p-6">
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-6">
+        <div className="p-3 rounded-lg bg-blue-100 text-blue-600">
+          <Users className="h-6 w-6" />
+        </div>
+        <div>
+          <h1 className="text-3xl font-bold">User Management</h1>
           <p className="text-muted-foreground">
-            Manage application users, roles, and permissions
+            Manage user accounts, roles, and permissions
           </p>
         </div>
+      </div>
 
-        {/* Filters */}
-        <Card className="mb-6">
-          <CardHeader>
-            <CardTitle className="text-lg">Filters</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="flex gap-4">
-              <div className="flex-1">
-                <div className="relative">
-                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-                  <Input
-                    placeholder="Search users by username, name, or email..."
-                    value={searchTerm}
-                    onChange={(e) => setSearchTerm(e.target.value)}
-                    className="pl-10"
-                  />
-                </div>
-              </div>
-              <Select value={roleFilter} onValueChange={setRoleFilter}>
-                <SelectTrigger className="w-48">
-                  <SelectValue placeholder="Filter by role" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">All Users</SelectItem>
-                  <SelectItem value="admin">Administrators</SelectItem>
-                  <SelectItem value="user">Regular Users</SelectItem>
-                  <SelectItem value="inactive">Inactive Users</SelectItem>
-                </SelectContent>
-              </Select>
-              <Button
-                variant="outline"
-                onClick={loadUsers}
-                disabled={loading}
-              >
-                <RefreshCw className={`h-4 w-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
-                Refresh
-              </Button>
+      {error && (
+        <Alert variant="destructive" className="mb-6">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {/* Stats Cards */}
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-2">
+              <Users className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm text-muted-foreground">Total Users</span>
             </div>
+            <p className="text-2xl font-bold">{stats.total}</p>
           </CardContent>
         </Card>
-
-        {/* Error State */}
-        {error && (
-          <Alert variant="destructive" className="mb-6">
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
-        )}
-
-        {/* Users Table */}
         <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center justify-between">
-              <span>Users ({filteredUsers.length})</span>
-              <Button disabled>
-                <UserPlus className="h-4 w-4 mr-2" />
-                Add User (Coming Soon)
-              </Button>
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {loading ? (
-              <div className="text-center py-8">
-                <RefreshCw className="h-8 w-8 animate-spin mx-auto mb-4" />
-                <p>Loading users...</p>
-              </div>
-            ) : (
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>User</TableHead>
-                    <TableHead>Role</TableHead>
-                    <TableHead>Status</TableHead>
-                    <TableHead>Last Login</TableHead>
-                    <TableHead>Actions</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {filteredUsers.map((user) => (
-                    <TableRow key={user.id}>
-                      <TableCell>
-                        <div className="flex items-center gap-3">
-                          <Avatar className="h-8 w-8">
-                            <AvatarImage src={user.avatar_url || ''} />
-                            <AvatarFallback>
-                              {user.github_username.charAt(0).toUpperCase()}
-                            </AvatarFallback>
-                          </Avatar>
-                          <div>
-                            <div className="font-medium">{user.github_username}</div>
-                            <div className="text-sm text-muted-foreground">
-                              {user.display_name || user.email}
-                            </div>
-                          </div>
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        {user.is_admin ? (
-                          <Badge variant="destructive" className="gap-1">
-                            <ShieldCheck className="h-3 w-3" />
-                            Admin
-                          </Badge>
-                        ) : (
-                          <Badge variant="outline">User</Badge>
-                        )}
-                      </TableCell>
-                      <TableCell>
-                        <Badge variant={user.is_active ? "default" : "secondary"}>
-                          {user.is_active ? "Active" : "Inactive"}
-                        </Badge>
-                      </TableCell>
-                      <TableCell>
-                        <div className="flex items-center gap-2 text-sm">
-                          <Clock className="h-3 w-3" />
-                          {formatDate(user.last_login_at)}
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        <Dialog>
-                          <DialogTrigger asChild>
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={() => handleUserClick(user)}
-                            >
-                              View Details
-                            </Button>
-                          </DialogTrigger>
-                          <DialogContent className="max-w-2xl">
-                            <DialogHeader>
-                              <DialogTitle className="flex items-center gap-3">
-                                <Avatar>
-                                  <AvatarImage src={selectedUser?.avatar_url || ''} />
-                                  <AvatarFallback>
-                                    {selectedUser?.github_username.charAt(0).toUpperCase()}
-                                  </AvatarFallback>
-                                </Avatar>
-                                User Details: {selectedUser?.github_username}
-                              </DialogTitle>
-                            </DialogHeader>
-                            {selectedUser && (
-                              <div className="space-y-6">
-                                <div className="grid grid-cols-2 gap-4">
-                                  <div>
-                                    <label className="text-sm font-medium">GitHub Username</label>
-                                    <p className="text-sm text-muted-foreground">{selectedUser.github_username}</p>
-                                  </div>
-                                  <div>
-                                    <label className="text-sm font-medium">Display Name</label>
-                                    <p className="text-sm text-muted-foreground">{selectedUser.display_name || 'N/A'}</p>
-                                  </div>
-                                  <div>
-                                    <label className="text-sm font-medium">Email</label>
-                                    <p className="text-sm text-muted-foreground">{selectedUser.email || 'N/A'}</p>
-                                  </div>
-                                  <div>
-                                    <label className="text-sm font-medium">GitHub ID</label>
-                                    <p className="text-sm text-muted-foreground">{selectedUser.github_user_id || 'N/A'}</p>
-                                  </div>
-                                  <div>
-                                    <label className="text-sm font-medium">First Login</label>
-                                    <p className="text-sm text-muted-foreground">{formatDate(selectedUser.first_login_at)}</p>
-                                  </div>
-                                  <div>
-                                    <label className="text-sm font-medium">Last Login</label>
-                                    <p className="text-sm text-muted-foreground">{formatDate(selectedUser.last_login_at)}</p>
-                                  </div>
-                                </div>
-
-                                <div>
-                                  <h4 className="font-medium mb-3">Roles</h4>
-                                  <div className="space-y-2">
-                                    {userRoles.filter(r => r.is_active).map((role) => (
-                                      <div key={role.id} className="flex items-center justify-between p-3 border rounded">
-                                        <div className="flex items-center gap-3">
-                                          <Badge variant={getRoleBadgeVariant(role.role)}>
-                                            {role.role}
-                                          </Badge>
-                                          <span className="text-sm">
-                                            Granted {formatDate(role.granted_at)}
-                                          </span>
-                                        </div>
-                                      </div>
-                                    ))}
-                                    {userRoles.filter(r => r.is_active).length === 0 && (
-                                      <p className="text-sm text-muted-foreground">No active roles</p>
-                                    )}
-                                  </div>
-                                </div>
-                              </div>
-                            )}
-                          </DialogContent>
-                        </Dialog>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                  {filteredUsers.length === 0 && !loading && (
-                    <TableRow>
-                      <TableCell colSpan={5} className="text-center py-8 text-muted-foreground">
-                        {searchTerm || roleFilter !== "all" ? "No users match your filters" : "No users found"}
-                      </TableCell>
-                    </TableRow>
-                  )}
-                </TableBody>
-              </Table>
-            )}
+          <CardContent className="p-4">
+            <div className="flex items-center gap-2">
+              <Shield className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm text-muted-foreground">Admins</span>
+            </div>
+            <p className="text-2xl font-bold">{stats.admins}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-2">
+              <UserCheck className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm text-muted-foreground">Active</span>
+            </div>
+            <p className="text-2xl font-bold">{stats.active}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center gap-2">
+              <Calendar className="h-4 w-4 text-muted-foreground" />
+              <span className="text-sm text-muted-foreground">Recent Logins</span>
+            </div>
+            <p className="text-2xl font-bold">{stats.recentLogins}</p>
           </CardContent>
         </Card>
       </div>
+
+      {/* Filters */}
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle>Filters</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col sm:flex-row gap-4">
+            <div className="flex-1">
+              <div className="relative">
+                <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+                <Input
+                  placeholder="Search users..."
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                  className="pl-10"
+                />
+              </div>
+            </div>
+            <Select value={filterRole} onValueChange={(value: any) => setFilterRole(value)}>
+              <SelectTrigger className="w-full sm:w-[180px]">
+                <SelectValue placeholder="Filter by role" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Roles</SelectItem>
+                <SelectItem value="admin">Admins</SelectItem>
+                <SelectItem value="user">Users</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select value={filterStatus} onValueChange={(value: any) => setFilterStatus(value)}>
+              <SelectTrigger className="w-full sm:w-[180px]">
+                <SelectValue placeholder="Filter by status" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Status</SelectItem>
+                <SelectItem value="active">Active</SelectItem>
+                <SelectItem value="inactive">Inactive</SelectItem>
+              </SelectContent>
+            </Select>
+            <Button onClick={fetchUsers} variant="outline">
+              <RefreshCw className="h-4 w-4 mr-2" />
+              Refresh
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Users Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Users ({filteredUsers.length})</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>User</TableHead>
+                  <TableHead>Role</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Last Login</TableHead>
+                  <TableHead>Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredUsers.map((user) => (
+                  <TableRow key={user.id}>
+                    <TableCell>
+                      <div className="flex items-center gap-3">
+                        <Avatar className="h-8 w-8">
+                          <AvatarImage src={user.avatar_url} alt={user.github_username} />
+                          <AvatarFallback>
+                            {user.github_username.slice(0, 2).toUpperCase()}
+                          </AvatarFallback>
+                        </Avatar>
+                        <div>
+                          <div className="flex items-center gap-2">
+                            <span className="font-medium">{user.github_username}</span>
+                            <Link 
+                              to={`https://github.com/${user.github_username}`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              <ExternalLink className="h-3 w-3 text-muted-foreground hover:text-foreground" />
+                            </Link>
+                          </div>
+                          {user.display_name && (
+                            <p className="text-sm text-muted-foreground">{user.display_name}</p>
+                          )}
+                          {user.email && (
+                            <p className="text-xs text-muted-foreground">{user.email}</p>
+                          )}
+                        </div>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={user.is_admin ? "default" : "secondary"}>
+                        {user.is_admin ? (
+                          <>
+                            <Shield className="h-3 w-3 mr-1" />
+                            Admin
+                          </>
+                        ) : (
+                          'User'
+                        )}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={user.is_active ? "default" : "secondary"}>
+                        {user.is_active ? 'Active' : 'Inactive'}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <div className="text-sm">
+                        {new Date(user.last_login_at).toLocaleDateString()}
+                        <div className="text-xs text-muted-foreground">
+                          {new Date(user.last_login_at).toLocaleTimeString()}
+                        </div>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Button
+                        onClick={() => toggleAdminStatus(user)}
+                        variant={user.is_admin ? "destructive" : "default"}
+                        size="sm"
+                        disabled={user.github_user_id === adminGitHubId} // Can't change own status
+                      >
+                        {user.is_admin ? 'Remove Admin' : 'Make Admin'}
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/src/components/features/auth/admin-route.tsx
+++ b/src/components/features/auth/admin-route.tsx
@@ -1,0 +1,101 @@
+import { useEffect } from "react";
+import type { ReactNode } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+import { useAdminAuth } from "@/hooks/use-admin-auth";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Loader2, ShieldX, Lock } from "lucide-react";
+
+interface AdminRouteProps {
+  children: ReactNode;
+  requireRole?: 'admin' | 'moderator'; // Optional specific role requirement
+}
+
+export function AdminRoute({ children }: AdminRouteProps) {
+  const { user, isLoggedIn, isAdmin, loading, error } = useAdminAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  useEffect(() => {
+    if (!loading && !isLoggedIn) {
+      // Store the attempted URL for redirect after login
+      const redirectTo = location.pathname + location.search;
+      localStorage.setItem("redirectTo", redirectTo);
+      navigate("/login");
+    }
+  }, [isLoggedIn, loading, navigate, location]);
+
+  // Show loading spinner while checking authentication
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="flex flex-col items-center gap-4">
+          <Loader2 className="h-8 w-8 animate-spin" />
+          <p className="text-sm text-muted-foreground">Checking admin access...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Show error state if there's an authentication error
+  if (error) {
+    return (
+      <div className="flex items-center justify-center min-h-screen p-4">
+        <div className="max-w-md w-full">
+          <Alert variant="destructive">
+            <ShieldX className="h-4 w-4" />
+            <AlertDescription>
+              Authentication error: {error}
+            </AlertDescription>
+          </Alert>
+          <div className="mt-4 text-center">
+            <Button onClick={() => window.location.reload()}>
+              Try Again
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Don't render if not authenticated (navigation will handle redirect)
+  if (!isLoggedIn || !user) {
+    return null;
+  }
+
+  // Check admin access
+  if (!isAdmin) {
+    return (
+      <div className="flex items-center justify-center min-h-screen p-4">
+        <div className="max-w-md w-full text-center">
+          <div className="mb-6">
+            <Lock className="h-16 w-16 mx-auto text-muted-foreground" />
+          </div>
+          <h2 className="text-2xl font-bold mb-2">Access Denied</h2>
+          <p className="text-muted-foreground mb-6">
+            You need administrator privileges to access this page.
+          </p>
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">
+              Current user: <span className="font-medium">{user.user_metadata?.user_name}</span>
+            </p>
+            <Button onClick={() => navigate("/")} variant="outline">
+              Return to Home
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // TODO: Add specific role checking when needed
+  // This can be extended later for more granular permissions
+  // if (requireRole === 'moderator') {
+  //   const hasModerator = await hasRole('moderator');
+  //   if (!hasModerator) {
+  //     // Show insufficient permissions
+  //   }
+  // }
+
+  return <>{children}</>;
+}

--- a/src/components/features/auth/auth-button.tsx
+++ b/src/components/features/auth/auth-button.tsx
@@ -30,9 +30,23 @@ export function AuthButton() {
       }
 
       try {
-        const { data: adminCheck } = await supabase
-          .rpc('is_user_admin', { user_github_username: user.user_metadata.user_name });
-        setIsAdmin(adminCheck === true);
+        // Get GitHub user ID from metadata and check admin status
+        const githubId = user.user_metadata?.provider_id || user.user_metadata?.sub;
+        if (!githubId) {
+          setIsAdmin(false);
+          return;
+        }
+
+        const { data: isAdminResult, error } = await supabase
+          .rpc('is_user_admin', { user_github_id: parseInt(githubId) });
+
+        if (error) {
+          console.warn('Failed to check admin status:', error);
+          setIsAdmin(false);
+          return;
+        }
+
+        setIsAdmin(isAdminResult === true);
       } catch (err) {
         console.warn('Failed to check admin status:', err);
         setIsAdmin(false);

--- a/src/components/features/auth/auth-button.tsx
+++ b/src/components/features/auth/auth-button.tsx
@@ -2,21 +2,43 @@ import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { GithubIcon, LogOut, MessageSquare } from "lucide-react";
+import { GithubIcon, LogOut, MessageSquare, Shield, Settings } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 import type { User } from "@supabase/supabase-js";
 
 export function AuthButton() {
+  const navigate = useNavigate();
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [isAdmin, setIsAdmin] = useState(false);
 
   useEffect(() => {
+    // Check admin status for a user
+    const checkAdminStatus = async (user: User | null) => {
+      if (!user || !user.user_metadata?.user_name) {
+        setIsAdmin(false);
+        return;
+      }
+
+      try {
+        const { data: adminCheck } = await supabase
+          .rpc('is_user_admin', { user_github_username: user.user_metadata.user_name });
+        setIsAdmin(adminCheck === true);
+      } catch (err) {
+        console.warn('Failed to check admin status:', err);
+        setIsAdmin(false);
+      }
+    };
+
     // Get initial session
     supabase.auth
       .getSession()
@@ -24,7 +46,9 @@ export function AuthButton() {
         if (sessionError) {
           setError(sessionError.message);
         }
-        setUser(session?.user ?? null);
+        const user = session?.user ?? null;
+        setUser(user);
+        checkAdminStatus(user);
         setLoading(false);
       })
       .catch(() => {
@@ -36,7 +60,9 @@ export function AuthButton() {
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_event, session) => {
-      setUser(session?.user ?? null);
+      const user = session?.user ?? null;
+      setUser(user);
+      checkAdminStatus(user);
     });
 
     return () => subscription.unsubscribe();
@@ -110,10 +136,33 @@ export function AuthButton() {
           </Avatar>
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
+      <DropdownMenuContent align="end" className="w-56">
         <DropdownMenuItem className="font-medium">
-          {user.user_metadata.user_name}
+          <div className="flex items-center justify-between w-full">
+            <span>{user.user_metadata.user_name}</span>
+            {isAdmin && (
+              <Badge variant="destructive" className="text-xs">
+                Admin
+              </Badge>
+            )}
+          </div>
         </DropdownMenuItem>
+        
+        {isAdmin && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={() => navigate("/admin")}>
+              <Shield className="mr-2 h-4 w-4" />
+              Admin Dashboard
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => navigate("/dev")}>
+              <Settings className="mr-2 h-4 w-4" />
+              Developer Tools
+            </DropdownMenuItem>
+          </>
+        )}
+        
+        <DropdownMenuSeparator />
         <DropdownMenuItem asChild>
           <a
             href="https://github.com/bdougie/contributor.info/discussions"

--- a/src/components/features/auth/index.ts
+++ b/src/components/features/auth/index.ts
@@ -1,6 +1,7 @@
 export { AuthButton } from './auth-button';
 export { LoginDialog } from './login-dialog';
 export { ProtectedRoute } from './protected-route';
+export { AdminRoute } from './admin-route';
 export { default as LoginPage } from './login-page';
 export { default as DebugAuthPage } from './debug-auth-page';
 export { default as LoginDialogTest } from './login-dialog-test';

--- a/src/components/features/debug/debug-menu.tsx
+++ b/src/components/features/debug/debug-menu.tsx
@@ -14,7 +14,8 @@ import {
   BarChart3,
   Image,
   Link,
-  Database
+  Database,
+  GitBranch
 } from "lucide-react";
 
 interface DebugRoute {
@@ -73,6 +74,13 @@ const debugRoutes: DebugRoute[] = [
     title: "Dub.co API Test",
     description: "Test dub.co API integration and debug authorization issues",
     icon: <Link className="h-4 w-4" />,
+    category: "testing"
+  },
+  {
+    path: "/dev/sync-test",
+    title: "GitHub Sync Test",
+    description: "Manual GitHub sync testing with real-time logging and debugging",
+    icon: <GitBranch className="h-4 w-4" />,
     category: "testing"
   },
   {

--- a/src/components/features/feed/feed-page.tsx
+++ b/src/components/features/feed/feed-page.tsx
@@ -5,7 +5,7 @@ import {
   CardContent,
 } from "@/components/ui/card";
 import { RepoStatsProvider } from "@/lib/repo-stats-context";
-import { PRActivity } from "../activity";
+import PRActivityWrapper from "../activity/pr-activity-wrapper";
 import { useTimeRangeStore } from "@/lib/time-range-store";
 import { useCachedRepoData } from "@/hooks/use-cached-repo-data";
 import { FeedSkeleton } from "@/components/skeletons";
@@ -86,7 +86,7 @@ export default function FeedPage() {
           setIncludeBots,
         }}
       >
-        <PRActivity />
+        <PRActivityWrapper />
       </RepoStatsProvider>
     </div>
   );

--- a/src/components/features/feed/spam-feed-page.tsx
+++ b/src/components/features/feed/spam-feed-page.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import { useParams } from "react-router-dom";
+import {
+  Card,
+  CardContent,
+} from "@/components/ui/card";
+import { RepoStatsProvider } from "@/lib/repo-stats-context";
+import FilteredPRActivity from "../activity/pr-activity-filtered";
+import { useTimeRangeStore } from "@/lib/time-range-store";
+import { useCachedRepoData } from "@/hooks/use-cached-repo-data";
+import { FeedSkeleton } from "@/components/skeletons";
+import { SocialMetaTags } from "@/components/common/layout";
+
+export default function SpamFeedPage() {
+  const { owner, repo } = useParams<{ owner: string; repo: string }>();
+  const timeRange = useTimeRangeStore((state) => state.timeRange);
+  const [includeBots, setIncludeBots] = useState(false);
+
+  // Use our custom hooks
+  const { stats, lotteryFactor, directCommitsData } = useCachedRepoData(
+    owner,
+    repo,
+    timeRange,
+    includeBots
+  );
+
+  if (!owner || !repo) {
+    return (
+      <div className="container mx-auto py-2">
+        <Card>
+          <CardContent className="p-8">
+            <div className="text-center">
+              <h2 className="text-2xl font-semibold mb-2">Invalid Repository</h2>
+              <p className="text-muted-foreground">
+                Please navigate to a specific repository to view its spam feed.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (stats.loading) {
+    return <FeedSkeleton />;
+  }
+
+  if (stats.error) {
+    return (
+      <div className="container mx-auto py-2">
+        <Card>
+          <CardContent className="p-8">
+            <div className="text-center">
+              <h2 className="text-2xl font-semibold text-destructive mb-2">
+                Error
+              </h2>
+              <p className="text-muted-foreground">{stats.error}</p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const feedTitle = `${owner}/${repo} - Spam Analysis Feed`;
+  const feedDescription = `Spam detection and analysis feed for ${owner}/${repo}. Review potentially suspicious pull requests and contributions with advanced filtering.`;
+  const feedUrl = `https://contributor.info/${owner}/${repo}/feed/spam`;
+
+  return (
+    <div className="container mx-auto py-2">
+      <SocialMetaTags
+        title={feedTitle}
+        description={feedDescription}
+        url={feedUrl}
+        type="article"
+        image={`social-cards/repo-${owner}-${repo}.png`}
+      />
+      
+
+      <RepoStatsProvider
+        value={{
+          stats,
+          lotteryFactor,
+          directCommitsData,
+          includeBots,
+          setIncludeBots,
+        }}
+      >
+        <FilteredPRActivity />
+      </RepoStatsProvider>
+    </div>
+  );
+}

--- a/src/components/features/repository/repo-view.tsx
+++ b/src/components/features/repository/repo-view.tsx
@@ -41,7 +41,7 @@ export default function RepoView() {
     const path = location.pathname;
     if (path.endsWith("/health")) return "lottery";
     if (path.endsWith("/distribution")) return "distribution";
-    if (path.endsWith("/feed")) return "feed";
+    if (path.endsWith("/feed") || path.includes("/feed/")) return "feed";
     if (path.endsWith("/activity") || path.endsWith("/contributions"))
       return "contributions";
     return "contributions"; // default for root path

--- a/src/components/features/spam/spam-filter-controls.tsx
+++ b/src/components/features/spam/spam-filter-controls.tsx
@@ -1,0 +1,247 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Slider } from '@/components/ui/slider';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import {
+  Alert,
+  AlertDescription,
+} from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Shield, AlertTriangle, Info } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { SpamFilterOptions } from '@/lib/api/spam-filtered-feed';
+import { useSpamTolerancePresets } from '@/hooks/use-spam-filtered-feed';
+
+interface SpamFilterControlsProps {
+  filterOptions: SpamFilterOptions;
+  onFilterChange: (options: SpamFilterOptions) => void;
+  spamStats?: {
+    totalAnalyzed: number;
+    spamCount: number;
+    spamPercentage: number;
+    distribution: {
+      legitimate: number;
+      warning: number;
+      likelySpam: number;
+      definiteSpam: number;
+    };
+  };
+  className?: string;
+}
+
+export function SpamFilterControls({
+  filterOptions,
+  onFilterChange,
+  spamStats,
+  className,
+}: SpamFilterControlsProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const presets = useSpamTolerancePresets();
+
+  // Determine current preset based on filter options
+  const currentPreset = Object.entries(presets).find(([_, preset]) => {
+    return (
+      preset.options.maxSpamScore === filterOptions.maxSpamScore &&
+      preset.options.includeSpam === filterOptions.includeSpam &&
+      preset.options.includeUnreviewed === filterOptions.includeUnreviewed
+    );
+  })?.[1];
+
+  const handlePresetSelect = (preset: typeof presets.strict) => {
+    onFilterChange(preset.options);
+  };
+
+  const handleSliderChange = (value: number[]) => {
+    onFilterChange({
+      ...filterOptions,
+      maxSpamScore: value[0],
+    });
+  };
+
+  const getFilteredCount = () => {
+    if (!spamStats) return null;
+    
+    const { distribution } = spamStats;
+    let included = 0;
+    
+    if (filterOptions.maxSpamScore !== undefined) {
+      if (filterOptions.maxSpamScore >= 76) included += distribution.definiteSpam;
+      if (filterOptions.maxSpamScore >= 51) included += distribution.likelySpam;
+      if (filterOptions.maxSpamScore >= 26) included += distribution.warning;
+      included += distribution.legitimate;
+    }
+    
+    return included;
+  };
+
+  const filteredCount = getFilteredCount();
+
+  return (
+    <div className={cn("flex items-center gap-2", className)}>
+      <Popover open={isOpen} onOpenChange={setIsOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-2"
+          >
+            <Shield className="h-4 w-4" />
+            <span>Spam Filter</span>
+            {currentPreset && (
+              <Badge variant="secondary" className="ml-1">
+                {currentPreset.name}
+              </Badge>
+            )}
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-96" align="end">
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <h4 className="font-medium flex items-center gap-2">
+                <Shield className="h-4 w-4" />
+                Spam Filter Settings
+              </h4>
+              <p className="text-sm text-muted-foreground">
+                Control which pull requests appear in your feed
+              </p>
+            </div>
+
+            {/* Spam Stats */}
+            {spamStats && spamStats.totalAnalyzed > 0 && (
+              <Alert>
+                <Info className="h-4 w-4" />
+                <AlertDescription>
+                  <div className="space-y-1">
+                    <p className="font-medium">Repository Statistics</p>
+                    <p className="text-xs">
+                      {spamStats.spamCount} of {spamStats.totalAnalyzed} PRs flagged as spam
+                      ({spamStats.spamPercentage.toFixed(1)}%)
+                    </p>
+                    {filteredCount !== null && (
+                      <p className="text-xs">
+                        Current filter shows {filteredCount} of {spamStats.totalAnalyzed} analyzed PRs
+                      </p>
+                    )}
+                  </div>
+                </AlertDescription>
+              </Alert>
+            )}
+
+            {/* Preset Options */}
+            <div className="space-y-2">
+              <Label>Quick Settings</Label>
+              <div className="grid grid-cols-2 gap-2">
+                {Object.entries(presets).map(([key, preset]) => (
+                  <Button
+                    key={key}
+                    variant={currentPreset === preset ? "default" : "outline"}
+                    size="sm"
+                    onClick={() => handlePresetSelect(preset)}
+                    className="justify-start"
+                  >
+                    <span className="text-xs">{preset.name}</span>
+                  </Button>
+                ))}
+              </div>
+            </div>
+
+            {/* Custom Settings */}
+            <div className="space-y-4 pt-2 border-t">
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <Label>Max Spam Score</Label>
+                  <span className="text-sm text-muted-foreground">
+                    {filterOptions.maxSpamScore || 0}
+                  </span>
+                </div>
+                <Slider
+                  value={[filterOptions.maxSpamScore || 50]}
+                  onValueChange={handleSliderChange}
+                  min={0}
+                  max={100}
+                  step={5}
+                  className="w-full"
+                />
+                <div className="flex justify-between text-xs text-muted-foreground">
+                  <span>Strict</span>
+                  <span>Permissive</span>
+                </div>
+              </div>
+
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <div className="space-y-0.5">
+                    <Label htmlFor="include-spam">Include Spam</Label>
+                    <p className="text-xs text-muted-foreground">
+                      Show PRs marked as definite spam
+                    </p>
+                  </div>
+                  <Switch
+                    id="include-spam"
+                    checked={filterOptions.includeSpam || false}
+                    onCheckedChange={(checked) =>
+                      onFilterChange({ ...filterOptions, includeSpam: checked })
+                    }
+                  />
+                </div>
+
+                <div className="flex items-center justify-between">
+                  <div className="space-y-0.5">
+                    <Label htmlFor="include-unreviewed">Include Unanalyzed</Label>
+                    <p className="text-xs text-muted-foreground">
+                      Show PRs not yet analyzed for spam
+                    </p>
+                  </div>
+                  <Switch
+                    id="include-unreviewed"
+                    checked={filterOptions.includeUnreviewed !== false}
+                    onCheckedChange={(checked) =>
+                      onFilterChange({ ...filterOptions, includeUnreviewed: checked })
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+
+            {/* Score Guide */}
+            <div className="space-y-2 pt-2 border-t">
+              <Label className="text-xs">Spam Score Guide</Label>
+              <div className="space-y-1 text-xs">
+                <div className="flex items-center gap-2">
+                  <div className="w-3 h-3 rounded-full bg-green-500" />
+                  <span>0-25: Legitimate PRs</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <div className="w-3 h-3 rounded-full bg-yellow-500" />
+                  <span>26-50: Warning (possibly low quality)</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <div className="w-3 h-3 rounded-full bg-orange-500" />
+                  <span>51-75: Likely spam</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <div className="w-3 h-3 rounded-full bg-red-500" />
+                  <span>76-100: Definite spam</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      {/* Current filter indicator */}
+      {filterOptions.maxSpamScore !== undefined && filterOptions.maxSpamScore < 100 && (
+        <Badge variant="outline" className="gap-1">
+          <AlertTriangle className="h-3 w-3" />
+          Filtering active
+        </Badge>
+      )}
+    </div>
+  );
+}

--- a/src/components/features/spam/spam-filter-controls.tsx
+++ b/src/components/features/spam/spam-filter-controls.tsx
@@ -48,12 +48,13 @@ export function SpamFilterControls({
   const currentPreset = Object.entries(presets).find(([_, preset]) => {
     return (
       preset.options.maxSpamScore === filterOptions.maxSpamScore &&
+      preset.options.minSpamScore === filterOptions.minSpamScore &&
       preset.options.includeSpam === filterOptions.includeSpam &&
       preset.options.includeUnreviewed === filterOptions.includeUnreviewed
     );
   })?.[1];
 
-  const handlePresetSelect = (preset: typeof presets.strict) => {
+  const handlePresetSelect = (preset: { name: string; description: string; options: SpamFilterOptions }) => {
     onFilterChange(preset.options);
   };
 
@@ -70,11 +71,27 @@ export function SpamFilterControls({
     const { distribution } = spamStats;
     let included = 0;
     
-    if (filterOptions.maxSpamScore !== undefined) {
-      if (filterOptions.maxSpamScore >= 76) included += distribution.definiteSpam;
-      if (filterOptions.maxSpamScore >= 51) included += distribution.likelySpam;
-      if (filterOptions.maxSpamScore >= 26) included += distribution.warning;
+    const minScore = filterOptions.minSpamScore || 0;
+    const maxScore = filterOptions.maxSpamScore || 100;
+    
+    // Count legitimate (0-25)
+    if (minScore <= 25 && maxScore >= 0) {
       included += distribution.legitimate;
+    }
+    
+    // Count warning (26-50)
+    if (minScore <= 50 && maxScore >= 26) {
+      included += distribution.warning;
+    }
+    
+    // Count likely spam (51-75)
+    if (minScore <= 75 && maxScore >= 51) {
+      included += distribution.likelySpam;
+    }
+    
+    // Count definite spam (76-100)
+    if (minScore <= 100 && maxScore >= 76) {
+      included += distribution.definiteSpam;
     }
     
     return included;

--- a/src/components/features/spam/spam-filter-controls.tsx
+++ b/src/components/features/spam/spam-filter-controls.tsx
@@ -49,7 +49,6 @@ export function SpamFilterControls({
     return (
       preset.options.maxSpamScore === filterOptions.maxSpamScore &&
       preset.options.minSpamScore === filterOptions.minSpamScore &&
-      preset.options.includeSpam === filterOptions.includeSpam &&
       preset.options.includeUnreviewed === filterOptions.includeUnreviewed
     );
   })?.[1];
@@ -192,22 +191,6 @@ export function SpamFilterControls({
               </div>
 
               <div className="space-y-3">
-                <div className="flex items-center justify-between">
-                  <div className="space-y-0.5">
-                    <Label htmlFor="include-spam">Include Spam</Label>
-                    <p className="text-xs text-muted-foreground">
-                      Show PRs marked as definite spam
-                    </p>
-                  </div>
-                  <Switch
-                    id="include-spam"
-                    checked={filterOptions.includeSpam || false}
-                    onCheckedChange={(checked) =>
-                      onFilterChange({ ...filterOptions, includeSpam: checked })
-                    }
-                  />
-                </div>
-
                 <div className="flex items-center justify-between">
                   <div className="space-y-0.5">
                     <Label htmlFor="include-unreviewed">Include Unanalyzed</Label>

--- a/src/components/features/spam/spam-indicator.tsx
+++ b/src/components/features/spam/spam-indicator.tsx
@@ -190,7 +190,24 @@ export function SpamProbabilityBadge({
   spamScore: number | null; 
   className?: string;
 }) {
-  if (spamScore === null) return null;
+  // Show "-" for unanalyzed PRs instead of hiding the badge
+  if (spamScore === null) {
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Badge variant="outline" className={cn('text-xs gap-1', className)}>
+              <span>📊</span>
+              <span>-</span>
+            </Badge>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Not analyzed for spam yet</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
 
   const getVariant = () => {
     if (spamScore <= 25) return 'outline';

--- a/src/components/features/spam/spam-indicator.tsx
+++ b/src/components/features/spam/spam-indicator.tsx
@@ -1,0 +1,215 @@
+import { Badge } from '@/components/ui/badge';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { Shield, AlertTriangle, XCircle, CheckCircle } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface SpamIndicatorProps {
+  spamScore: number | null;
+  isSpam?: boolean;
+  size?: 'sm' | 'md' | 'lg';
+  showScore?: boolean;
+  className?: string;
+}
+
+export function SpamIndicator({
+  spamScore,
+  isSpam = false,
+  size = 'sm',
+  showScore = false,
+  className,
+}: SpamIndicatorProps) {
+  // If no spam score, don't show anything
+  if (spamScore === null || spamScore === undefined) {
+    return null;
+  }
+
+  // Determine severity level
+  const getLevel = () => {
+    if (spamScore <= 25) return 'legitimate';
+    if (spamScore <= 50) return 'warning';
+    if (spamScore <= 75) return 'likely';
+    return 'definite';
+  };
+
+  const level = getLevel();
+
+  // Get styling based on level
+  const getStyles = () => {
+    switch (level) {
+      case 'legitimate':
+        return {
+          icon: CheckCircle,
+          color: 'text-green-600',
+          bgColor: 'bg-green-50',
+          borderColor: 'border-green-200',
+          label: 'Legitimate',
+        };
+      case 'warning':
+        return {
+          icon: Shield,
+          color: 'text-yellow-600',
+          bgColor: 'bg-yellow-50',
+          borderColor: 'border-yellow-200',
+          label: 'Low Quality',
+        };
+      case 'likely':
+        return {
+          icon: AlertTriangle,
+          color: 'text-orange-600',
+          bgColor: 'bg-orange-50',
+          borderColor: 'border-orange-200',
+          label: 'Likely Spam',
+        };
+      case 'definite':
+        return {
+          icon: XCircle,
+          color: 'text-red-600',
+          bgColor: 'bg-red-50',
+          borderColor: 'border-red-200',
+          label: 'Spam',
+        };
+      default:
+        return {
+          icon: Shield,
+          color: 'text-gray-600',
+          bgColor: 'bg-gray-50',
+          borderColor: 'border-gray-200',
+          label: 'Unknown',
+        };
+    }
+  };
+
+  const styles = getStyles();
+  const Icon = styles.icon;
+
+  const sizeClasses = {
+    sm: 'h-3 w-3',
+    md: 'h-4 w-4',
+    lg: 'h-5 w-5',
+  };
+
+  const badgeSizes = {
+    sm: 'text-xs px-1.5 py-0.5',
+    md: 'text-sm px-2 py-0.5',
+    lg: 'text-base px-2.5 py-1',
+  };
+
+  // Don't show indicator for legitimate PRs unless explicitly marked as spam
+  if (level === 'legitimate' && !isSpam && !showScore) {
+    return null;
+  }
+
+  const content = (
+    <Badge
+      variant="outline"
+      className={cn(
+        'gap-1 font-normal',
+        styles.bgColor,
+        styles.borderColor,
+        styles.color,
+        badgeSizes[size],
+        className
+      )}
+    >
+      <Icon className={cn(sizeClasses[size])} />
+      {showScore ? (
+        <span>Score: {spamScore}</span>
+      ) : (
+        <span>{styles.label}</span>
+      )}
+    </Badge>
+  );
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          {content}
+        </TooltipTrigger>
+        <TooltipContent>
+          <div className="space-y-1">
+            <p className="font-medium">Spam Detection Score: {spamScore}/100</p>
+            <p className="text-xs text-muted-foreground">
+              {level === 'legitimate' && 'This PR appears to be legitimate'}
+              {level === 'warning' && 'This PR may be low quality'}
+              {level === 'likely' && 'This PR is likely spam'}
+              {level === 'definite' && 'This PR has been identified as spam'}
+            </p>
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+// Compact version for use in lists
+export function SpamBadge({ 
+  spamScore, 
+  showScore = false,
+  className 
+}: { 
+  spamScore: number | null; 
+  showScore?: boolean;
+  className?: string;
+}) {
+  if (spamScore === null || spamScore <= 25) return null;
+
+  const getVariant = () => {
+    if (spamScore <= 50) return 'secondary';
+    if (spamScore <= 75) return 'destructive';
+    return 'destructive';
+  };
+
+  const getContent = () => {
+    if (showScore) {
+      return `${spamScore}%`;
+    }
+    
+    if (spamScore <= 50) return '⚠️';
+    if (spamScore <= 75) return '⚠️ Spam';
+    return '🚫 Spam';
+  };
+
+  return (
+    <Badge variant={getVariant()} className={cn('text-xs', className)}>
+      {getContent()}
+    </Badge>
+  );
+}
+
+// Version that always shows the probability score
+export function SpamProbabilityBadge({ 
+  spamScore, 
+  className 
+}: { 
+  spamScore: number | null; 
+  className?: string;
+}) {
+  if (spamScore === null) return null;
+
+  const getVariant = () => {
+    if (spamScore <= 25) return 'outline';
+    if (spamScore <= 50) return 'secondary';
+    if (spamScore <= 75) return 'destructive';
+    return 'destructive';
+  };
+
+  const getIcon = () => {
+    if (spamScore <= 25) return '✅';
+    if (spamScore <= 50) return '⚠️';
+    if (spamScore <= 75) return '🟠';
+    return '🚫';
+  };
+
+  return (
+    <Badge variant={getVariant()} className={cn('text-xs gap-1', className)}>
+      <span>{getIcon()}</span>
+      <span>{spamScore}%</span>
+    </Badge>
+  );
+}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -17,7 +17,7 @@ const TooltipContent = React.forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      'z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      'z-50 overflow-hidden rounded-md bg-popover px-3 py-1.5 text-xs text-popover-foreground border animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
       className
     )}
     {...props}

--- a/src/hooks/use-admin-auth.ts
+++ b/src/hooks/use-admin-auth.ts
@@ -1,0 +1,273 @@
+import { useState, useEffect } from 'react';
+import { supabase } from '@/lib/supabase';
+import type { User } from '@supabase/supabase-js';
+
+interface AdminAuthState {
+  user: User | null;
+  isLoggedIn: boolean;
+  isAdmin: boolean;
+  loading: boolean;
+  error: string | null;
+}
+
+/**
+ * Hook for managing admin authentication state and actions
+ * Extends regular GitHub auth with admin role verification
+ */
+export function useAdminAuth() {
+  const [state, setState] = useState<AdminAuthState>({
+    user: null,
+    isLoggedIn: false,
+    isAdmin: false,
+    loading: true,
+    error: null,
+  });
+  
+  useEffect(() => {
+    let mounted = true;
+    
+    async function checkAdminAuth() {
+      try {
+        setState(prev => ({ ...prev, loading: true, error: null }));
+        
+        // Check URL for auth tokens first
+        if (window.location.hash.includes('access_token')) {
+          try {
+            const hashParams = new URLSearchParams(window.location.hash.substring(1));
+            const accessToken = hashParams.get('access_token');
+            const refreshToken = hashParams.get('refresh_token');
+            
+            if (accessToken && refreshToken) {
+              await supabase.auth.setSession({
+                access_token: accessToken,
+                refresh_token: refreshToken
+              });
+            }
+          } catch (err) {
+            // Silently handle token processing errors
+          }
+          
+          // Clear the URL hash after processing
+          window.history.replaceState({}, document.title, window.location.pathname);
+        }
+        
+        // Get current session
+        const { data: { session }, error: sessionError } = await supabase.auth.getSession();
+        
+        if (sessionError) {
+          throw sessionError;
+        }
+        
+        const user = session?.user ?? null;
+        const isLoggedIn = !!user;
+        let isAdmin = false;
+        
+        if (user && user.user_metadata?.user_name) {
+          // Check admin status from database
+          const { data: adminCheck, error: adminError } = await supabase
+            .rpc('is_user_admin', { user_github_username: user.user_metadata.user_name });
+          
+          if (adminError) {
+            console.warn('Failed to check admin status:', adminError);
+          } else {
+            isAdmin = adminCheck === true;
+          }
+          
+          // Upsert user data if logged in
+          if (isLoggedIn) {
+            await upsertUserData(user);
+          }
+        }
+        
+        if (mounted) {
+          setState({
+            user,
+            isLoggedIn,
+            isAdmin,
+            loading: false,
+            error: null,
+          });
+        }
+      } catch (err) {
+        if (mounted) {
+          setState(prev => ({
+            ...prev,
+            loading: false,
+            error: err instanceof Error ? err.message : 'Authentication failed',
+          }));
+        }
+      }
+    }
+    
+    checkAdminAuth();
+
+    // Listen for auth changes
+    const { data: { subscription } } = supabase.auth.onAuthStateChange(async (_, session) => {
+      if (!mounted) return;
+      
+      const user = session?.user ?? null;
+      const isLoggedIn = !!user;
+      let isAdmin = false;
+      
+      if (user && user.user_metadata?.user_name) {
+        try {
+          // Check admin status from database
+          const { data: adminCheck } = await supabase
+            .rpc('is_user_admin', { user_github_username: user.user_metadata.user_name });
+          
+          isAdmin = adminCheck === true;
+          
+          // Upsert user data if logged in
+          if (isLoggedIn) {
+            await upsertUserData(user);
+          }
+        } catch (err) {
+          console.warn('Failed to check admin status on auth change:', err);
+        }
+      }
+      
+      setState(prev => ({
+        ...prev,
+        user,
+        isLoggedIn,
+        isAdmin,
+        loading: false,
+        error: null,
+      }));
+    });
+
+    return () => {
+      mounted = false;
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  /**
+   * Upsert user data to app_users table
+   */
+  const upsertUserData = async (user: User) => {
+    try {
+      if (!user.user_metadata?.user_name) {
+        return;
+      }
+      
+      await supabase.rpc('upsert_app_user', {
+        p_auth_user_id: user.id,
+        p_github_username: user.user_metadata.user_name,
+        p_github_user_id: user.user_metadata.provider_id ? 
+          parseInt(user.user_metadata.provider_id) : null,
+        p_email: user.email,
+        p_avatar_url: user.user_metadata.avatar_url,
+        p_display_name: user.user_metadata.full_name || user.user_metadata.name,
+      });
+    } catch (err) {
+      console.warn('Failed to upsert user data:', err);
+    }
+  };
+
+  /**
+   * Initiates GitHub OAuth login flow
+   */
+  const login = async () => {
+    try {
+      setState(prev => ({ ...prev, error: null }));
+      
+      // Store the current path for redirect after login
+      const currentPath = window.location.pathname;
+      if (currentPath !== '/login') {
+        localStorage.setItem('redirectAfterLogin', currentPath);
+      }
+      
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: 'github',
+        options: {
+          redirectTo: window.location.origin,
+          scopes: 'repo user',
+        },
+      });
+      
+      if (error) {
+        throw error;
+      }
+    } catch (err) {
+      setState(prev => ({
+        ...prev,
+        error: err instanceof Error ? err.message : 'Login failed',
+      }));
+    }
+  };
+
+  /**
+   * Signs the user out
+   */
+  const logout = async () => {
+    try {
+      setState(prev => ({ ...prev, error: null }));
+      await supabase.auth.signOut();
+    } catch (err) {
+      setState(prev => ({
+        ...prev,
+        error: err instanceof Error ? err.message : 'Logout failed',
+      }));
+    }
+  };
+
+  /**
+   * Force refresh admin status
+   */
+  const refreshAdminStatus = async () => {
+    if (!state.user || !state.user.user_metadata?.user_name) {
+      return false;
+    }
+    
+    try {
+      const { data: adminCheck, error } = await supabase
+        .rpc('is_user_admin', { user_github_username: state.user.user_metadata.user_name });
+      
+      if (error) {
+        throw error;
+      }
+      
+      const isAdmin = adminCheck === true;
+      setState(prev => ({ ...prev, isAdmin }));
+      return isAdmin;
+    } catch (err) {
+      console.warn('Failed to refresh admin status:', err);
+      return false;
+    }
+  };
+
+  /**
+   * Check if user has a specific role
+   */
+  const hasRole = async (role: string): Promise<boolean> => {
+    if (!state.user || !state.user.user_metadata?.user_name) {
+      return false;
+    }
+    
+    try {
+      const { data: hasRoleResult, error } = await supabase
+        .rpc('user_has_role', { 
+          user_github_username: state.user.user_metadata.user_name,
+          role_name: role 
+        });
+      
+      if (error) {
+        throw error;
+      }
+      
+      return hasRoleResult === true;
+    } catch (err) {
+      console.warn(`Failed to check role ${role}:`, err);
+      return false;
+    }
+  };
+
+  return { 
+    ...state,
+    login, 
+    logout,
+    refreshAdminStatus,
+    hasRole,
+  };
+}

--- a/src/hooks/use-admin-auth.ts
+++ b/src/hooks/use-admin-auth.ts
@@ -99,17 +99,14 @@ export function useAdminAuth(): AdminAuthState {
 
         const isAdmin = isAdminResult === true;
 
-        // If user is admin, get their full user data
+        // If user is admin, get their full user data using RPC to bypass RLS
         let adminUser = null;
         if (isAdmin) {
           try {
-            // Use a direct query that should work since we know they're admin
+            // Use RPC to get user data since direct queries may fail due to RLS
             const { data: userData } = await supabase
-              .from('app_users')
-              .select('*')
-              .eq('github_user_id', parseInt(githubId))
-              .single();
-            adminUser = userData;
+              .rpc('get_user_by_github_id', { user_github_id: parseInt(githubId) });
+            adminUser = userData?.[0] || null; // RPC returns array
           } catch (err) {
             console.warn('Could not fetch admin user data:', err);
           }

--- a/src/hooks/use-cached-pr-activity.ts
+++ b/src/hooks/use-cached-pr-activity.ts
@@ -203,7 +203,7 @@ function processActivities(pullRequests: PullRequest[]): PullRequestActivity[] {
 
   // Sort activities by date, newest first
   return processedActivities.sort(
-    (a, b) => b.createdAt.getTime() - a.createdAt.getTime()
+    (a, b) => (b.createdAt?.getTime() || 0) - (a.createdAt?.getTime() || 0)
   );
 }
 

--- a/src/hooks/use-pr-activity.ts
+++ b/src/hooks/use-pr-activity.ts
@@ -184,7 +184,7 @@ export function usePRActivity(pullRequests: PullRequest[]) {
 
       // Sort activities by date, newest first
       const sortedActivities = processedActivities.sort(
-        (a, b) => b.createdAt.getTime() - a.createdAt.getTime()
+        (a, b) => (b.createdAt?.getTime() || 0) - (a.createdAt?.getTime() || 0)
       );
 
       setActivities(sortedActivities);

--- a/src/hooks/use-spam-filtered-feed.ts
+++ b/src/hooks/use-spam-filtered-feed.ts
@@ -1,0 +1,143 @@
+import { useState, useEffect, useCallback } from 'react';
+import { 
+  fetchFilteredPullRequests, 
+  getRepositorySpamStats,
+  getUserSpamPreferences,
+  saveUserSpamPreferences,
+  type SpamFilterOptions,
+  DEFAULT_SPAM_FILTER
+} from '@/lib/api/spam-filtered-feed';
+import type { Database } from '@/types/database';
+
+type PullRequestWithAuthor = Database['public']['Tables']['pull_requests']['Row'] & {
+  author: Database['public']['Tables']['contributors']['Row'];
+  repository: Database['public']['Tables']['repositories']['Row'];
+};
+
+interface UseSpamFilteredFeedResult {
+  pullRequests: PullRequestWithAuthor[];
+  loading: boolean;
+  error: string | null;
+  spamStats: {
+    totalAnalyzed: number;
+    spamCount: number;
+    spamPercentage: number;
+    averageScore: number;
+    distribution: {
+      legitimate: number;
+      warning: number;
+      likelySpam: number;
+      definiteSpam: number;
+    };
+  } | null;
+  filterOptions: SpamFilterOptions;
+  updateFilterOptions: (options: SpamFilterOptions) => Promise<void>;
+  refetch: () => Promise<void>;
+}
+
+export function useSpamFilteredFeed(
+  owner: string,
+  repo: string,
+  limit: number = 100
+): UseSpamFilteredFeedResult {
+  const [pullRequests, setPullRequests] = useState<PullRequestWithAuthor[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [spamStats, setSpamStats] = useState<UseSpamFilteredFeedResult['spamStats']>(null);
+  const [filterOptions, setFilterOptions] = useState<SpamFilterOptions>(DEFAULT_SPAM_FILTER);
+
+  // Load user preferences on mount
+  useEffect(() => {
+    getUserSpamPreferences().then(setFilterOptions);
+  }, []);
+
+  // Fetch data
+  const fetchData = useCallback(async () => {
+    if (!owner || !repo) return;
+    
+    setLoading(true);
+    setError(null);
+
+    try {
+      // Fetch filtered PRs and stats in parallel
+      const [prs, stats] = await Promise.all([
+        fetchFilteredPullRequests(owner, repo, filterOptions, limit),
+        getRepositorySpamStats(owner, repo)
+      ]);
+
+      setPullRequests(prs);
+      setSpamStats(stats);
+    } catch (err) {
+      console.error('Error fetching spam-filtered feed:', err);
+      setError(err instanceof Error ? err.message : 'Failed to fetch pull requests');
+      setPullRequests([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [owner, repo, filterOptions, limit]);
+
+  // Fetch data when dependencies change
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  // Update filter options
+  const updateFilterOptions = useCallback(async (newOptions: SpamFilterOptions) => {
+    setFilterOptions(newOptions);
+    await saveUserSpamPreferences(newOptions);
+  }, []);
+
+  return {
+    pullRequests,
+    loading,
+    error,
+    spamStats,
+    filterOptions,
+    updateFilterOptions,
+    refetch: fetchData,
+  };
+}
+
+// Helper hook for spam tolerance presets
+export function useSpamTolerancePresets() {
+  const presets = {
+    strict: {
+      name: 'Strict',
+      description: 'Only show high-quality PRs',
+      options: {
+        maxSpamScore: 25,
+        includeSpam: false,
+        includeUnreviewed: false,
+      } as SpamFilterOptions,
+    },
+    balanced: {
+      name: 'Balanced',
+      description: 'Hide likely spam, show warnings',
+      options: {
+        maxSpamScore: 50,
+        includeSpam: false,
+        includeUnreviewed: true,
+      } as SpamFilterOptions,
+    },
+    permissive: {
+      name: 'Permissive',
+      description: 'Show most PRs, hide only definite spam',
+      options: {
+        maxSpamScore: 75,
+        includeSpam: false,
+        includeUnreviewed: true,
+      } as SpamFilterOptions,
+    },
+    all: {
+      name: 'Show All',
+      description: 'No filtering, show everything',
+      options: {
+        maxSpamScore: 100,
+        includeSpam: true,
+        includeUnreviewed: true,
+      } as SpamFilterOptions,
+    },
+  };
+
+  return presets;
+}

--- a/src/lib/api/pr-activity-adapter.ts
+++ b/src/lib/api/pr-activity-adapter.ts
@@ -1,0 +1,80 @@
+import type { PullRequestActivity } from '@/lib/types';
+import type { Database } from '@/types/database';
+
+type DatabasePR = Database['public']['Tables']['pull_requests']['Row'] & {
+  author: Database['public']['Tables']['contributors']['Row'];
+  repository: Database['public']['Tables']['repositories']['Row'];
+};
+
+/**
+ * Convert database PR data to PullRequestActivity format for use with ActivityItem components
+ */
+export function convertDatabasePRToActivity(pr: DatabasePR): PullRequestActivity | null {
+  // Skip PRs with missing required data
+  if (!pr.author || !pr.repository) {
+    return null;
+  }
+
+  return {
+    id: pr.id,
+    type: pr.merged ? 'merged' : pr.state === 'closed' ? 'closed' : 'opened',
+    user: {
+      id: String(pr.author.github_id),
+      name: pr.author.username,
+      avatar: pr.author.avatar_url,
+      isBot: pr.author.is_bot,
+    },
+    pullRequest: {
+      id: pr.github_id,
+      number: pr.number,
+      title: pr.title,
+      body: pr.body || '',
+      state: pr.state,
+      draft: pr.draft,
+      merged: pr.merged,
+      mergeable: null, // Not available in our DB schema
+      url: pr.html_url,
+      additions: pr.additions,
+      deletions: pr.deletions,
+      changedFiles: pr.changed_files,
+      commits: pr.commits,
+      createdAt: pr.created_at,
+      updatedAt: pr.updated_at,
+      closedAt: pr.closed_at,
+      mergedAt: pr.merged_at,
+      // Add spam detection fields
+      spamScore: pr.spam_score,
+      isSpam: pr.is_spam,
+      spamFlags: pr.spam_flags,
+    },
+    repository: {
+      id: String(pr.repository.github_id),
+      name: pr.repository.name,
+      fullName: pr.repository.full_name,
+      owner: pr.repository.owner,
+      private: pr.repository.is_private,
+      url: `https://github.com/${pr.repository.full_name}`,
+    },
+    timestamp: pr.created_at,
+    // Additional metadata for spam detection
+    metadata: {
+      spamScore: pr.spam_score,
+      isSpam: pr.is_spam,
+      spamDetectedAt: pr.spam_detected_at,
+    },
+  };
+}
+
+/**
+ * Convert multiple database PRs to activity format
+ */
+export function convertDatabasePRsToActivities(prs: DatabasePR[]): PullRequestActivity[] {
+  return prs.map(convertDatabasePRToActivity).filter((activity): activity is PullRequestActivity => activity !== null);
+}
+
+/**
+ * Sort activities by timestamp (most recent first)
+ */
+export function sortActivitiesByTimestamp(activities: PullRequestActivity[]): PullRequestActivity[] {
+  return activities.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+}

--- a/src/lib/api/spam-filtered-feed.ts
+++ b/src/lib/api/spam-filtered-feed.ts
@@ -1,0 +1,165 @@
+import { supabase } from '@/lib/supabase';
+import type { Database } from '@/types/database';
+
+type PullRequestWithAuthor = Database['public']['Tables']['pull_requests']['Row'] & {
+  author: Database['public']['Tables']['contributors']['Row'];
+  repository: Database['public']['Tables']['repositories']['Row'];
+};
+
+export interface SpamFilterOptions {
+  maxSpamScore?: number;      // Maximum spam score to include (0-100)
+  includeSpam?: boolean;       // Include PRs marked as spam
+  includeUnreviewed?: boolean; // Include PRs not yet analyzed
+}
+
+export const DEFAULT_SPAM_FILTER: SpamFilterOptions = {
+  maxSpamScore: 50,          // Show legitimate and warning level PRs
+  includeSpam: false,        // Hide definite spam
+  includeUnreviewed: true,   // Show PRs not yet analyzed
+};
+
+/**
+ * Fetch pull requests from database with spam filtering
+ */
+export async function fetchFilteredPullRequests(
+  owner: string,
+  repo: string,
+  options: SpamFilterOptions = DEFAULT_SPAM_FILTER,
+  limit: number = 100
+): Promise<PullRequestWithAuthor[]> {
+  try {
+    // Start building the query
+    let query = supabase
+      .from('pull_requests')
+      .select(`
+        *,
+        author:contributors!author_id(*),
+        repository:repositories!repository_id(*)
+      `)
+      .eq('repository.owner', owner)
+      .eq('repository.name', repo)
+      .order('created_at', { ascending: false })
+      .limit(limit);
+
+    // Apply spam filtering
+    if (!options.includeSpam) {
+      query = query.eq('is_spam', false);
+    }
+
+    // Apply spam score filtering
+    if (options.maxSpamScore !== undefined && options.maxSpamScore < 100) {
+      if (options.includeUnreviewed) {
+        // Include PRs with no spam score OR below threshold
+        query = query.or(`spam_score.is.null,spam_score.lte.${options.maxSpamScore}`);
+      } else {
+        // Only include PRs with spam score below threshold
+        query = query.lte('spam_score', options.maxSpamScore);
+      }
+    }
+
+    const { data, error } = await query;
+
+    if (error) {
+      console.error('Error fetching filtered PRs:', error);
+      throw new Error(`Failed to fetch pull requests: ${error.message}`);
+    }
+
+    return data || [];
+  } catch (error) {
+    console.error('Error in fetchFilteredPullRequests:', error);
+    throw error;
+  }
+}
+
+/**
+ * Get spam statistics for a repository
+ */
+export async function getRepositorySpamStats(owner: string, repo: string) {
+  try {
+    // First get the repository ID
+    const { data: repoData, error: repoError } = await supabase
+      .from('repositories')
+      .select('id')
+      .eq('owner', owner)
+      .eq('name', repo)
+      .single();
+
+    if (repoError || !repoData) {
+      throw new Error('Repository not found');
+    }
+
+    // Get spam statistics
+    const { data: stats, error: statsError } = await supabase
+      .from('pull_requests')
+      .select('spam_score, is_spam')
+      .eq('repository_id', repoData.id)
+      .not('spam_score', 'is', null);
+
+    if (statsError) {
+      throw new Error('Failed to fetch spam statistics');
+    }
+
+    if (!stats || stats.length === 0) {
+      return {
+        totalAnalyzed: 0,
+        spamCount: 0,
+        spamPercentage: 0,
+        averageScore: 0,
+        distribution: {
+          legitimate: 0,
+          warning: 0,
+          likelySpam: 0,
+          definiteSpam: 0,
+        }
+      };
+    }
+
+    const totalAnalyzed = stats.length;
+    const spamCount = stats.filter(pr => pr.is_spam).length;
+    const averageScore = stats.reduce((sum, pr) => sum + (pr.spam_score || 0), 0) / totalAnalyzed;
+
+    const distribution = {
+      legitimate: stats.filter(pr => (pr.spam_score || 0) <= 25).length,
+      warning: stats.filter(pr => (pr.spam_score || 0) > 25 && (pr.spam_score || 0) <= 50).length,
+      likelySpam: stats.filter(pr => (pr.spam_score || 0) > 50 && (pr.spam_score || 0) <= 75).length,
+      definiteSpam: stats.filter(pr => (pr.spam_score || 0) > 75).length,
+    };
+
+    return {
+      totalAnalyzed,
+      spamCount,
+      spamPercentage: (spamCount / totalAnalyzed) * 100,
+      averageScore: Math.round(averageScore * 10) / 10,
+      distribution,
+    };
+  } catch (error) {
+    console.error('Error fetching spam stats:', error);
+    throw error;
+  }
+}
+
+/**
+ * Get user's spam filter preferences
+ */
+export async function getUserSpamPreferences(): Promise<SpamFilterOptions> {
+  // For now, return from localStorage
+  // In the future, this could be stored in user profile
+  const stored = localStorage.getItem('spam-filter-preferences');
+  if (stored) {
+    try {
+      return JSON.parse(stored);
+    } catch {
+      return DEFAULT_SPAM_FILTER;
+    }
+  }
+  return DEFAULT_SPAM_FILTER;
+}
+
+/**
+ * Save user's spam filter preferences
+ */
+export async function saveUserSpamPreferences(preferences: SpamFilterOptions): Promise<void> {
+  // For now, save to localStorage
+  // In the future, this could be stored in user profile
+  localStorage.setItem('spam-filter-preferences', JSON.stringify(preferences));
+}

--- a/src/lib/pr-activity-store.ts
+++ b/src/lib/pr-activity-store.ts
@@ -6,10 +6,8 @@ export type ActivityType = 'opened' | 'closed' | 'merged' | 'reviewed' | 'commen
 interface PRActivityState {
   selectedTypes: ActivityType[];
   includeBots: boolean;
-  includeSpam: boolean;
   setSelectedTypes: (types: ActivityType[]) => void;
   setIncludeBots: (include: boolean) => void;
-  setIncludeSpam: (include: boolean) => void;
   toggleActivityType: (type: ActivityType) => void;
 }
 
@@ -18,10 +16,8 @@ export const usePRActivityStore = create<PRActivityState>()(
     (set) => ({
       selectedTypes: ['opened', 'merged', 'commented'],
       includeBots: true,
-      includeSpam: false, // Default to hiding spam
       setSelectedTypes: (types) => set({ selectedTypes: types }),
       setIncludeBots: (include) => set({ includeBots: include }),
-      setIncludeSpam: (include) => set({ includeSpam: include }),
       toggleActivityType: (type) => set((state) => ({
         selectedTypes: state.selectedTypes.includes(type)
           ? state.selectedTypes.filter((t) => t !== type)

--- a/src/lib/pr-activity-store.ts
+++ b/src/lib/pr-activity-store.ts
@@ -6,8 +6,10 @@ export type ActivityType = 'opened' | 'closed' | 'merged' | 'reviewed' | 'commen
 interface PRActivityState {
   selectedTypes: ActivityType[];
   includeBots: boolean;
+  includeSpam: boolean;
   setSelectedTypes: (types: ActivityType[]) => void;
   setIncludeBots: (include: boolean) => void;
+  setIncludeSpam: (include: boolean) => void;
   toggleActivityType: (type: ActivityType) => void;
 }
 
@@ -16,8 +18,10 @@ export const usePRActivityStore = create<PRActivityState>()(
     (set) => ({
       selectedTypes: ['opened', 'merged', 'commented'],
       includeBots: true,
+      includeSpam: false, // Default to hiding spam
       setSelectedTypes: (types) => set({ selectedTypes: types }),
       setIncludeBots: (include) => set({ includeBots: include }),
+      setIncludeSpam: (include) => set({ includeSpam: include }),
       toggleActivityType: (type) => set((state) => ({
         selectedTypes: state.selectedTypes.includes(type)
           ? state.selectedTypes.filter((t) => t !== type)

--- a/src/lib/spam/AccountAnalysisService.ts
+++ b/src/lib/spam/AccountAnalysisService.ts
@@ -1,0 +1,233 @@
+import { 
+  PullRequestData, 
+  SpamFlags, 
+  ACCOUNT_THRESHOLDS 
+} from './types';
+
+export class AccountAnalysisService {
+  /**
+   * Analyze contributor account patterns for spam indicators
+   */
+  analyzeAccount(pr: PullRequestData): SpamFlags['account_flags'] {
+    const author = pr.author;
+    const accountAgeInDays = this.calculateAccountAge(author.created_at);
+    const isNewAccount = this.isNewAccount(accountAgeInDays);
+    const hasProfileData = this.hasCompletedProfile(author);
+    const contributionScore = this.calculateContributionHistoryScore(author);
+
+    return {
+      account_age_days: accountAgeInDays,
+      is_new_account: isNewAccount,
+      has_profile_data: hasProfileData,
+      contribution_history_score: contributionScore,
+    };
+  }
+
+  /**
+   * Calculate account age in days
+   */
+  private calculateAccountAge(createdAt?: string): number {
+    if (!createdAt) {
+      // If we don't have creation date, assume it's recent for safety
+      return 0;
+    }
+
+    const accountCreated = new Date(createdAt);
+    const now = new Date();
+    const diffMs = now.getTime() - accountCreated.getTime();
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+    return Math.max(0, diffDays);
+  }
+
+  /**
+   * Determine if account is considered "new" and potentially suspicious
+   */
+  private isNewAccount(accountAgeInDays: number): boolean {
+    return accountAgeInDays <= ACCOUNT_THRESHOLDS.NEW_ACCOUNT_DAYS;
+  }
+
+  /**
+   * Check if user has completed their GitHub profile
+   */
+  private hasCompletedProfile(author: PullRequestData['author']): boolean {
+    let profileScore = 0;
+    const maxScore = 5;
+
+    // Check various profile completeness indicators
+    if (author.bio && author.bio.trim().length > 10) {
+      profileScore += 1;
+    }
+
+    if (author.company && author.company.trim().length > 0) {
+      profileScore += 1;
+    }
+
+    if (author.location && author.location.trim().length > 0) {
+      profileScore += 1;
+    }
+
+    if (author.public_repos && author.public_repos > 0) {
+      profileScore += 1;
+    }
+
+    if (author.followers && author.followers > 0) {
+      profileScore += 1;
+    }
+
+    const completionRatio = profileScore / maxScore;
+    return completionRatio >= ACCOUNT_THRESHOLDS.MIN_PROFILE_SCORE;
+  }
+
+  /**
+   * Calculate a score based on contribution history indicators
+   */
+  private calculateContributionHistoryScore(author: PullRequestData['author']): number {
+    let score = 0;
+
+    // Repository count score (0-0.3)
+    const repoCount = author.public_repos || 0;
+    if (repoCount > 0) {
+      score += Math.min(repoCount / 10, 0.3);
+    }
+
+    // Follower count score (0-0.2)
+    const followerCount = author.followers || 0;
+    if (followerCount > 0) {
+      score += Math.min(followerCount / 50, 0.2);
+    }
+
+    // Following count score (0-0.1)
+    const followingCount = author.following || 0;
+    if (followingCount > 0) {
+      score += Math.min(followingCount / 100, 0.1);
+    }
+
+    // Profile completeness score (0-0.4)
+    const hasProfile = this.hasCompletedProfile(author);
+    if (hasProfile) {
+      score += 0.4;
+    }
+
+    return Math.min(score, 1.0);
+  }
+
+  /**
+   * Check for patterns that might indicate automated or bot accounts
+   */
+  private checkForBotPatterns(author: PullRequestData['author']): {
+    likely_bot: boolean;
+    bot_indicators: string[];
+  } {
+    const indicators: string[] = [];
+    const login = author.login.toLowerCase();
+
+    // Check username patterns
+    if (login.includes('bot') || login.includes('automated')) {
+      indicators.push('username_contains_bot');
+    }
+
+    // Check for numeric suffixes that might indicate generated accounts
+    if (/\d{3,}$/.test(login)) {
+      indicators.push('numeric_suffix');
+    }
+
+    // Check for very new accounts with high activity
+    const repoCount = author.public_repos || 0;
+    if (repoCount > 20) {
+      // This would need account age to be meaningful
+      // indicators.push('high_activity_new_account');
+    }
+
+    // Check for accounts with no followers but many repos
+    const followers = author.followers || 0;
+    if (followers === 0 && repoCount > 10) {
+      indicators.push('no_followers_many_repos');
+    }
+
+    return {
+      likely_bot: indicators.length >= 2,
+      bot_indicators: indicators,
+    };
+  }
+
+  /**
+   * Analyze account for suspicious creation patterns
+   */
+  analyzeCreationPatterns(author: PullRequestData['author']): {
+    is_suspicious: boolean;
+    risk_factors: string[];
+  } {
+    const riskFactors: string[] = [];
+    const accountAge = this.calculateAccountAge(author.created_at);
+
+    // Very new account (less than 7 days)
+    if (accountAge <= ACCOUNT_THRESHOLDS.SUSPICIOUS_ACCOUNT_DAYS) {
+      riskFactors.push('very_new_account');
+    }
+
+    // Empty or minimal profile
+    if (!this.hasCompletedProfile(author)) {
+      riskFactors.push('incomplete_profile');
+    }
+
+    // No repositories but making contributions
+    if (!author.public_repos || author.public_repos === 0) {
+      riskFactors.push('no_public_repos');
+    }
+
+    // No followers or following (might indicate throwaway account)
+    if ((!author.followers || author.followers === 0) && 
+        (!author.following || author.following === 0)) {
+      riskFactors.push('no_social_connections');
+    }
+
+    // Check for bot patterns
+    const botAnalysis = this.checkForBotPatterns(author);
+    if (botAnalysis.likely_bot) {
+      riskFactors.push('bot_like_behavior');
+    }
+
+    return {
+      is_suspicious: riskFactors.length >= 2,
+      risk_factors: riskFactors,
+    };
+  }
+
+  /**
+   * Calculate overall account trust score
+   */
+  calculateTrustScore(pr: PullRequestData): number {
+    const accountFlags = this.analyzeAccount(pr);
+    const creationPatterns = this.analyzeCreationPatterns(pr.author);
+
+    let trustScore = 0.5; // Start with neutral score
+
+    // Boost score for established accounts
+    if (accountFlags && !accountFlags.is_new_account) {
+      trustScore += 0.2;
+    }
+
+    // Boost score for complete profiles
+    if (accountFlags && accountFlags.has_profile_data) {
+      trustScore += 0.2;
+    }
+
+    // Add contribution history score
+    if (accountFlags) {
+      trustScore += accountFlags.contribution_history_score * 0.3;
+    }
+
+    // Penalize suspicious patterns
+    if (creationPatterns.is_suspicious) {
+      trustScore -= 0.4;
+    }
+
+    // Penalize very new accounts making contributions
+    if (accountFlags && accountFlags.account_age_days <= ACCOUNT_THRESHOLDS.SUSPICIOUS_ACCOUNT_DAYS) {
+      trustScore -= 0.3;
+    }
+
+    return Math.max(0, Math.min(trustScore, 1.0));
+  }
+}

--- a/src/lib/spam/PRAnalysisService.ts
+++ b/src/lib/spam/PRAnalysisService.ts
@@ -1,0 +1,240 @@
+import { 
+  PullRequestData, 
+  SpamFlags, 
+  CONTENT_THRESHOLDS
+} from './types';
+import { TemplateDetector, SPAM_PATTERNS } from './templates/CommonTemplates';
+
+export class PRAnalysisService {
+  private templateDetector = new TemplateDetector();
+
+  /**
+   * Analyze PR content quality and characteristics
+   */
+  analyzePR(pr: PullRequestData): {
+    content_quality: SpamFlags['content_quality'];
+    pr_characteristics: SpamFlags['pr_characteristics'];
+    template_match: SpamFlags['template_match'];
+  } {
+    const contentQuality = this.analyzeContentQuality(pr);
+    const prCharacteristics = this.analyzePRCharacteristics(pr);
+    const templateMatch = this.analyzeTemplateMatch(pr);
+
+    return {
+      content_quality: contentQuality,
+      pr_characteristics: prCharacteristics,
+      template_match: templateMatch,
+    };
+  }
+
+  /**
+   * Analyze the quality of PR description and title
+   */
+  private analyzeContentQuality(pr: PullRequestData): SpamFlags['content_quality'] {
+    const description = pr.body || '';
+    const title = pr.title || '';
+    const combinedText = `${title} ${description}`.trim();
+
+    const descriptionLength = description.length;
+    
+    // Check for meaningful content indicators
+    const hasMeaningfulContent = this.hasMeaningfulContent(combinedText);
+    
+    // Calculate quality score based on various factors
+    let qualityScore = 0;
+    
+    // Length score (0-0.3)
+    if (descriptionLength >= CONTENT_THRESHOLDS.MIN_DESCRIPTION_LENGTH) {
+      qualityScore += 0.3;
+    } else if (descriptionLength > 0) {
+      qualityScore += (descriptionLength / CONTENT_THRESHOLDS.MIN_DESCRIPTION_LENGTH) * 0.3;
+    }
+    
+    // Meaningful content score (0-0.4)
+    if (hasMeaningfulContent) {
+      qualityScore += 0.4;
+    }
+    
+    // Title quality score (0-0.3)
+    const titleQuality = this.analyzeTitleQuality(title);
+    qualityScore += titleQuality * 0.3;
+
+    return {
+      description_length: descriptionLength,
+      has_meaningful_content: hasMeaningfulContent,
+      quality_score: Math.min(qualityScore, 1.0),
+    };
+  }
+
+  /**
+   * Check if content contains meaningful information
+   */
+  private hasMeaningfulContent(text: string): boolean {
+    if (!text || text.length < 5) return false;
+
+    const normalized = text.toLowerCase().trim();
+    
+    // Check against spam patterns
+    for (const pattern of Object.values(SPAM_PATTERNS)) {
+      if (pattern.test(normalized)) {
+        return false;
+      }
+    }
+
+    // Look for meaningful indicators
+    const meaningfulIndicators = [
+      /fix(es|ed)?\s+#?\d+/i, // References to issues
+      /close(s|d)?\s+#?\d+/i, // Closes issues
+      /implement(s|ed)?/i,    // Implementation details
+      /add(s|ed)?\s+\w{4,}/i, // Adds something specific
+      /updat(e|ed)?\s+\w{4,}/i, // Updates something specific
+      /remov(e|ed)?\s+\w{4,}/i, // Removes something specific
+      /refactor/i,            // Refactoring
+      /performance/i,         // Performance improvements
+      /security/i,            // Security fixes
+      /test(s|ing)?/i,        // Testing related
+      /documentation/i,       // Documentation
+      /feature/i,             // Feature additions
+      /bug/i,                 // Bug fixes
+    ];
+
+    const hasIndicators = meaningfulIndicators.some(pattern => pattern.test(normalized));
+    
+    // Check for code snippets, file paths, or technical terms
+    const hasTechnicalContent = /\.(js|ts|py|java|cpp|c|h|css|html|md|json|yml|yaml)|\w+\/\w+|`[^`]+`/i.test(text);
+    
+    // Check word diversity (not just repeated words)
+    const words = normalized.split(/\s+/).filter(word => word.length > 2);
+    const uniqueWords = new Set(words);
+    const wordDiversity = words.length > 0 ? uniqueWords.size / words.length : 0;
+    
+    return hasIndicators || hasTechnicalContent || (words.length >= 5 && wordDiversity > 0.6);
+  }
+
+  /**
+   * Analyze title quality
+   */
+  private analyzeTitleQuality(title: string): number {
+    if (!title || title.length === 0) return 0;
+
+    const normalized = title.toLowerCase().trim();
+    let score = 0.5; // Base score for having a title
+
+    // Check length appropriateness
+    if (title.length >= 10 && title.length <= 100) {
+      score += 0.3;
+    }
+
+    // Check for specific keywords that indicate quality
+    const qualityKeywords = [
+      /fix/i, /add/i, /update/i, /implement/i, /remove/i, 
+      /refactor/i, /improve/i, /enhance/i, /optimize/i
+    ];
+
+    if (qualityKeywords.some(pattern => pattern.test(normalized))) {
+      score += 0.2;
+    }
+
+    // Penalize very generic titles
+    const genericPatterns = [
+      /^(update|fix|change|test)\.?$/i,
+      /^.{1,3}$/,
+    ];
+
+    if (genericPatterns.some(pattern => pattern.test(normalized))) {
+      score = Math.max(score - 0.4, 0);
+    }
+
+    return Math.min(score, 1.0);
+  }
+
+  /**
+   * Analyze PR size and documentation ratio
+   */
+  private analyzePRCharacteristics(pr: PullRequestData): SpamFlags['pr_characteristics'] {
+    const totalChanges = pr.additions + pr.deletions;
+    const filesChanged = pr.changed_files || 0;
+    const descriptionLength = (pr.body || '').length;
+
+    // Calculate size vs documentation ratio
+    let sizeDocRatio = 0;
+    if (totalChanges > 0) {
+      sizeDocRatio = descriptionLength / totalChanges;
+    }
+
+    // Check if PR has context
+    const hasContext = this.prHasContext(pr);
+
+    // Analyze commit quality (simplified - would need commit messages for full analysis)
+    const commitQualityScore = this.estimateCommitQuality(pr);
+
+    return {
+      size_vs_documentation_ratio: sizeDocRatio,
+      files_changed: filesChanged,
+      has_context: hasContext,
+      commit_quality_score: commitQualityScore,
+    };
+  }
+
+  /**
+   * Check if PR provides adequate context
+   */
+  private prHasContext(pr: PullRequestData): boolean {
+    const description = pr.body || '';
+    const title = pr.title || '';
+    const combinedLength = description.length + title.length;
+
+    // Very small PRs should have proportionally more description
+    const totalChanges = pr.additions + pr.deletions;
+    
+    if (totalChanges <= 10) {
+      return combinedLength >= 20; // Small changes need some explanation
+    } else if (totalChanges <= 100) {
+      return combinedLength >= 50; // Medium changes need more explanation
+    } else {
+      return combinedLength >= 100; // Large changes need substantial explanation
+    }
+  }
+
+  /**
+   * Estimate commit quality based on available PR data
+   */
+  private estimateCommitQuality(pr: PullRequestData): number {
+    // This is a simplified estimation since we don't have commit messages
+    // In a full implementation, we'd analyze actual commit messages
+    
+    let score = 0.5; // Base score
+    
+    // PRs with many small files might indicate focused changes
+    const avgChangesPerFile = pr.changed_files > 0 ? 
+      (pr.additions + pr.deletions) / pr.changed_files : 0;
+    
+    if (avgChangesPerFile > 0 && avgChangesPerFile < 50) {
+      score += 0.2; // Focused changes are generally better
+    }
+    
+    // Very large PRs with many files might be problematic
+    if (pr.changed_files > 20 && (pr.additions + pr.deletions) > 1000) {
+      score -= 0.3;
+    }
+    
+    return Math.max(0, Math.min(score, 1.0));
+  }
+
+  /**
+   * Analyze template matching
+   */
+  private analyzeTemplateMatch(pr: PullRequestData): SpamFlags['template_match'] {
+    const description = pr.body || '';
+    const title = pr.title || '';
+    const combinedText = `${title}\n${description}`.trim();
+
+    const templateMatch = this.templateDetector.detectTemplateMatch(combinedText);
+
+    return {
+      is_match: templateMatch.is_match,
+      template_id: templateMatch.template_id,
+      similarity_score: templateMatch.similarity_score,
+    };
+  }
+}

--- a/src/lib/spam/PRTemplateService.ts
+++ b/src/lib/spam/PRTemplateService.ts
@@ -155,8 +155,13 @@ export class PRTemplateService {
     const patterns: SpamPattern[] = [];
 
     // Clean up template content
-    const cleanTemplate = templateContent
-      .replace(/<!--[\s\S]*?-->/g, '') // Remove HTML comments
+    let cleanTemplate = templateContent;
+    let previousTemplate;
+    do {
+      previousTemplate = cleanTemplate;
+      cleanTemplate = cleanTemplate.replace(/<!--[\s\S]*?-->/g, ''); // Remove HTML comments
+    } while (cleanTemplate !== previousTemplate);
+    cleanTemplate = cleanTemplate
       .replace(/\[.*?\]/g, '') // Remove markdown checkboxes
       .replace(/#+\s*/g, '') // Remove markdown headers
       .trim();

--- a/src/lib/spam/PRTemplateService.ts
+++ b/src/lib/spam/PRTemplateService.ts
@@ -1,0 +1,455 @@
+import { supabase } from '@/lib/supabase';
+
+interface PRTemplate {
+  content: string;
+  url: string;
+  hash: string;
+  fetched_at: string;
+}
+
+interface SpamPattern {
+  pattern_type: 'template_match' | 'empty_sections' | 'minimal_effort';
+  pattern_content: string;
+  pattern_description: string;
+  weight: number;
+}
+
+export class PRTemplateService {
+  private static readonly TEMPLATE_PATHS = [
+    '.github/pull_request_template.md',
+    '.github/PULL_REQUEST_TEMPLATE.md',
+    '.github/pull_request_template/PULL_REQUEST_TEMPLATE.md',
+    '.github/PULL_REQUEST_TEMPLATE/pull_request_template.md',
+    'docs/pull_request_template.md',
+    'docs/PULL_REQUEST_TEMPLATE.md',
+    'PULL_REQUEST_TEMPLATE.md',
+    'pull_request_template.md',
+  ];
+
+  /**
+   * Fetch PR template for a repository from GitHub
+   */
+  async fetchPRTemplate(owner: string, repo: string): Promise<PRTemplate | null> {
+    for (const templatePath of PRTemplateService.TEMPLATE_PATHS) {
+      try {
+        const response = await fetch(
+          `https://api.github.com/repos/${owner}/${repo}/contents/${templatePath}`
+        );
+
+        if (response.ok) {
+          const data = await response.json();
+          
+          if (data.content && data.encoding === 'base64') {
+            const content = atob(data.content).replace(/\n/g, '');
+            const hash = this.generateHash(content);
+            
+            return {
+              content,
+              url: data.html_url,
+              hash,
+              fetched_at: new Date().toISOString(),
+            };
+          }
+        }
+      } catch (error) {
+        console.warn(`Failed to fetch template at ${templatePath}:`, error);
+        continue;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Generate hash for template content using simple string hashing
+   */
+  private generateHash(content: string): string {
+    const normalizedContent = content.toLowerCase().trim();
+    let hash = 0;
+    if (normalizedContent.length === 0) return '0';
+    for (let i = 0; i < normalizedContent.length; i++) {
+      const char = normalizedContent.charCodeAt(i);
+      hash = ((hash << 5) - hash) + char;
+      hash = hash & hash; // Convert to 32bit integer
+    }
+    return Math.abs(hash).toString(16);
+  }
+
+  /**
+   * Cache PR template in database
+   */
+  async cachePRTemplate(repositoryId: string, template: PRTemplate): Promise<void> {
+    const { error } = await supabase
+      .from('repositories')
+      .update({
+        pr_template_content: template.content,
+        pr_template_url: template.url,
+        pr_template_hash: template.hash,
+        pr_template_fetched_at: template.fetched_at,
+      })
+      .eq('id', repositoryId);
+
+    if (error) {
+      throw new Error(`Failed to cache PR template: ${error.message}`);
+    }
+
+    // Generate and store spam patterns for this template
+    await this.generateSpamPatterns(repositoryId, template.content);
+  }
+
+  /**
+   * Get cached PR template for repository
+   */
+  async getCachedPRTemplate(owner: string, repo: string): Promise<PRTemplate | null> {
+    const { data, error } = await supabase
+      .from('repositories')
+      .select('pr_template_content, pr_template_url, pr_template_hash, pr_template_fetched_at')
+      .eq('owner', owner)
+      .eq('name', repo)
+      .single();
+
+    if (error || !data?.pr_template_content) {
+      return null;
+    }
+
+    return {
+      content: data.pr_template_content,
+      url: data.pr_template_url || '',
+      hash: data.pr_template_hash || '',
+      fetched_at: data.pr_template_fetched_at || '',
+    };
+  }
+
+  /**
+   * Fetch and cache PR template if not already cached or outdated
+   */
+  async ensurePRTemplate(repositoryId: string, owner: string, repo: string): Promise<PRTemplate | null> {
+    // Check if we have a cached template that's less than 7 days old
+    const cached = await this.getCachedPRTemplate(owner, repo);
+    
+    if (cached && cached.fetched_at) {
+      const fetchedDate = new Date(cached.fetched_at);
+      const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+      
+      if (fetchedDate > weekAgo) {
+        return cached;
+      }
+    }
+
+    // Fetch fresh template
+    const template = await this.fetchPRTemplate(owner, repo);
+    
+    if (template) {
+      await this.cachePRTemplate(repositoryId, template);
+      return template;
+    }
+
+    // If fetch failed but we have cached version, return it
+    return cached;
+  }
+
+  /**
+   * Generate spam detection patterns from PR template
+   */
+  private async generateSpamPatterns(repositoryId: string, templateContent: string): Promise<void> {
+    const patterns: SpamPattern[] = [];
+
+    // Clean up template content
+    const cleanTemplate = templateContent
+      .replace(/<!--[\s\S]*?-->/g, '') // Remove HTML comments
+      .replace(/\[.*?\]/g, '') // Remove markdown checkboxes
+      .replace(/#+\s*/g, '') // Remove markdown headers
+      .trim();
+
+    // Pattern 1: Template sections as content (empty template usage)
+    const templateSections = this.extractTemplateSections(cleanTemplate);
+    if (templateSections.length > 0) {
+      patterns.push({
+        pattern_type: 'template_match',
+        pattern_content: templateSections.join(' ').toLowerCase(),
+        pattern_description: 'PR description matches template structure without content',
+        weight: 0.9,
+      });
+    }
+
+    // Pattern 2: Common placeholder text
+    const placeholders = this.extractPlaceholders(templateContent);
+    for (const placeholder of placeholders) {
+      patterns.push({
+        pattern_type: 'template_match',
+        pattern_content: placeholder.toLowerCase(),
+        pattern_description: `PR contains template placeholder: "${placeholder}"`,
+        weight: 0.95,
+      });
+    }
+
+    // Pattern 3: Empty sections pattern
+    const sectionTitles = this.extractSectionTitles(templateContent);
+    if (sectionTitles.length > 0) {
+      patterns.push({
+        pattern_type: 'empty_sections',
+        pattern_content: sectionTitles.join('|').toLowerCase(),
+        pattern_description: 'PR has template sections but no content',
+        weight: 0.8,
+      });
+    }
+
+    // Store patterns in database
+    for (const pattern of patterns) {
+      await supabase
+        .from('repository_spam_patterns')
+        .upsert({
+          repository_id: repositoryId,
+          ...pattern,
+        }, {
+          onConflict: 'repository_id,pattern_type,pattern_content'
+        });
+    }
+  }
+
+  /**
+   * Extract main sections from template
+   */
+  private extractTemplateSections(template: string): string[] {
+    const sections = template
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => line.length > 0 && !line.startsWith('#'))
+      .filter(line => line.length < 100) // Avoid very long lines
+      .slice(0, 5); // Take first 5 meaningful lines
+
+    return sections;
+  }
+
+  /**
+   * Extract placeholder text from template
+   */
+  private extractPlaceholders(template: string): string[] {
+    const placeholders: string[] = [];
+
+    // Match common placeholder patterns
+    const patterns = [
+      /\[(.*?)\]/g, // [placeholder text]
+      /\{(.*?)\}/g, // {placeholder text}
+      /\<(.*?)\>/g, // <placeholder text>
+      /\[(.*?)\]\(.*?\)/g, // [text](link) - markdown links as placeholders
+    ];
+
+    for (const pattern of patterns) {
+      let match;
+      while ((match = pattern.exec(template)) !== null) {
+        const placeholder = match[1].trim();
+        if (placeholder.length > 5 && placeholder.length < 50) {
+          placeholders.push(placeholder);
+        }
+      }
+    }
+
+    return [...new Set(placeholders)]; // Remove duplicates
+  }
+
+  /**
+   * Extract section titles from template
+   */
+  private extractSectionTitles(template: string): string[] {
+    const titles: string[] = [];
+    const lines = template.split('\n');
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      
+      // Match markdown headers
+      const headerMatch = trimmed.match(/^#+\s*(.+)$/);
+      if (headerMatch) {
+        const title = headerMatch[1].trim();
+        if (title.length > 2 && title.length < 30) {
+          titles.push(title);
+        }
+      }
+    }
+
+    return titles;
+  }
+
+  /**
+   * Check if PR description matches repository-specific spam patterns
+   */
+  async checkRepositorySpamPatterns(
+    repositoryId: string, 
+    description: string
+  ): Promise<{
+    is_match: boolean;
+    matched_patterns: Array<{
+      pattern_type: string;
+      pattern_content: string;
+      pattern_description: string;
+      weight: number;
+      confidence: number;
+    }>;
+    overall_confidence: number;
+  }> {
+    const { data: patterns, error } = await supabase
+      .from('repository_spam_patterns')
+      .select('*')
+      .eq('repository_id', repositoryId);
+
+    if (error || !patterns || patterns.length === 0) {
+      return {
+        is_match: false,
+        matched_patterns: [],
+        overall_confidence: 0,
+      };
+    }
+
+    const matched_patterns = [];
+    const cleanDescription = description.toLowerCase().trim();
+
+    for (const pattern of patterns) {
+      let confidence = 0;
+
+      switch (pattern.pattern_type) {
+        case 'template_match':
+          confidence = this.calculateSimilarity(cleanDescription, pattern.pattern_content);
+          break;
+        case 'empty_sections':
+          confidence = this.checkEmptySections(description, pattern.pattern_content);
+          break;
+        case 'minimal_effort':
+          confidence = this.checkMinimalEffort(description, pattern.pattern_content);
+          break;
+      }
+
+      if (confidence > 0.7) {
+        matched_patterns.push({
+          pattern_type: pattern.pattern_type,
+          pattern_content: pattern.pattern_content,
+          pattern_description: pattern.pattern_description,
+          weight: pattern.weight,
+          confidence,
+        });
+      }
+    }
+
+    const overall_confidence = matched_patterns.length > 0
+      ? matched_patterns.reduce((sum, p) => sum + (p.confidence * p.weight), 0) / matched_patterns.length
+      : 0;
+
+    return {
+      is_match: matched_patterns.length > 0,
+      matched_patterns,
+      overall_confidence,
+    };
+  }
+
+  /**
+   * Calculate similarity between two strings
+   */
+  private calculateSimilarity(str1: string, str2: string): number {
+    const len1 = str1.length;
+    const len2 = str2.length;
+    
+    if (len1 === 0) return len2 === 0 ? 1 : 0;
+    if (len2 === 0) return 0;
+    
+    const matrix = Array(len2 + 1).fill(null).map(() => Array(len1 + 1).fill(null));
+    
+    for (let i = 0; i <= len1; i++) matrix[0][i] = i;
+    for (let j = 0; j <= len2; j++) matrix[j][0] = j;
+    
+    for (let j = 1; j <= len2; j++) {
+      for (let i = 1; i <= len1; i++) {
+        const indicator = str1[i - 1] === str2[j - 1] ? 0 : 1;
+        matrix[j][i] = Math.min(
+          matrix[j][i - 1] + 1,
+          matrix[j - 1][i] + 1,
+          matrix[j - 1][i - 1] + indicator
+        );
+      }
+    }
+    
+    const maxLen = Math.max(len1, len2);
+    return 1 - (matrix[len2][len1] / maxLen);
+  }
+
+  /**
+   * Check if description has template sections without content
+   */
+  private checkEmptySections(description: string, sectionPattern: string): number {
+    const sections = sectionPattern.split('|');
+    let emptyCount = 0;
+
+    for (const section of sections) {
+      if (description.toLowerCase().includes(section.toLowerCase())) {
+        // Check if section appears but has no content after it
+        const sectionIndex = description.toLowerCase().indexOf(section.toLowerCase());
+        const afterSection = description.substring(sectionIndex + section.length, sectionIndex + section.length + 100);
+        
+        if (afterSection.trim().length < 10) {
+          emptyCount++;
+        }
+      }
+    }
+
+    return sections.length > 0 ? emptyCount / sections.length : 0;
+  }
+
+  /**
+   * Check for minimal effort patterns
+   */
+  private checkMinimalEffort(description: string, pattern: string): number {
+    const minimalPatterns = pattern.split('|');
+    
+    for (const minPattern of minimalPatterns) {
+      if (description.toLowerCase().includes(minPattern.toLowerCase())) {
+        return 1.0;
+      }
+    }
+
+    return 0;
+  }
+
+  /**
+   * Fetch templates for all tracked repositories
+   */
+  async syncAllRepositoryTemplates(): Promise<{
+    processed: number;
+    updated: number;
+    errors: string[];
+  }> {
+    const { data: repositories, error } = await supabase
+      .from('repositories')
+      .select('id, owner, name, pr_template_fetched_at')
+      .eq('tracking_enabled', true);
+
+    if (error) {
+      throw new Error(`Failed to fetch repositories: ${error.message}`);
+    }
+
+    const results = {
+      processed: 0,
+      updated: 0,
+      errors: [] as string[],
+    };
+
+    for (const repo of repositories || []) {
+      try {
+        results.processed++;
+        
+        const template = await this.ensurePRTemplate(repo.id, repo.owner, repo.name);
+        if (template) {
+          results.updated++;
+        }
+        
+        // Add small delay to avoid hitting GitHub API rate limits
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        
+      } catch (error) {
+        const errorMsg = `${repo.owner}/${repo.name}: ${error instanceof Error ? error.message : 'Unknown error'}`;
+        results.errors.push(errorMsg);
+        console.error(`Error syncing template for ${repo.owner}/${repo.name}:`, error);
+      }
+    }
+
+    return results;
+  }
+}

--- a/src/lib/spam/SpamDetectionService.ts
+++ b/src/lib/spam/SpamDetectionService.ts
@@ -25,7 +25,7 @@ export class SpamDetectionService {
       }
 
       // Analyze different aspects of the PR
-      const prAnalysis = this.prAnalysisService.analyzePR(pr);
+      const prAnalysis = await this.prAnalysisService.analyzePR(pr);
       const accountFlags = this.accountAnalysisService.analyzeAccount(pr);
 
       // Combine all flags

--- a/src/lib/spam/SpamDetectionService.ts
+++ b/src/lib/spam/SpamDetectionService.ts
@@ -1,0 +1,362 @@
+import { 
+  PullRequestData, 
+  SpamDetectionResult, 
+  SpamFlags,
+  DETECTION_WEIGHTS,
+  SPAM_THRESHOLDS 
+} from './types';
+import { PRAnalysisService } from './PRAnalysisService';
+import { AccountAnalysisService } from './AccountAnalysisService';
+
+export class SpamDetectionService {
+  private prAnalysisService = new PRAnalysisService();
+  private accountAnalysisService = new AccountAnalysisService();
+
+  /**
+   * Main method to detect spam in a pull request
+   */
+  async detectSpam(pr: PullRequestData): Promise<SpamDetectionResult> {
+    const startTime = Date.now();
+
+    try {
+      // Validate input
+      if (!pr || !pr.author) {
+        throw new Error('Invalid PR data: missing required fields');
+      }
+
+      // Analyze different aspects of the PR
+      const prAnalysis = this.prAnalysisService.analyzePR(pr);
+      const accountFlags = this.accountAnalysisService.analyzeAccount(pr);
+
+      // Combine all flags
+      const flags: SpamFlags = {
+        template_match: prAnalysis.template_match,
+        content_quality: prAnalysis.content_quality,
+        account_flags: accountFlags,
+        pr_characteristics: prAnalysis.pr_characteristics,
+      };
+
+      // Calculate composite spam score
+      const spamScore = this.calculateSpamScore(flags);
+      
+      // Determine if it's spam based on thresholds
+      const isSpam = spamScore >= SPAM_THRESHOLDS.LIKELY_SPAM;
+      
+      // Calculate confidence based on multiple factors
+      const confidence = this.calculateConfidence(flags, spamScore);
+      
+      // Generate human-readable reasons
+      const reasons = this.generateReasons(flags, spamScore);
+
+      const result: SpamDetectionResult = {
+        spam_score: Math.round(spamScore),
+        is_spam: isSpam,
+        flags,
+        detected_at: new Date().toISOString(),
+        confidence,
+        reasons,
+      };
+
+      // Log performance
+      const processingTime = Date.now() - startTime;
+      if (processingTime > 100) {
+        console.warn(`Spam detection took ${processingTime}ms for PR ${pr.id}`);
+      }
+
+      return result;
+    } catch (error) {
+      console.error('Error during spam detection:', error);
+      
+      // Return safe default on error
+      return {
+        spam_score: 0,
+        is_spam: false,
+        flags: {},
+        detected_at: new Date().toISOString(),
+        confidence: 0,
+        reasons: ['Error during spam detection'],
+      };
+    }
+  }
+
+  /**
+   * Calculate composite spam score from all detection flags
+   */
+  private calculateSpamScore(flags: SpamFlags): number {
+    let score = 0;
+
+    // Template matching score (0-100 * weight)
+    if (flags.template_match?.is_match) {
+      const templateScore = (flags.template_match.similarity_score || 1.0) * 100;
+      score += templateScore * DETECTION_WEIGHTS.TEMPLATE_MATCH;
+    }
+
+    // Content quality score (0-100 * weight)
+    if (flags.content_quality) {
+      const qualityScore = (1 - flags.content_quality.quality_score) * 100;
+      score += qualityScore * DETECTION_WEIGHTS.CONTENT_QUALITY;
+    }
+
+    // Account patterns score (0-100 * weight)
+    if (flags.account_flags) {
+      const accountScore = this.calculateAccountSpamScore(flags.account_flags);
+      score += accountScore * DETECTION_WEIGHTS.ACCOUNT_PATTERNS;
+    }
+
+    // PR characteristics score (0-100 * weight)
+    if (flags.pr_characteristics) {
+      const prScore = this.calculatePRCharacteristicsScore(flags.pr_characteristics);
+      score += prScore * DETECTION_WEIGHTS.PR_CHARACTERISTICS;
+    }
+
+    return Math.min(score, 100);
+  }
+
+  /**
+   * Calculate account-based spam score
+   */
+  private calculateAccountSpamScore(accountFlags: SpamFlags['account_flags']): number {
+    if (!accountFlags) return 0;
+
+    let score = 0;
+
+    // New account penalty
+    if (accountFlags.is_new_account) {
+      score += 50;
+      
+      // Extra penalty for very new accounts
+      if (accountFlags.account_age_days <= 7) {
+        score += 25;
+      }
+    }
+
+    // Incomplete profile penalty
+    if (!accountFlags.has_profile_data) {
+      score += 30;
+    }
+
+    // Low contribution history penalty
+    const contributionScore = accountFlags.contribution_history_score || 0;
+    score += (1 - contributionScore) * 40;
+
+    return Math.min(score, 100);
+  }
+
+  /**
+   * Calculate PR characteristics spam score
+   */
+  private calculatePRCharacteristicsScore(prFlags: SpamFlags['pr_characteristics']): number {
+    if (!prFlags) return 0;
+
+    let score = 0;
+
+    // No context penalty
+    if (!prFlags.has_context) {
+      score += 40;
+    }
+
+    // Poor commit quality penalty
+    const commitQuality = prFlags.commit_quality_score || 0;
+    score += (1 - commitQuality) * 30;
+
+    // Large PR with poor documentation ratio
+    if (prFlags.files_changed > 10 && prFlags.size_vs_documentation_ratio < 0.1) {
+      score += 20;
+    }
+
+    // Single file changes with no context (common spam pattern)
+    if (prFlags.files_changed === 1 && !prFlags.has_context) {
+      score += 10;
+    }
+
+    return Math.min(score, 100);
+  }
+
+  /**
+   * Calculate confidence in the spam detection result
+   */
+  private calculateConfidence(flags: SpamFlags, spamScore: number): number {
+    let confidence = 0.5; // Base confidence
+
+    // High confidence indicators
+    if (flags.template_match?.is_match && 
+        (flags.template_match.similarity_score || 0) > 0.9) {
+      confidence += 0.3;
+    }
+
+    if (flags.account_flags?.is_new_account && 
+        !flags.account_flags.has_profile_data) {
+      confidence += 0.2;
+    }
+
+    if (flags.content_quality && 
+        flags.content_quality.quality_score < 0.2) {
+      confidence += 0.2;
+    }
+
+    // Moderate confidence indicators
+    if (flags.pr_characteristics && 
+        !flags.pr_characteristics.has_context) {
+      confidence += 0.1;
+    }
+
+    // Score-based confidence adjustment
+    if (spamScore > 80 || spamScore < 20) {
+      confidence += 0.1; // More confident in extreme scores
+    }
+
+    // Ensure minimum confidence for legitimate PRs
+    if (spamScore < 25) {
+      confidence = Math.max(confidence, 0.6);
+    }
+
+    return Math.min(confidence, 1.0);
+  }
+
+  /**
+   * Generate human-readable reasons for the spam classification
+   */
+  private generateReasons(flags: SpamFlags, spamScore: number): string[] {
+    const reasons: string[] = [];
+
+    // Template matching reasons
+    if (flags.template_match?.is_match) {
+      const similarity = flags.template_match.similarity_score || 0;
+      if (similarity >= 0.9) {
+        reasons.push(`Matches known spam template (${Math.round(similarity * 100)}% similarity)`);
+      } else {
+        reasons.push(`Similar to spam patterns (${Math.round(similarity * 100)}% similarity)`);
+      }
+    }
+
+    // Content quality reasons
+    if (flags.content_quality) {
+      const quality = flags.content_quality.quality_score;
+      if (quality < 0.3) {
+        reasons.push('Very low content quality');
+      } else if (quality < 0.5) {
+        reasons.push('Poor content quality');
+      }
+
+      if (flags.content_quality.description_length === 0) {
+        reasons.push('Empty description');
+      } else if (flags.content_quality.description_length < 10) {
+        reasons.push('Extremely short description');
+      }
+
+      if (!flags.content_quality.has_meaningful_content) {
+        reasons.push('No meaningful content detected');
+      }
+    }
+
+    // Account reasons
+    if (flags.account_flags) {
+      if (flags.account_flags.is_new_account) {
+        const days = flags.account_flags.account_age_days;
+        if (days <= 7) {
+          reasons.push(`Very new account (${days} days old)`);
+        } else {
+          reasons.push(`New account (${days} days old)`);
+        }
+      }
+
+      if (!flags.account_flags.has_profile_data) {
+        reasons.push('Incomplete GitHub profile');
+      }
+
+      const contributionScore = flags.account_flags.contribution_history_score;
+      if (contributionScore < 0.2) {
+        reasons.push('No contribution history');
+      } else if (contributionScore < 0.4) {
+        reasons.push('Limited contribution history');
+      }
+    }
+
+    // PR characteristics reasons
+    if (flags.pr_characteristics) {
+      if (!flags.pr_characteristics.has_context) {
+        reasons.push('No context or explanation provided');
+      }
+
+      if (flags.pr_characteristics.files_changed === 1) {
+        reasons.push('Single file change');
+      }
+
+      const commitQuality = flags.pr_characteristics.commit_quality_score;
+      if (commitQuality < 0.3) {
+        reasons.push('Poor commit quality indicators');
+      }
+    }
+
+    // Overall score reason
+    if (spamScore >= SPAM_THRESHOLDS.DEFINITE_SPAM) {
+      reasons.push('Multiple spam indicators detected');
+    } else if (spamScore >= SPAM_THRESHOLDS.LIKELY_SPAM) {
+      reasons.push('Several spam indicators present');
+    }
+
+    return reasons.length > 0 ? reasons : ['Automated analysis completed'];
+  }
+
+  /**
+   * Batch process multiple PRs for spam detection
+   */
+  async detectSpamBatch(prs: PullRequestData[]): Promise<SpamDetectionResult[]> {
+    const results: SpamDetectionResult[] = [];
+    
+    // Process in batches to avoid overwhelming the system
+    const batchSize = 10;
+    for (let i = 0; i < prs.length; i += batchSize) {
+      const batch = prs.slice(i, i + batchSize);
+      const batchPromises = batch.map(pr => this.detectSpam(pr));
+      const batchResults = await Promise.all(batchPromises);
+      results.push(...batchResults);
+
+      // Add small delay between batches to prevent overwhelming
+      if (i + batchSize < prs.length) {
+        await new Promise(resolve => setTimeout(resolve, 10));
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Get spam detection statistics
+   */
+  getDetectionStats(results: SpamDetectionResult[]): {
+    total: number;
+    spam_count: number;
+    spam_percentage: number;
+    avg_score: number;
+    avg_confidence: number;
+    by_threshold: Record<string, number>;
+  } {
+    const total = results.length;
+    const spamCount = results.filter(r => r.is_spam).length;
+    const avgScore = results.reduce((sum, r) => sum + r.spam_score, 0) / total;
+    const avgConfidence = results.reduce((sum, r) => sum + r.confidence, 0) / total;
+
+    const byThreshold = {
+      legitimate: results.filter(r => r.spam_score <= SPAM_THRESHOLDS.LEGITIMATE).length,
+      warning: results.filter(r => 
+        r.spam_score > SPAM_THRESHOLDS.LEGITIMATE && 
+        r.spam_score <= SPAM_THRESHOLDS.WARNING
+      ).length,
+      likely_spam: results.filter(r => 
+        r.spam_score > SPAM_THRESHOLDS.WARNING && 
+        r.spam_score <= SPAM_THRESHOLDS.LIKELY_SPAM
+      ).length,
+      definite_spam: results.filter(r => r.spam_score > SPAM_THRESHOLDS.LIKELY_SPAM).length,
+    };
+
+    return {
+      total,
+      spam_count: spamCount,
+      spam_percentage: (spamCount / total) * 100,
+      avg_score: Math.round(avgScore * 10) / 10,
+      avg_confidence: Math.round(avgConfidence * 100) / 100,
+      by_threshold: byThreshold,
+    };
+  }
+}

--- a/src/lib/spam/__tests__/SpamDetectionService.test.ts
+++ b/src/lib/spam/__tests__/SpamDetectionService.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SpamDetectionService } from '../SpamDetectionService';
+import { PullRequestData, SPAM_THRESHOLDS } from '../types';
+
+// Mock data for testing
+const createMockPR = (overrides: Partial<PullRequestData> = {}): PullRequestData => ({
+  id: '1',
+  title: 'Fix bug in authentication',
+  body: 'This PR fixes a critical bug in the authentication system where users were unable to log in.',
+  number: 123,
+  additions: 10,
+  deletions: 5,
+  changed_files: 2,
+  created_at: '2024-01-15T10:00:00Z',
+  html_url: 'https://github.com/owner/repo/pull/123',
+  author: {
+    id: 12345,
+    login: 'gooddev',
+    created_at: '2022-01-01T00:00:00Z',
+    public_repos: 15,
+    followers: 25,
+    following: 30,
+    bio: 'Software developer with 5 years experience',
+    company: 'Tech Corp',
+    location: 'San Francisco',
+  },
+  repository: {
+    full_name: 'owner/repo',
+  },
+  ...overrides,
+});
+
+describe('SpamDetectionService', () => {
+  let spamDetectionService: SpamDetectionService;
+
+  beforeEach(() => {
+    spamDetectionService = new SpamDetectionService();
+  });
+
+  describe('detectSpam', () => {
+    it('should classify legitimate PR as not spam', async () => {
+      const pr = createMockPR();
+      const result = await spamDetectionService.detectSpam(pr);
+
+      expect(result.is_spam).toBe(false);
+      expect(result.spam_score).toBeLessThan(SPAM_THRESHOLDS.WARNING);
+      expect(result.confidence).toBeGreaterThan(0);
+      expect(result.flags).toBeDefined();
+    });
+
+    it('should detect template-matched spam PR', async () => {
+      const spamPR = createMockPR({
+        title: 'update',
+        body: '',
+        author: {
+          id: 99999,
+          login: 'spammer123',
+          created_at: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(), // 5 days ago
+          public_repos: 0,
+          followers: 0,
+          following: 0,
+        },
+      });
+
+      const result = await spamDetectionService.detectSpam(spamPR);
+
+      expect(result.is_spam).toBe(true);
+      expect(result.spam_score).toBeGreaterThan(SPAM_THRESHOLDS.LIKELY_SPAM);
+      expect(result.flags.template_match?.is_match).toBe(true);
+      expect(result.reasons.join(' ')).toMatch(/template|pattern|spam/i);
+    });
+
+    it('should detect new account with poor content quality', async () => {
+      const newAccountPR = createMockPR({
+        title: 'fix',
+        body: 'fix',
+        author: {
+          id: 88888,
+          login: 'newuser2024',
+          created_at: new Date().toISOString(), // Today
+          public_repos: 0,
+          followers: 0,
+          following: 0,
+        },
+      });
+
+      const result = await spamDetectionService.detectSpam(newAccountPR);
+
+      expect(result.spam_score).toBeGreaterThan(SPAM_THRESHOLDS.WARNING);
+      expect(result.flags.account_flags?.is_new_account).toBe(true);
+      expect(result.flags.content_quality?.quality_score).toBeLessThan(0.5);
+    });
+
+    it('should handle Hacktoberfest spam patterns', async () => {
+      const hacktoberfestSpam = createMockPR({
+        title: 'Added my name',
+        body: 'added my name to contributors list',
+        additions: 1,
+        deletions: 0,
+        changed_files: 1,
+        author: {
+          id: 77777,
+          login: 'hacktober2024',
+          created_at: '2024-09-01T00:00:00Z', // September (typical Hacktoberfest prep)
+          public_repos: 0,
+          followers: 0,
+          following: 0,
+        },
+      });
+
+      const result = await spamDetectionService.detectSpam(hacktoberfestSpam);
+
+      expect(result.spam_score).toBeGreaterThan(SPAM_THRESHOLDS.WARNING);
+      expect(result.flags.template_match?.is_match).toBe(true);
+      expect(result.reasons.join(' ')).toMatch(/template|spam/i);
+    });
+
+    it('should detect empty or minimal content', async () => {
+      const emptyContentPR = createMockPR({
+        title: 'Update',
+        body: '',
+        author: {
+          id: 66666,
+          login: 'minimalist',
+          created_at: '2024-01-01T00:00:00Z',
+          public_repos: 1,
+          followers: 0,
+          following: 0,
+        },
+      });
+
+      const result = await spamDetectionService.detectSpam(emptyContentPR);
+
+      expect(result.spam_score).toBeGreaterThan(SPAM_THRESHOLDS.WARNING);
+      expect(result.flags.content_quality?.description_length).toBe(0);
+      expect(result.reasons).toContain('Empty description');
+    });
+
+    it('should have lower spam score for established accounts', async () => {
+      const establishedAccountPR = createMockPR({
+        title: 'Minor update',
+        body: 'Small formatting change',
+        author: {
+          id: 11111,
+          login: 'veteran_dev',
+          created_at: '2020-01-01T00:00:00Z', // 4+ years old
+          public_repos: 50,
+          followers: 100,
+          following: 80,
+          bio: 'Senior software engineer at Big Tech',
+          company: 'Big Tech Corp',
+          location: 'Seattle',
+        },
+      });
+
+      const result = await spamDetectionService.detectSpam(establishedAccountPR);
+
+      expect(result.spam_score).toBeLessThan(SPAM_THRESHOLDS.WARNING);
+      expect(result.flags.account_flags?.is_new_account).toBe(false);
+      expect(result.flags.account_flags?.has_profile_data).toBe(true);
+    });
+
+    it('should handle errors gracefully', async () => {
+      const invalidPR = {} as PullRequestData;
+      const result = await spamDetectionService.detectSpam(invalidPR);
+
+      expect(result.spam_score).toBe(0);
+      expect(result.is_spam).toBe(false);
+      expect(result.confidence).toBe(0);
+      expect(result.reasons).toContain('Error during spam detection');
+    });
+  });
+
+  describe('detectSpamBatch', () => {
+    it('should process multiple PRs correctly', async () => {
+      const prs = [
+        createMockPR({ id: '1' }),
+        createMockPR({ 
+          id: '2',
+          title: 'fix',
+          body: '',
+          author: {
+            id: 99998,
+            login: 'spammer',
+            created_at: new Date().toISOString(),
+            public_repos: 0,
+            followers: 0,
+            following: 0,
+          },
+        }),
+        createMockPR({ id: '3' }),
+      ];
+
+      const results = await spamDetectionService.detectSpamBatch(prs);
+
+      expect(results).toHaveLength(3);
+      expect(results[0].is_spam).toBe(false); // Legitimate PR
+      expect(results[1].is_spam).toBe(true);  // Spam PR
+      expect(results[2].is_spam).toBe(false); // Legitimate PR
+    });
+
+    it('should handle empty batch', async () => {
+      const results = await spamDetectionService.detectSpamBatch([]);
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('getDetectionStats', () => {
+    it('should calculate statistics correctly', async () => {
+      const results = [
+        { spam_score: 10, is_spam: false, confidence: 0.8 } as any,
+        { spam_score: 85, is_spam: true, confidence: 0.9 } as any,
+        { spam_score: 30, is_spam: false, confidence: 0.6 } as any,
+        { spam_score: 95, is_spam: true, confidence: 0.95 } as any,
+      ];
+
+      const stats = spamDetectionService.getDetectionStats(results);
+
+      expect(stats.total).toBe(4);
+      expect(stats.spam_count).toBe(2);
+      expect(stats.spam_percentage).toBe(50);
+      expect(stats.avg_score).toBe(55); // (10 + 85 + 30 + 95) / 4
+      expect(stats.avg_confidence).toBe(0.81); // (0.8 + 0.9 + 0.6 + 0.95) / 4
+      expect(stats.by_threshold.legitimate).toBe(1); // score <= 25
+      expect(stats.by_threshold.warning).toBe(1); // 25 < score <= 50
+      expect(stats.by_threshold.likely_spam).toBe(0); // 50 < score <= 75
+      expect(stats.by_threshold.definite_spam).toBe(2); // score > 75
+    });
+  });
+
+  describe('performance', () => {
+    it('should process PR within acceptable time limit', async () => {
+      const pr = createMockPR();
+      const startTime = Date.now();
+      
+      await spamDetectionService.detectSpam(pr);
+      
+      const processingTime = Date.now() - startTime;
+      expect(processingTime).toBeLessThan(100); // Should be under 100ms
+    });
+
+    it('should handle large batch efficiently', async () => {
+      const prs = Array.from({ length: 50 }, (_, i) => createMockPR({ id: i.toString() }));
+      const startTime = Date.now();
+      
+      await spamDetectionService.detectSpamBatch(prs);
+      
+      const processingTime = Date.now() - startTime;
+      expect(processingTime).toBeLessThan(5000); // Should handle 50 PRs in under 5 seconds
+    });
+  });
+});

--- a/src/lib/spam/__tests__/TemplateDetector.test.ts
+++ b/src/lib/spam/__tests__/TemplateDetector.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { TemplateDetector, SPAM_PATTERNS } from '../templates/CommonTemplates';
+
+describe('TemplateDetector', () => {
+  let detector: TemplateDetector;
+
+  beforeEach(() => {
+    detector = new TemplateDetector();
+  });
+
+  describe('detectTemplateMatch', () => {
+    it('should detect exact template matches', () => {
+      const testCases = [
+        'update',
+        'fix',
+        'change',
+        'added my name',
+        'hello world',
+      ];
+
+      testCases.forEach(template => {
+        const result = detector.detectTemplateMatch(template);
+        expect(result.is_match).toBe(true);
+        expect(result.similarity_score).toBeGreaterThanOrEqual(0.9);
+      });
+    });
+
+    it('should detect case-insensitive matches', () => {
+      const result = detector.detectTemplateMatch('UPDATE');
+      expect(result.is_match).toBe(true);
+      expect(result.similarity_score).toBeGreaterThanOrEqual(0.9);
+    });
+
+    it('should detect empty descriptions as spam', () => {
+      const result = detector.detectTemplateMatch('');
+      expect(result.is_match).toBe(true);
+      expect(result.template_id).toBe('empty_description');
+      expect(result.similarity_score).toBe(1.0);
+    });
+
+    it('should detect whitespace-only descriptions', () => {
+      const result = detector.detectTemplateMatch('   ');
+      expect(result.is_match).toBe(true);
+      expect(result.template_id).toBe('empty_description');
+    });
+
+    it('should detect Hacktoberfest patterns', () => {
+      const hacktoberfestCases = [
+        'added my name to contributors',
+        'Hacktoberfest contribution',
+        'name added',
+        'added name to list',
+      ];
+
+      hacktoberfestCases.forEach(text => {
+        const result = detector.detectTemplateMatch(text);
+        expect(result.is_match).toBe(true);
+        expect(result.template_id).toBe('hacktoberfest');
+      });
+    });
+
+    it('should detect first contribution patterns', () => {
+      const firstContribCases = [
+        'my first contribution',
+        'first commit ever',
+        'hello world program',
+        'My First PR',
+      ];
+
+      firstContribCases.forEach(text => {
+        const result = detector.detectTemplateMatch(text);
+        expect(result.is_match).toBe(true);
+        expect(result.template_id).toBe('first_contrib');
+      });
+    });
+
+    it('should detect minimal effort patterns', () => {
+      const minimalCases = [
+        'fix.',
+        'update.',
+        'change',
+        'test',
+      ];
+
+      minimalCases.forEach(text => {
+        const result = detector.detectTemplateMatch(text);
+        expect(result.is_match).toBe(true);
+        // These will be detected as exact matches or minimal_effort patterns
+        expect(['exact_match', 'minimal_effort'].includes(result.template_id || '')).toBe(true);
+      });
+    });
+
+    it('should detect single character spam', () => {
+      const singleCharCases = ['a', 'x', '🎉', '123'];
+
+      singleCharCases.forEach(text => {
+        const result = detector.detectTemplateMatch(text);
+        expect(result.is_match).toBe(true);
+        expect(result.template_id).toBe('single_char');
+      });
+    });
+
+    it('should not flag legitimate descriptions', () => {
+      const legitimateCases = [
+        'Fixed authentication bug that prevented users from logging in',
+        'Add support for TypeScript configuration files',
+        'Refactor user management service to improve performance',
+        'Update documentation with new API endpoints',
+        'Remove deprecated methods from payment processor',
+        'Implement dark mode toggle for user interface',
+      ];
+
+      legitimateCases.forEach(text => {
+        const result = detector.detectTemplateMatch(text);
+        expect(result.is_match).toBe(false);
+      });
+    });
+
+    it('should handle similarity matching', () => {
+      const result = detector.detectTemplateMatch('updated readme file');
+      
+      // Should detect similarity to "update" but not exact match
+      if (result.is_match) {
+        expect(result.similarity_score).toBeLessThan(1.0);
+        expect(result.similarity_score).toBeGreaterThan(0.5);
+      }
+    });
+
+    it('should handle special characters and punctuation', () => {
+      const result = detector.detectTemplateMatch('fix!!!');
+      expect(result.is_match).toBe(true); // Should still detect "fix"
+    });
+  });
+
+  describe('getAllMatches', () => {
+    it('should return all matching templates sorted by similarity', () => {
+      const matches = detector.getAllMatches('fix');
+      
+      // Should find some matches for "fix"
+      expect(matches.length).toBeGreaterThan(0);
+      
+      // Should be sorted by similarity (descending)
+      for (let i = 1; i < matches.length; i++) {
+        expect(matches[i - 1].similarity).toBeGreaterThanOrEqual(matches[i].similarity);
+      }
+    });
+
+    it('should return empty array for no matches', () => {
+      const matches = detector.getAllMatches('comprehensive technical implementation of advanced features');
+      expect(matches.length).toBe(0);
+    });
+
+    it('should handle empty input', () => {
+      const matches = detector.getAllMatches('');
+      expect(matches).toEqual([]);
+    });
+  });
+
+  describe('spam patterns', () => {
+    it('should test all spam patterns work correctly', () => {
+      const testCases = [
+        { pattern: SPAM_PATTERNS.MINIMAL_EFFORT, text: 'fix', shouldMatch: true },
+        { pattern: SPAM_PATTERNS.MINIMAL_EFFORT, text: 'Fixed authentication bug', shouldMatch: false },
+        { pattern: SPAM_PATTERNS.HACKTOBERFEST, text: 'hacktoberfest contribution', shouldMatch: true },
+        { pattern: SPAM_PATTERNS.HACKTOBERFEST, text: 'legitimate feature addition', shouldMatch: false },
+        { pattern: SPAM_PATTERNS.FIRST_CONTRIB, text: 'my first contribution', shouldMatch: true },
+        { pattern: SPAM_PATTERNS.FIRST_CONTRIB, text: 'experienced developer update', shouldMatch: false },
+        { pattern: SPAM_PATTERNS.SINGLE_CHAR, text: 'x', shouldMatch: true },
+        { pattern: SPAM_PATTERNS.SINGLE_CHAR, text: 'comprehensive update', shouldMatch: false },
+        { pattern: SPAM_PATTERNS.MEANINGLESS, text: 'done', shouldMatch: true },
+        { pattern: SPAM_PATTERNS.MEANINGLESS, text: 'Implementation completed successfully', shouldMatch: false },
+      ];
+
+      testCases.forEach(({ pattern, text, shouldMatch }) => {
+        const matches = pattern.test(text);
+        expect(matches).toBe(shouldMatch);
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle very long descriptions', () => {
+      const longText = 'a'.repeat(10000);
+      const result = detector.detectTemplateMatch(longText);
+      
+      // Should not crash and should return a result
+      expect(result).toBeDefined();
+      expect(typeof result.is_match).toBe('boolean');
+    });
+
+    it('should handle unicode characters', () => {
+      const unicodeText = '🚀 Added emoji support 🎉';
+      const result = detector.detectTemplateMatch(unicodeText);
+      
+      expect(result).toBeDefined();
+      expect(typeof result.is_match).toBe('boolean');
+    });
+
+    it('should handle mixed case and spacing', () => {
+      const messyText = '  FiX  ';
+      const result = detector.detectTemplateMatch(messyText);
+      
+      // Should normalize and still detect "fix"
+      expect(result.is_match).toBe(true);
+    });
+
+    it('should handle null and undefined gracefully', () => {
+      const result1 = detector.detectTemplateMatch(null as any);
+      const result2 = detector.detectTemplateMatch(undefined as any);
+      
+      expect(result1.is_match).toBe(true); // Empty content is spam
+      expect(result2.is_match).toBe(true); // Empty content is spam
+    });
+  });
+});

--- a/src/lib/spam/index.ts
+++ b/src/lib/spam/index.ts
@@ -1,0 +1,19 @@
+// Export all spam detection services and types
+export { SpamDetectionService } from './SpamDetectionService';
+export { PRAnalysisService } from './PRAnalysisService';
+export { AccountAnalysisService } from './AccountAnalysisService';
+export { TemplateDetector, COMMON_SPAM_TEMPLATES, SPAM_PATTERNS } from './templates/CommonTemplates';
+
+export type {
+  SpamFlags,
+  SpamDetectionResult,
+  PullRequestData,
+  SpamTemplate,
+} from './types';
+
+export {
+  SPAM_THRESHOLDS,
+  DETECTION_WEIGHTS,
+  ACCOUNT_THRESHOLDS,
+  CONTENT_THRESHOLDS,
+} from './types';

--- a/src/lib/spam/templates/CommonTemplates.ts
+++ b/src/lib/spam/templates/CommonTemplates.ts
@@ -79,6 +79,29 @@ export const COMMON_SPAM_TEMPLATES: SpamTemplate[] = [
     category: 'automated',
     weight: 0.6,
   },
+  
+  // Repository-specific templates - Continue project
+  {
+    id: 'continue_template_unchanged',
+    template: 'what changed feel free to be brief',
+    description: 'Continue PR template with placeholder text unchanged',
+    category: 'generic_spam',
+    weight: 0.95,
+  },
+  {
+    id: 'continue_placeholder_sections',
+    template: 'for visual changes include screenshots screen recordings are particularly helpful what tests were added or updated',
+    description: 'Continue PR template sections left as placeholders',
+    category: 'generic_spam',
+    weight: 0.90,
+  },
+  {
+    id: 'continue_empty_checklist',
+    template: 'description checklist screenshots tests',
+    description: 'Continue PR template with empty sections',
+    category: 'generic_spam',
+    weight: 0.85,
+  },
 ];
 
 // Templates that should be checked for exact matches (100% similarity)
@@ -112,6 +135,9 @@ export const SPAM_PATTERNS = {
   
   // Common meaningless phrases
   MEANINGLESS: /^(done|finished|complete|ok|good|nice|cool|awesome)\.?$/i,
+  
+  // Continue project specific placeholder patterns
+  CONTINUE_PLACEHOLDERS: /what changed\??\s*feel free to be brief|for visual changes,?\s*include screenshots|what tests were added or updated|screen recordings are particularly helpful/i,
 };
 
 export class TemplateDetector {

--- a/src/lib/spam/templates/CommonTemplates.ts
+++ b/src/lib/spam/templates/CommonTemplates.ts
@@ -1,0 +1,237 @@
+import { SpamTemplate } from '../types';
+
+// Common spam templates identified from PR data
+export const COMMON_SPAM_TEMPLATES: SpamTemplate[] = [
+  // Hacktoberfest spam templates
+  {
+    id: 'hacktoberfest_basic',
+    template: 'added my name',
+    description: 'Basic "added my name" spam common during Hacktoberfest',
+    category: 'hacktoberfest',
+    weight: 0.9,
+  },
+  {
+    id: 'hacktoberfest_readme',
+    template: 'updated readme',
+    description: 'Generic readme updates without meaningful changes',
+    category: 'hacktoberfest',
+    weight: 0.8,
+  },
+  {
+    id: 'hacktoberfest_typo',
+    template: 'fixed typo',
+    description: 'Generic typo fixes without specific details',
+    category: 'hacktoberfest',
+    weight: 0.7,
+  },
+  
+  // First contribution templates
+  {
+    id: 'first_contrib_basic',
+    template: 'my first contribution',
+    description: 'Basic first contribution message without context',
+    category: 'first_contribution',
+    weight: 0.6,
+  },
+  {
+    id: 'first_contrib_hello',
+    template: 'hello world',
+    description: 'Hello world style first contributions',
+    category: 'first_contribution',
+    weight: 0.7,
+  },
+  
+  // Generic spam
+  {
+    id: 'generic_update',
+    template: 'update',
+    description: 'Single word "update" descriptions',
+    category: 'generic_spam',
+    weight: 0.8,
+  },
+  {
+    id: 'generic_fix',
+    template: 'fix',
+    description: 'Single word "fix" descriptions',
+    category: 'generic_spam',
+    weight: 0.8,
+  },
+  {
+    id: 'generic_change',
+    template: 'change',
+    description: 'Single word "change" descriptions',
+    category: 'generic_spam',
+    weight: 0.8,
+  },
+  
+  // Automated/bot patterns
+  {
+    id: 'auto_dependency',
+    template: 'bump',
+    description: 'Dependency bump PRs without context',
+    category: 'automated',
+    weight: 0.4, // Lower weight as some automated updates are legitimate
+  },
+  {
+    id: 'auto_whitespace',
+    template: 'whitespace',
+    description: 'Whitespace-only changes',
+    category: 'automated',
+    weight: 0.6,
+  },
+];
+
+// Templates that should be checked for exact matches (100% similarity)
+export const EXACT_MATCH_TEMPLATES = [
+  'added my name',
+  'update',
+  'fix',
+  'change',
+  'hello world',
+  'test',
+  'first commit',
+  'initial commit',
+];
+
+// Regex patterns for common spam characteristics
+export const SPAM_PATTERNS = {
+  // Very short descriptions with no context
+  MINIMAL_EFFORT: /^(update|fix|change|test)\.?$/i,
+  
+  // Hacktoberfest specific patterns
+  HACKTOBERFEST: /hacktoberfest|added?\s+(my\s+)?name|name\s+add(ed)?/i,
+  
+  // Generic first contribution patterns  
+  FIRST_CONTRIB: /first\s+(contribution|commit|pr|pull\s+request)|hello\s+world/i,
+  
+  // Whitespace only changes
+  WHITESPACE_ONLY: /^\s*(whitespace|spaces?|tabs?|formatting)\s*$/i,
+  
+  // Single character or emoji only
+  SINGLE_CHAR: /^.{1,3}$/,
+  
+  // Common meaningless phrases
+  MEANINGLESS: /^(done|finished|complete|ok|good|nice|cool|awesome)\.?$/i,
+};
+
+export class TemplateDetector {
+  /**
+   * Calculate similarity between two strings using Levenshtein distance
+   */
+  private calculateSimilarity(str1: string, str2: string): number {
+    const len1 = str1.length;
+    const len2 = str2.length;
+    
+    if (len1 === 0) return len2;
+    if (len2 === 0) return len1;
+    
+    const matrix = Array(len2 + 1).fill(null).map(() => Array(len1 + 1).fill(null));
+    
+    for (let i = 0; i <= len1; i++) matrix[0][i] = i;
+    for (let j = 0; j <= len2; j++) matrix[j][0] = j;
+    
+    for (let j = 1; j <= len2; j++) {
+      for (let i = 1; i <= len1; i++) {
+        const indicator = str1[i - 1] === str2[j - 1] ? 0 : 1;
+        matrix[j][i] = Math.min(
+          matrix[j][i - 1] + 1,     // deletion
+          matrix[j - 1][i] + 1,     // insertion
+          matrix[j - 1][i - 1] + indicator // substitution
+        );
+      }
+    }
+    
+    const maxLen = Math.max(len1, len2);
+    return 1 - (matrix[len2][len1] / maxLen);
+  }
+  
+  /**
+   * Check if description matches any known spam templates
+   */
+  detectTemplateMatch(description: string): {
+    is_match: boolean;
+    template_id?: string;
+    similarity_score?: number;
+    template?: string;
+  } {
+    if (!description || description.trim().length === 0) {
+      return {
+        is_match: true,
+        template_id: 'empty_description',
+        similarity_score: 1.0,
+        template: '',
+      };
+    }
+    
+    const normalizedDesc = description.toLowerCase().trim().replace(/[^\w\s]/g, '').replace(/\s+/g, ' ');
+    const originalNormalized = description.toLowerCase().trim();
+    
+    // Check regex patterns first (more specific)
+    for (const [patternName, pattern] of Object.entries(SPAM_PATTERNS)) {
+      if (pattern.test(originalNormalized)) {
+        return {
+          is_match: true,
+          template_id: patternName.toLowerCase(),
+          similarity_score: 0.9,
+          template: originalNormalized,
+        };
+      }
+    }
+    
+    // Check exact matches (less specific) - but only for very short descriptions
+    if (normalizedDesc.split(' ').length <= 2) {
+      for (const template of EXACT_MATCH_TEMPLATES) {
+        const normalizedTemplate = template.toLowerCase().replace(/[^\w\s]/g, '');
+        if (normalizedDesc === normalizedTemplate) {
+          return {
+            is_match: true,
+            template_id: 'exact_match',
+            similarity_score: 1.0,
+            template,
+          };
+        }
+      }
+    }
+    
+    // Check template similarity
+    for (const template of COMMON_SPAM_TEMPLATES) {
+      const similarity = this.calculateSimilarity(normalizedDesc, template.template);
+      
+      if (similarity >= 0.8) {
+        return {
+          is_match: true,
+          template_id: template.id,
+          similarity_score: similarity,
+          template: template.template,
+        };
+      }
+    }
+    
+    return {
+      is_match: false,
+    };
+  }
+  
+  /**
+   * Get all matching templates with their similarity scores
+   */
+  getAllMatches(description: string): Array<{
+    template: SpamTemplate;
+    similarity: number;
+  }> {
+    if (!description) return [];
+    
+    const normalizedDesc = description.toLowerCase().trim();
+    const matches: Array<{ template: SpamTemplate; similarity: number }> = [];
+    
+    for (const template of COMMON_SPAM_TEMPLATES) {
+      const similarity = this.calculateSimilarity(normalizedDesc, template.template);
+      
+      if (similarity >= 0.5) {
+        matches.push({ template, similarity });
+      }
+    }
+    
+    return matches.sort((a, b) => b.similarity - a.similarity);
+  }
+}

--- a/src/lib/spam/types.ts
+++ b/src/lib/spam/types.ts
@@ -1,0 +1,99 @@
+// Spam detection types and interfaces
+
+export interface SpamFlags {
+  template_match?: {
+    is_match: boolean;
+    template_id?: string;
+    similarity_score?: number;
+  };
+  content_quality?: {
+    description_length: number;
+    has_meaningful_content: boolean;
+    quality_score: number;
+  };
+  account_flags?: {
+    account_age_days: number;
+    is_new_account: boolean;
+    has_profile_data: boolean;
+    contribution_history_score: number;
+  };
+  pr_characteristics?: {
+    size_vs_documentation_ratio: number;
+    files_changed: number;
+    has_context: boolean;
+    commit_quality_score: number;
+  };
+}
+
+export interface SpamDetectionResult {
+  spam_score: number; // 0-100
+  is_spam: boolean;
+  flags: SpamFlags;
+  detected_at: string;
+  confidence: number; // 0-1
+  reasons: string[];
+}
+
+export interface PullRequestData {
+  id: string;
+  title: string;
+  body?: string;
+  number: number;
+  additions: number;
+  deletions: number;
+  changed_files: number;
+  created_at: string;
+  html_url: string;
+  author: {
+    id: number;
+    login: string;
+    created_at?: string;
+    public_repos?: number;
+    followers?: number;
+    following?: number;
+    bio?: string;
+    company?: string;
+    location?: string;
+  };
+  repository: {
+    full_name: string;
+  };
+}
+
+export interface SpamTemplate {
+  id: string;
+  template: string;
+  description: string;
+  category: 'hacktoberfest' | 'first_contribution' | 'generic_spam' | 'automated';
+  weight: number;
+}
+
+// Spam thresholds configuration
+export const SPAM_THRESHOLDS = {
+  LEGITIMATE: 25,
+  WARNING: 50,
+  LIKELY_SPAM: 75,
+  DEFINITE_SPAM: 90,
+} as const;
+
+// Detection weights for different criteria
+export const DETECTION_WEIGHTS = {
+  TEMPLATE_MATCH: 0.4,
+  CONTENT_QUALITY: 0.3,
+  ACCOUNT_PATTERNS: 0.2,
+  PR_CHARACTERISTICS: 0.1,
+} as const;
+
+// Account age thresholds
+export const ACCOUNT_THRESHOLDS = {
+  NEW_ACCOUNT_DAYS: 30,
+  SUSPICIOUS_ACCOUNT_DAYS: 7,
+  MIN_PROFILE_SCORE: 0.3,
+} as const;
+
+// Content quality thresholds
+export const CONTENT_THRESHOLDS = {
+  MIN_DESCRIPTION_LENGTH: 20,
+  MEANINGFUL_CONTENT_RATIO: 0.5,
+  MAX_TEMPLATE_SIMILARITY: 0.9,
+} as const;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -129,14 +129,40 @@ export interface PullRequestActivity {
   type: ActivityType;
   user: User;
   pullRequest: {
-    id: string;
+    id: string | number;
     number: number;
     title: string;
+    body?: string;
+    state?: string;
+    draft?: boolean;
+    merged?: boolean;
+    mergeable?: boolean | null;
     url: string;
+    additions?: number;
+    deletions?: number;
+    changedFiles?: number;
+    commits?: number;
+    createdAt?: string;
+    updatedAt?: string;
+    closedAt?: string | null;
+    mergedAt?: string | null;
+    // Spam detection fields
+    spamScore?: number | null;
+    isSpam?: boolean;
+    spamFlags?: any;
   };
-  repository: Repository;
+  repository: Repository & {
+    fullName?: string;
+    private?: boolean;
+  };
   timestamp: string;
-  createdAt: Date;
+  createdAt?: Date;
+  // Additional metadata for spam detection
+  metadata?: {
+    spamScore?: number | null;
+    isSpam?: boolean;
+    spamDetectedAt?: string | null;
+  };
 }
 
 // Add TimeRange type for use in hooks

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1,0 +1,77 @@
+// Database types for spam detection
+export interface Database {
+  public: {
+    Tables: {
+      pull_requests: {
+        Row: {
+          id: string;
+          github_id: number;
+          number: number;
+          title: string;
+          body: string | null;
+          state: string;
+          repository_id: string;
+          author_id: string;
+          base_branch: string;
+          head_branch: string;
+          draft: boolean;
+          merged: boolean;
+          created_at: string;
+          updated_at: string;
+          merged_at: string | null;
+          closed_at: string | null;
+          additions: number;
+          deletions: number;
+          changed_files: number;
+          commits: number;
+          html_url: string;
+          spam_score: number | null;
+          spam_flags: any | null;
+          is_spam: boolean;
+          reviewed_by_admin: boolean;
+          spam_detected_at: string | null;
+        };
+      };
+      contributors: {
+        Row: {
+          id: string;
+          github_id: number;
+          username: string;
+          display_name: string;
+          avatar_url: string;
+          profile_url: string;
+          is_bot: boolean;
+          first_seen_at: string;
+          last_updated_at: string;
+          is_active: boolean;
+        };
+      };
+      repositories: {
+        Row: {
+          id: string;
+          github_id: number;
+          full_name: string;
+          owner: string;
+          name: string;
+          description: string | null;
+          homepage: string | null;
+          language: string | null;
+          stargazers_count: number;
+          watchers_count: number;
+          forks_count: number;
+          open_issues_count: number;
+          size: number;
+          default_branch: string;
+          is_fork: boolean;
+          is_private: boolean;
+          is_archived: boolean;
+          github_created_at: string;
+          github_updated_at: string;
+          github_pushed_at: string | null;
+          last_updated_at: string;
+          is_active: boolean;
+        };
+      };
+    };
+  };
+}

--- a/supabase/functions/_shared/spam-detection-integration.ts
+++ b/supabase/functions/_shared/spam-detection-integration.ts
@@ -1,0 +1,275 @@
+import { SpamDetectionService } from '../../../src/lib/spam/SpamDetectionService.ts';
+import { PullRequestData, SpamDetectionResult } from '../../../src/lib/spam/types.ts';
+
+// Singleton instance for performance
+let spamServiceInstance: SpamDetectionService | null = null;
+
+function getSpamService(): SpamDetectionService {
+  if (!spamServiceInstance) {
+    spamServiceInstance = new SpamDetectionService();
+  }
+  return spamServiceInstance;
+}
+
+// Convert GitHub API PR data to our PullRequestData format
+export function convertGitHubPRToSpamData(pr: any, author: any): PullRequestData {
+  return {
+    id: pr.id.toString(),
+    title: pr.title,
+    body: pr.body || '',
+    number: pr.number,
+    additions: pr.additions || 0,
+    deletions: pr.deletions || 0,
+    changed_files: pr.changed_files || 0,
+    created_at: pr.created_at,
+    html_url: pr.html_url,
+    author: {
+      id: author.id,
+      login: author.login,
+      created_at: author.created_at,
+      public_repos: author.public_repos,
+      followers: author.followers,
+      following: author.following,
+      bio: author.bio,
+      company: author.company,
+      location: author.location,
+    },
+    repository: {
+      full_name: `${pr.base?.repo?.full_name || 'unknown/unknown'}`,
+    },
+  };
+}
+
+// Process PR with spam detection
+export async function processPRWithSpamDetection(
+  supabase: any,
+  pr: any,
+  repositoryId: string,
+  spamService?: SpamDetectionService
+): Promise<{ success: boolean; spamResult?: SpamDetectionResult; error?: string }> {
+  const startTime = Date.now();
+  const author = pr.user;
+  
+  try {
+    // First ensure the contributor exists
+    const { data: contributor, error: contributorError } = await supabase
+      .from('contributors')
+      .upsert({
+        github_id: author.id,
+        username: author.login,
+        display_name: author.login,
+        avatar_url: author.avatar_url,
+        profile_url: author.html_url,
+        is_bot: author.type === 'Bot',
+        first_seen_at: new Date().toISOString(),
+        last_updated_at: new Date().toISOString(),
+        is_active: true
+      }, {
+        onConflict: 'github_id',
+        ignoreDuplicates: false
+      })
+      .select()
+      .single()
+    
+    if (contributorError) {
+      console.error(`[Spam Detection] Error upserting contributor ${author.login}:`, contributorError)
+      return { success: false, error: contributorError.message };
+    }
+    
+    // Convert PR data for spam detection
+    const prData = convertGitHubPRToSpamData(pr, author);
+    
+    // Run spam detection (use singleton if not provided)
+    const service = spamService || getSpamService();
+    const spamResult = await service.detectSpam(prData);
+    
+    // Log performance warning if too slow
+    const detectionTime = Date.now() - startTime;
+    if (detectionTime > 100) {
+      console.warn(`[Spam Detection] Slow detection for PR #${pr.number}: ${detectionTime}ms`);
+    }
+    
+    // Create/update the pull request with spam detection results
+    const { error: prError } = await supabase
+      .from('pull_requests')
+      .upsert({
+        github_id: pr.id,
+        number: pr.number,
+        title: pr.title,
+        body: pr.body,
+        state: pr.state,
+        repository_id: repositoryId,
+        author_id: contributor.id,
+        base_branch: pr.base?.ref || 'main',
+        head_branch: pr.head?.ref || 'unknown',
+        draft: pr.draft || false,
+        merged: pr.merged || false,
+        created_at: pr.created_at,
+        updated_at: pr.updated_at,
+        merged_at: pr.merged_at,
+        closed_at: pr.closed_at,
+        additions: pr.additions || 0,
+        deletions: pr.deletions || 0,
+        changed_files: pr.changed_files || 0,
+        commits: pr.commits || 0,
+        html_url: pr.html_url,
+        // Add spam detection fields
+        spam_score: spamResult.spam_score,
+        spam_flags: spamResult.flags,
+        is_spam: spamResult.is_spam,
+        spam_detected_at: spamResult.detected_at
+      }, {
+        onConflict: 'github_id',
+        ignoreDuplicates: false
+      })
+    
+    if (prError) {
+      console.error(`[Spam Detection] Error upserting pull request #${pr.number}:`, prError)
+      return { success: false, error: prError.message };
+    }
+    
+    console.log(`[Spam Detection] PR #${pr.number} processed - Spam Score: ${spamResult.spam_score}, Is Spam: ${spamResult.is_spam}`);
+    
+    return { success: true, spamResult };
+  } catch (error) {
+    console.error(`[Spam Detection] Error processing PR #${pr.number}:`, error)
+    return { success: false, error: error.message };
+  }
+}
+
+// Batch process existing PRs for spam detection
+export async function batchProcessPRsForSpam(
+  supabase: any,
+  repositoryId: string,
+  limit: number = 100
+): Promise<{ processed: number; errors: number }> {
+  const spamService = getSpamService(); // Use singleton for performance
+  let processed = 0;
+  let errors = 0;
+  let offset = 0;
+  const batchSize = 10; // Process 10 PRs concurrently for better performance
+  
+  console.log(`[Spam Detection] Starting batch processing for repository ${repositoryId}`);
+  
+  while (true) {
+    // Fetch PRs without spam scores
+    const { data: prs, error: fetchError } = await supabase
+      .from('pull_requests')
+      .select(`
+        id,
+        github_id,
+        number,
+        title,
+        body,
+        additions,
+        deletions,
+        changed_files,
+        created_at,
+        html_url,
+        author:contributors(
+          id,
+          github_id,
+          username,
+          created_at,
+          first_seen_at
+        ),
+        repository:repositories(
+          full_name
+        )
+      `)
+      .eq('repository_id', repositoryId)
+      .is('spam_score', null)
+      .order('created_at', { ascending: false })
+      .range(offset, offset + limit - 1);
+    
+    if (fetchError) {
+      console.error(`[Spam Detection] Error fetching PRs:`, fetchError);
+      break;
+    }
+    
+    if (!prs || prs.length === 0) {
+      break;
+    }
+    
+    // Process PRs in concurrent batches for better performance
+    for (let i = 0; i < prs.length; i += batchSize) {
+      const batch = prs.slice(i, i + batchSize);
+      const batchPromises = batch.map(async (pr) => {
+        try {
+          // Convert to spam detection format
+          const prData: PullRequestData = {
+            id: pr.id,
+            title: pr.title,
+            body: pr.body || '',
+            number: pr.number,
+            additions: pr.additions,
+            deletions: pr.deletions,
+            changed_files: pr.changed_files,
+            created_at: pr.created_at,
+            html_url: pr.html_url,
+            author: {
+              id: pr.author.github_id,
+              login: pr.author.username,
+              created_at: pr.author.created_at || pr.author.first_seen_at,
+              // These fields might not be available in DB, but that's ok
+              public_repos: undefined,
+              followers: undefined,
+              following: undefined,
+              bio: undefined,
+              company: undefined,
+              location: undefined,
+            },
+            repository: {
+              full_name: pr.repository.full_name,
+            },
+          };
+          
+          // Run spam detection
+          const spamResult = await spamService.detectSpam(prData);
+          
+          // Update PR with spam detection results
+          const { error: updateError } = await supabase
+            .from('pull_requests')
+            .update({
+              spam_score: spamResult.spam_score,
+              spam_flags: spamResult.flags,
+              is_spam: spamResult.is_spam,
+              spam_detected_at: spamResult.detected_at
+            })
+            .eq('id', pr.id);
+          
+          if (updateError) {
+            console.error(`[Spam Detection] Error updating PR ${pr.number}:`, updateError);
+            return { success: false, prNumber: pr.number };
+          } else {
+            return { success: true, prNumber: pr.number };
+          }
+        } catch (error) {
+          console.error(`[Spam Detection] Error processing PR ${pr.number}:`, error);
+          return { success: false, prNumber: pr.number };
+        }
+      });
+      
+      // Wait for batch to complete
+      const results = await Promise.all(batchPromises);
+      
+      // Count successes and failures
+      results.forEach(result => {
+        if (result.success) {
+          processed++;
+        } else {
+          errors++;
+        }
+      });
+      
+      // Log progress
+      console.log(`[Spam Detection] Batch complete. Total processed: ${processed}, errors: ${errors}`);
+    }
+    
+    offset += limit;
+  }
+  
+  console.log(`[Spam Detection] Batch processing complete. Processed: ${processed}, Errors: ${errors}`);
+  
+  return { processed, errors };
+}

--- a/supabase/functions/_shared/spam-detection-integration.ts
+++ b/supabase/functions/_shared/spam-detection-integration.ts
@@ -166,7 +166,7 @@ export async function batchProcessPRsForSpam(
         changed_files,
         created_at,
         html_url,
-        author:contributors(
+        author:contributors!fk_pull_requests_author(
           id,
           github_id,
           username,

--- a/supabase/functions/backfill-pr-stats/index.ts
+++ b/supabase/functions/backfill-pr-stats/index.ts
@@ -1,0 +1,188 @@
+// Backfill PR Statistics
+// This function fetches missing additions, deletions, and changed_files for existing PRs
+
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+interface PRToUpdate {
+  id: string;
+  github_id: number;
+  number: number;
+  repository_owner: string;
+  repository_name: string;
+  html_url: string;
+}
+
+Deno.serve(async (req) => {
+  // Handle CORS
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!
+    const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    const githubToken = Deno.env.get('GITHUB_TOKEN')
+    
+    if (!githubToken) {
+      return new Response(
+        JSON.stringify({ error: 'GITHUB_TOKEN not configured' }), 
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseServiceKey)
+
+    // Get query parameters
+    const url = new URL(req.url)
+    const batchSize = parseInt(url.searchParams.get('batch_size') || '50')
+    const maxBatches = parseInt(url.searchParams.get('max_batches') || '10')
+    
+    console.log(`[Backfill] Starting with batch_size=${batchSize}, max_batches=${maxBatches}`)
+
+    let totalProcessed = 0
+    let totalErrors = 0
+    let batchCount = 0
+
+    while (batchCount < maxBatches) {
+      // Get PRs that need stats (additions=0, deletions=0, changed_files=0)
+      const { data: prsToUpdate, error: fetchError } = await supabase
+        .from('pull_requests')
+        .select(`
+          id,
+          github_id,
+          number,
+          repositories!repository_id(owner, name)
+        `)
+        .eq('additions', 0)
+        .eq('deletions', 0)
+        .eq('changed_files', 0)
+        .limit(batchSize)
+
+      if (fetchError) {
+        console.error('[Backfill] Error fetching PRs:', fetchError)
+        break
+      }
+
+      if (!prsToUpdate || prsToUpdate.length === 0) {
+        console.log('[Backfill] No more PRs to update')
+        break
+      }
+
+      console.log(`[Backfill] Processing batch ${batchCount + 1}: ${prsToUpdate.length} PRs`)
+
+      // Process each PR in the batch
+      for (const pr of prsToUpdate) {
+        try {
+          const repo = pr.repositories as any
+          if (!repo?.owner || !repo?.name) {
+            console.warn(`[Backfill] Skipping PR ${pr.number} - missing repository info`)
+            console.log(`[Backfill] PR data:`, JSON.stringify(pr, null, 2))
+            totalErrors++
+            continue
+          }
+
+          // Fetch detailed PR data from GitHub
+          const response = await fetch(
+            `https://api.github.com/repos/${repo.owner}/${repo.name}/pulls/${pr.number}`,
+            {
+              headers: {
+                'Authorization': `token ${githubToken}`,
+                'Accept': 'application/vnd.github.v3+json'
+              }
+            }
+          )
+
+          if (!response.ok) {
+            if (response.status === 404) {
+              console.warn(`[Backfill] PR ${repo.owner}/${repo.name}#${pr.number} not found (deleted?)`)
+            } else if (response.status === 403) {
+              console.warn(`[Backfill] Rate limited or forbidden for ${repo.owner}/${repo.name}#${pr.number}`)
+              // Break out of batch to avoid hitting rate limits harder
+              break
+            } else {
+              console.error(`[Backfill] Failed to fetch ${repo.owner}/${repo.name}#${pr.number}: ${response.status}`)
+            }
+            totalErrors++
+            continue
+          }
+
+          const detailedPR = await response.json()
+
+          // Update the PR with detailed stats
+          const { error: updateError } = await supabase
+            .from('pull_requests')
+            .update({
+              additions: detailedPR.additions || 0,
+              deletions: detailedPR.deletions || 0,
+              changed_files: detailedPR.changed_files || 0,
+              commits: detailedPR.commits || 0
+            })
+            .eq('id', pr.id)
+
+          if (updateError) {
+            console.error(`[Backfill] Error updating PR ${pr.number}:`, updateError)
+            totalErrors++
+          } else {
+            console.log(`[Backfill] Updated PR ${repo.owner}/${repo.name}#${pr.number}: +${detailedPR.additions}/-${detailedPR.deletions}, ${detailedPR.changed_files} files`)
+            totalProcessed++
+          }
+
+          // Small delay to be respectful to GitHub API
+          await new Promise(resolve => setTimeout(resolve, 100))
+
+        } catch (error) {
+          console.error(`[Backfill] Error processing PR ${pr.number}:`, error)
+          totalErrors++
+        }
+      }
+
+      batchCount++
+      console.log(`[Backfill] Completed batch ${batchCount}/${maxBatches}`)
+
+      // Short delay between batches
+      await new Promise(resolve => setTimeout(resolve, 1000))
+    }
+
+    const result = {
+      success: true,
+      batches_processed: batchCount,
+      prs_updated: totalProcessed,
+      errors: totalErrors,
+      message: `Successfully processed ${totalProcessed} PRs with ${totalErrors} errors across ${batchCount} batches`
+    }
+
+    console.log('[Backfill] Final result:', result)
+
+    return new Response(
+      JSON.stringify(result),
+      { 
+        headers: { 
+          ...corsHeaders, 
+          'Content-Type': 'application/json' 
+        } 
+      }
+    )
+
+  } catch (error) {
+    console.error('[Backfill] Unexpected error:', error)
+    
+    return new Response(
+      JSON.stringify({ 
+        error: 'Internal server error', 
+        details: error.message 
+      }),
+      { 
+        status: 500, 
+        headers: { 
+          ...corsHeaders, 
+          'Content-Type': 'application/json' 
+        } 
+      }
+    )
+  }
+})

--- a/supabase/functions/github-sync/index.ts
+++ b/supabase/functions/github-sync/index.ts
@@ -8,6 +8,10 @@ import {
 import { 
   batchUpdateConfidenceScores 
 } from '../_shared/confidence-scoring.ts'
+import { 
+  processPRWithSpamDetection, 
+  batchProcessPRsForSpam 
+} from '../_shared/spam-detection-integration.ts'
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -179,68 +183,11 @@ async function processPullRequestData(
   pr: any,
   repositoryId: string
 ) {
-  const author = pr.user
+  // Use the spam detection version (will use singleton internally)
+  const result = await processPRWithSpamDetection(supabase, pr, repositoryId);
   
-  try {
-    // First ensure the contributor exists
-    const { data: contributor, error: contributorError } = await supabase
-      .from('contributors')
-      .upsert({
-        github_id: author.id,
-        username: author.login,
-        display_name: author.login,
-        avatar_url: author.avatar_url,
-        profile_url: author.html_url,
-        is_bot: author.type === 'Bot',
-        first_seen_at: new Date().toISOString(),
-        last_updated_at: new Date().toISOString(),
-        is_active: true
-      }, {
-        onConflict: 'github_id',
-        ignoreDuplicates: false
-      })
-      .select()
-      .single()
-    
-    if (contributorError) {
-      console.error(`[GitHub Sync] Error upserting contributor ${author.login}:`, contributorError)
-      return
-    }
-    
-    // Then create/update the pull request
-    const { error: prError } = await supabase
-      .from('pull_requests')
-      .upsert({
-        github_id: pr.id,
-        number: pr.number,
-        title: pr.title,
-        body: pr.body,
-        state: pr.state,
-        repository_id: repositoryId,
-        author_id: contributor.id,
-        base_branch: pr.base?.ref || 'main',
-        head_branch: pr.head?.ref || 'unknown',
-        draft: pr.draft || false,
-        merged: pr.merged || false,
-        created_at: pr.created_at,
-        updated_at: pr.updated_at,
-        merged_at: pr.merged_at,
-        closed_at: pr.closed_at,
-        additions: pr.additions || 0,
-        deletions: pr.deletions || 0,
-        changed_files: pr.changed_files || 0,
-        commits: pr.commits || 0,
-        html_url: pr.html_url
-      }, {
-        onConflict: 'github_id',
-        ignoreDuplicates: false
-      })
-    
-    if (prError) {
-      console.error(`[GitHub Sync] Error upserting pull request #${pr.number}:`, prError)
-    }
-  } catch (error) {
-    console.error(`[GitHub Sync] Error processing pull request #${pr.number}:`, error)
+  if (!result.success) {
+    console.error(`[GitHub Sync] Error processing pull request #${pr.number}:`, result.error);
   }
 }
 
@@ -253,70 +200,14 @@ async function processPullRequestEvent(
   repo: string
 ) {
   const pr = event.payload.pull_request
-  const author = pr.user
   
-  try {
-    // First ensure the contributor exists
-    const { data: contributor, error: contributorError } = await supabase
-      .from('contributors')
-      .upsert({
-        github_id: author.id,
-        username: author.login,
-        display_name: author.login,
-        avatar_url: author.avatar_url,
-        profile_url: author.html_url,
-        is_bot: author.type === 'Bot',
-        first_seen_at: new Date().toISOString(),
-        last_updated_at: new Date().toISOString(),
-        is_active: true
-      }, {
-        onConflict: 'github_id',
-        ignoreDuplicates: false
-      })
-      .select()
-      .single()
-    
-    if (contributorError) {
-      console.error(`[GitHub Sync] Error upserting contributor ${author.login}:`, contributorError)
-      return
-    }
-    
-    // Then create/update the pull request
-    const { error: prError } = await supabase
-      .from('pull_requests')
-      .upsert({
-        github_id: pr.id,
-        number: pr.number,
-        title: pr.title,
-        body: pr.body,
-        state: pr.state,
-        repository_id: repositoryId,
-        author_id: contributor.id,
-        base_branch: pr.base?.ref || 'main',
-        head_branch: pr.head?.ref || 'unknown',
-        draft: pr.draft || false,
-        merged: pr.merged || false,
-        created_at: pr.created_at,
-        updated_at: pr.updated_at,
-        merged_at: pr.merged_at,
-        closed_at: pr.closed_at,
-        additions: pr.additions || 0,
-        deletions: pr.deletions || 0,
-        changed_files: pr.changed_files || 0,
-        commits: pr.commits || 0,
-        html_url: pr.html_url
-      }, {
-        onConflict: 'github_id',
-        ignoreDuplicates: false
-      })
-    
-    if (prError) {
-      console.error(`[GitHub Sync] Error upserting pull request #${pr.number}:`, prError)
-    } else {
-      console.log(`[GitHub Sync] Processed pull request #${pr.number} by ${author.login}`)
-    }
-  } catch (error) {
-    console.error(`[GitHub Sync] Error processing pull request event:`, error)
+  // Use the spam detection version (will use singleton internally)
+  const result = await processPRWithSpamDetection(supabase, pr, repositoryId);
+  
+  if (!result.success) {
+    console.error(`[GitHub Sync] Error processing pull request event:`, result.error);
+  } else {
+    console.log(`[GitHub Sync] Processed pull request #${pr.number} by ${pr.user.login} - Spam Score: ${result.spamResult?.spam_score}`);
   }
 }
 
@@ -551,6 +442,20 @@ serve(async (req) => {
         
         // Fetch and process pull requests directly from GitHub API
         await fetchAndProcessPullRequests(supabase, repo.owner, repo.name, github_token)
+        
+        // Batch process existing PRs for spam detection (for PRs that might not have spam scores)
+        const { data: repoData } = await supabase
+          .from('repositories')
+          .select('id')
+          .eq('owner', repo.owner)
+          .eq('name', repo.name)
+          .single()
+          
+        if (repoData) {
+          console.log(`[GitHub Sync] Running batch spam detection for existing PRs in ${repo.owner}/${repo.name}`)
+          const { processed, errors } = await batchProcessPRsForSpam(supabase, repoData.id, 50) // Process 50 at a time
+          console.log(`[GitHub Sync] Spam detection complete: ${processed} processed, ${errors} errors`)
+        }
         
         // Update confidence scores for all contributors
         await batchUpdateConfidenceScores(supabase, repo.owner, repo.name)

--- a/supabase/functions/spam-detection/index.ts
+++ b/supabase/functions/spam-detection/index.ts
@@ -71,7 +71,7 @@ serve(async (req) => {
           created_at,
           html_url,
           spam_score,
-          author:contributors(
+          author:contributors!fk_pull_requests_author(
             id,
             github_id,
             username,

--- a/supabase/functions/spam-detection/index.ts
+++ b/supabase/functions/spam-detection/index.ts
@@ -1,0 +1,263 @@
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { SpamDetectionService } from '../../../src/lib/spam/SpamDetectionService.ts'
+import { PullRequestData } from '../../../src/lib/spam/types.ts'
+import { batchProcessPRsForSpam } from '../_shared/spam-detection-integration.ts'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+interface SpamDetectionRequest {
+  // Single PR detection
+  pr_id?: string;
+  
+  // Batch detection
+  repository_id?: string;
+  repository_owner?: string;
+  repository_name?: string;
+  
+  // Options
+  limit?: number;
+  force_recheck?: boolean; // Re-analyze PRs that already have spam scores
+}
+
+serve(async (req) => {
+  // Handle CORS
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  console.log('[Spam Detection] Received spam detection request')
+
+  try {
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    )
+
+    // Parse request body
+    const body: SpamDetectionRequest = await req.json().catch(() => ({}))
+    const { pr_id, repository_id, repository_owner, repository_name, limit = 100, force_recheck = false } = body
+    
+    console.log('[Spam Detection] Request:', { 
+      pr_id, 
+      repository_id,
+      repository_owner,
+      repository_name,
+      limit,
+      force_recheck
+    })
+
+    const spamService = new SpamDetectionService();
+
+    // Single PR detection
+    if (pr_id) {
+      console.log(`[Spam Detection] Analyzing single PR: ${pr_id}`)
+      
+      // Fetch PR data with all necessary joins
+      const { data: pr, error: prError } = await supabase
+        .from('pull_requests')
+        .select(`
+          id,
+          github_id,
+          number,
+          title,
+          body,
+          additions,
+          deletions,
+          changed_files,
+          created_at,
+          html_url,
+          spam_score,
+          author:contributors(
+            id,
+            github_id,
+            username,
+            created_at,
+            first_seen_at
+          ),
+          repository:repositories(
+            full_name
+          )
+        `)
+        .eq('id', pr_id)
+        .single()
+      
+      if (prError || !pr) {
+        throw new Error(`Pull request not found: ${pr_id}`)
+      }
+      
+      // Skip if already has spam score and not forcing recheck
+      if (pr.spam_score !== null && !force_recheck) {
+        return new Response(
+          JSON.stringify({ 
+            success: true,
+            message: 'PR already has spam score',
+            spam_score: pr.spam_score
+          }),
+          { 
+            headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+            status: 200 
+          }
+        )
+      }
+      
+      // Convert to spam detection format
+      const prData: PullRequestData = {
+        id: pr.id,
+        title: pr.title,
+        body: pr.body || '',
+        number: pr.number,
+        additions: pr.additions,
+        deletions: pr.deletions,
+        changed_files: pr.changed_files,
+        created_at: pr.created_at,
+        html_url: pr.html_url,
+        author: {
+          id: pr.author.github_id,
+          login: pr.author.username,
+          created_at: pr.author.created_at || pr.author.first_seen_at,
+        },
+        repository: {
+          full_name: pr.repository.full_name,
+        },
+      };
+      
+      // Run spam detection
+      const spamResult = await spamService.detectSpam(prData);
+      
+      // Update PR with spam detection results
+      const { error: updateError } = await supabase
+        .from('pull_requests')
+        .update({
+          spam_score: spamResult.spam_score,
+          spam_flags: spamResult.flags,
+          is_spam: spamResult.is_spam,
+          spam_detected_at: spamResult.detected_at
+        })
+        .eq('id', pr.id);
+      
+      if (updateError) {
+        throw new Error(`Failed to update PR: ${updateError.message}`)
+      }
+      
+      return new Response(
+        JSON.stringify({ 
+          success: true,
+          pr_id: pr.id,
+          pr_number: pr.number,
+          spam_result: spamResult
+        }),
+        { 
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+          status: 200 
+        }
+      )
+    }
+    
+    // Batch detection for repository
+    if (repository_id || (repository_owner && repository_name)) {
+      let repoId = repository_id;
+      
+      // If we have owner/name but not ID, look it up
+      if (!repoId && repository_owner && repository_name) {
+        const { data: repo, error: repoError } = await supabase
+          .from('repositories')
+          .select('id')
+          .eq('owner', repository_owner)
+          .eq('name', repository_name)
+          .single()
+        
+        if (repoError || !repo) {
+          throw new Error(`Repository not found: ${repository_owner}/${repository_name}`)
+        }
+        
+        repoId = repo.id;
+      }
+      
+      console.log(`[Spam Detection] Running batch detection for repository: ${repoId}`)
+      
+      // If force_recheck is true, clear existing spam scores first
+      if (force_recheck) {
+        console.log('[Spam Detection] Force recheck enabled, clearing existing spam scores')
+        const { error: clearError } = await supabase
+          .from('pull_requests')
+          .update({
+            spam_score: null,
+            spam_flags: null,
+            is_spam: null,
+            spam_detected_at: null
+          })
+          .eq('repository_id', repoId)
+        
+        if (clearError) {
+          console.warn('[Spam Detection] Error clearing spam scores:', clearError)
+        }
+      }
+      
+      // Run batch processing
+      const { processed, errors } = await batchProcessPRsForSpam(supabase, repoId, limit)
+      
+      // Get summary statistics
+      const { data: stats, error: statsError } = await supabase
+        .from('pull_requests')
+        .select('spam_score, is_spam')
+        .eq('repository_id', repoId)
+        .not('spam_score', 'is', null)
+      
+      let avgScore = 0;
+      let spamCount = 0;
+      
+      if (stats && stats.length > 0) {
+        avgScore = stats.reduce((sum, pr) => sum + pr.spam_score, 0) / stats.length;
+        spamCount = stats.filter(pr => pr.is_spam).length;
+      }
+      
+      return new Response(
+        JSON.stringify({ 
+          success: true,
+          repository_id: repoId,
+          processed,
+          errors,
+          stats: {
+            total_analyzed: stats?.length || 0,
+            spam_count: spamCount,
+            spam_percentage: stats?.length ? (spamCount / stats.length) * 100 : 0,
+            avg_spam_score: Math.round(avgScore * 10) / 10
+          }
+        }),
+        { 
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+          status: 200 
+        }
+      )
+    }
+    
+    // No valid parameters provided
+    return new Response(
+      JSON.stringify({ 
+        success: false,
+        error: 'Invalid request. Provide either pr_id or repository details.' 
+      }),
+      { 
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: 400 
+      }
+    )
+
+  } catch (error) {
+    console.error('[Spam Detection] Error:', error)
+    return new Response(
+      JSON.stringify({ 
+        success: false,
+        error: error.message 
+      }),
+      { 
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        status: 500 
+      }
+    )
+  }
+})

--- a/supabase/migrations/20240115000000_add_spam_detection_fields.sql
+++ b/supabase/migrations/20240115000000_add_spam_detection_fields.sql
@@ -1,0 +1,19 @@
+-- Add spam detection fields to pull_requests table
+ALTER TABLE pull_requests 
+ADD COLUMN IF NOT EXISTS spam_score INTEGER DEFAULT NULL,
+ADD COLUMN IF NOT EXISTS spam_flags JSONB DEFAULT NULL,
+ADD COLUMN IF NOT EXISTS is_spam BOOLEAN DEFAULT FALSE,
+ADD COLUMN IF NOT EXISTS reviewed_by_admin BOOLEAN DEFAULT FALSE,
+ADD COLUMN IF NOT EXISTS spam_detected_at TIMESTAMP WITH TIME ZONE DEFAULT NULL;
+
+-- Create indexes for efficient querying
+CREATE INDEX IF NOT EXISTS idx_pull_requests_spam_score ON pull_requests(spam_score);
+CREATE INDEX IF NOT EXISTS idx_pull_requests_is_spam ON pull_requests(is_spam);
+CREATE INDEX IF NOT EXISTS idx_pull_requests_repository_spam ON pull_requests(repository_id, is_spam);
+
+-- Add comment to explain spam score range
+COMMENT ON COLUMN pull_requests.spam_score IS 'Spam detection score from 0-100. 0=legitimate, 100=definite spam';
+COMMENT ON COLUMN pull_requests.spam_flags IS 'Detailed spam detection flags as JSONB';
+COMMENT ON COLUMN pull_requests.is_spam IS 'Whether PR is classified as spam (score >= 75)';
+COMMENT ON COLUMN pull_requests.reviewed_by_admin IS 'Whether an admin has manually reviewed this spam classification';
+COMMENT ON COLUMN pull_requests.spam_detected_at IS 'Timestamp when spam detection was performed';

--- a/supabase/migrations/20250629000000_add_admin_system.sql
+++ b/supabase/migrations/20250629000000_add_admin_system.sql
@@ -1,0 +1,387 @@
+-- Admin System Database Schema Migration
+-- Creates user management and role-based access control system
+-- This enables database-driven admin permissions for user "bdougie"
+
+-- Enable UUID extension if not already enabled
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- =====================================================
+-- ADMIN SYSTEM TABLES
+-- =====================================================
+
+-- 1. App Users table - tracks application users linked to Supabase Auth
+CREATE TABLE app_users (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    auth_user_id UUID UNIQUE, -- References auth.users(id) but not enforced due to auth schema
+    github_username TEXT UNIQUE NOT NULL,
+    github_user_id BIGINT UNIQUE, -- GitHub user ID for reliable identification
+    email TEXT,
+    avatar_url TEXT,
+    display_name TEXT,
+    is_admin BOOLEAN DEFAULT FALSE,
+    is_active BOOLEAN DEFAULT TRUE,
+    first_login_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_login_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- 2. User Roles table - flexible role management system
+CREATE TABLE user_roles (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES app_users(id) ON DELETE CASCADE,
+    role TEXT NOT NULL CHECK (role IN ('admin', 'moderator', 'user')),
+    granted_by UUID REFERENCES app_users(id), -- who granted this role
+    granted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    revoked_at TIMESTAMPTZ,
+    revoked_by UUID REFERENCES app_users(id),
+    is_active BOOLEAN DEFAULT TRUE,
+    
+    -- Unique constraint to prevent duplicate active roles
+    CONSTRAINT unique_active_user_role UNIQUE (user_id, role, is_active)
+);
+
+-- 3. Admin Action Logs table - audit trail for admin actions
+CREATE TABLE admin_action_logs (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    admin_user_id UUID NOT NULL REFERENCES app_users(id),
+    action_type TEXT NOT NULL CHECK (action_type IN (
+        'grant_role', 'revoke_role', 'create_user', 'update_user', 
+        'deactivate_user', 'activate_user', 'system_config'
+    )),
+    target_user_id UUID REFERENCES app_users(id), -- user affected by action
+    action_details JSONB, -- additional context about the action
+    ip_address INET,
+    user_agent TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- =====================================================
+-- INDEXES FOR PERFORMANCE
+-- =====================================================
+
+-- App users indexes
+CREATE INDEX idx_app_users_auth_user_id ON app_users(auth_user_id);
+CREATE INDEX idx_app_users_github_username ON app_users(github_username);
+CREATE INDEX idx_app_users_github_user_id ON app_users(github_user_id);
+CREATE INDEX idx_app_users_is_admin ON app_users(is_admin) WHERE is_admin = TRUE;
+CREATE INDEX idx_app_users_active ON app_users(is_active) WHERE is_active = TRUE;
+
+-- User roles indexes
+CREATE INDEX idx_user_roles_user_id ON user_roles(user_id);
+CREATE INDEX idx_user_roles_role ON user_roles(role);
+CREATE INDEX idx_user_roles_active ON user_roles(is_active) WHERE is_active = TRUE;
+CREATE INDEX idx_user_roles_user_role_active ON user_roles(user_id, role, is_active);
+
+-- Admin action logs indexes
+CREATE INDEX idx_admin_logs_admin_user ON admin_action_logs(admin_user_id);
+CREATE INDEX idx_admin_logs_target_user ON admin_action_logs(target_user_id);
+CREATE INDEX idx_admin_logs_action_type ON admin_action_logs(action_type);
+CREATE INDEX idx_admin_logs_created_at ON admin_action_logs(created_at DESC);
+
+-- =====================================================
+-- FUNCTIONS FOR ADMIN OPERATIONS
+-- =====================================================
+
+-- Function to check if a user is an admin
+CREATE OR REPLACE FUNCTION is_user_admin(user_github_username TEXT)
+RETURNS BOOLEAN AS $$
+DECLARE
+    admin_status BOOLEAN := FALSE;
+BEGIN
+    SELECT is_admin INTO admin_status
+    FROM app_users
+    WHERE github_username = user_github_username
+      AND is_active = TRUE;
+    
+    RETURN COALESCE(admin_status, FALSE);
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+-- Function to check if a user has a specific role
+CREATE OR REPLACE FUNCTION user_has_role(user_github_username TEXT, role_name TEXT)
+RETURNS BOOLEAN AS $$
+DECLARE
+    has_role BOOLEAN := FALSE;
+BEGIN
+    SELECT EXISTS(
+        SELECT 1
+        FROM app_users au
+        JOIN user_roles ur ON au.id = ur.user_id
+        WHERE au.github_username = user_github_username
+          AND au.is_active = TRUE
+          AND ur.role = role_name
+          AND ur.is_active = TRUE
+    ) INTO has_role;
+    
+    RETURN has_role;
+END;
+$$ LANGUAGE plpgsql STABLE;
+
+-- Function to create or update app user from GitHub OAuth data
+CREATE OR REPLACE FUNCTION upsert_app_user(
+    p_auth_user_id UUID,
+    p_github_username TEXT,
+    p_github_user_id BIGINT,
+    p_email TEXT DEFAULT NULL,
+    p_avatar_url TEXT DEFAULT NULL,
+    p_display_name TEXT DEFAULT NULL
+)
+RETURNS UUID AS $$
+DECLARE
+    user_id UUID;
+    is_new_user BOOLEAN := FALSE;
+BEGIN
+    -- Try to find existing user by GitHub username or auth_user_id
+    SELECT id INTO user_id
+    FROM app_users
+    WHERE github_username = p_github_username
+       OR auth_user_id = p_auth_user_id;
+    
+    IF user_id IS NULL THEN
+        -- Create new user
+        INSERT INTO app_users (
+            auth_user_id, github_username, github_user_id,
+            email, avatar_url, display_name
+        )
+        VALUES (
+            p_auth_user_id, p_github_username, p_github_user_id,
+            p_email, p_avatar_url, p_display_name
+        )
+        RETURNING id INTO user_id;
+        
+        is_new_user := TRUE;
+    ELSE
+        -- Update existing user
+        UPDATE app_users
+        SET 
+            auth_user_id = p_auth_user_id,
+            github_user_id = p_github_user_id,
+            email = COALESCE(p_email, email),
+            avatar_url = COALESCE(p_avatar_url, avatar_url),
+            display_name = COALESCE(p_display_name, display_name),
+            last_login_at = NOW(),
+            updated_at = NOW()
+        WHERE id = user_id;
+    END IF;
+    
+    -- Assign default 'user' role if new user
+    IF is_new_user THEN
+        INSERT INTO user_roles (user_id, role)
+        VALUES (user_id, 'user');
+    END IF;
+    
+    RETURN user_id;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Function to grant a role to a user
+CREATE OR REPLACE FUNCTION grant_user_role(
+    target_username TEXT,
+    role_name TEXT,
+    granted_by_username TEXT
+)
+RETURNS BOOLEAN AS $$
+DECLARE
+    target_user_id UUID;
+    granter_user_id UUID;
+    granter_is_admin BOOLEAN;
+BEGIN
+    -- Get target user ID
+    SELECT id INTO target_user_id
+    FROM app_users
+    WHERE github_username = target_username AND is_active = TRUE;
+    
+    IF target_user_id IS NULL THEN
+        RAISE EXCEPTION 'Target user not found: %', target_username;
+    END IF;
+    
+    -- Get granter user ID and check admin status
+    SELECT id, is_admin INTO granter_user_id, granter_is_admin
+    FROM app_users
+    WHERE github_username = granted_by_username AND is_active = TRUE;
+    
+    IF granter_user_id IS NULL THEN
+        RAISE EXCEPTION 'Granter user not found: %', granted_by_username;
+    END IF;
+    
+    IF NOT granter_is_admin THEN
+        RAISE EXCEPTION 'User % is not authorized to grant roles', granted_by_username;
+    END IF;
+    
+    -- Deactivate any existing role of the same type
+    UPDATE user_roles
+    SET is_active = FALSE,
+        revoked_at = NOW(),
+        revoked_by = granter_user_id
+    WHERE user_id = target_user_id
+      AND role = role_name
+      AND is_active = TRUE;
+    
+    -- Grant the new role
+    INSERT INTO user_roles (user_id, role, granted_by)
+    VALUES (target_user_id, role_name, granter_user_id);
+    
+    -- Update admin status if granting admin role
+    IF role_name = 'admin' THEN
+        UPDATE app_users
+        SET is_admin = TRUE, updated_at = NOW()
+        WHERE id = target_user_id;
+    END IF;
+    
+    -- Log the action
+    INSERT INTO admin_action_logs (
+        admin_user_id, action_type, target_user_id,
+        action_details
+    )
+    VALUES (
+        granter_user_id, 'grant_role', target_user_id,
+        jsonb_build_object('role', role_name, 'target_username', target_username)
+    );
+    
+    RETURN TRUE;
+END;
+$$ LANGUAGE plpgsql;
+
+-- =====================================================
+-- BOOTSTRAP ADMIN USER
+-- =====================================================
+
+-- Bootstrap "bdougie" as the initial admin user
+-- This will be updated when the user first logs in via OAuth
+INSERT INTO app_users (
+    github_username,
+    github_user_id,
+    email,
+    display_name,
+    is_admin
+)
+VALUES (
+    'bdougie',
+    5713670, -- bdougie's GitHub user ID
+    'hello@bdougie.live',
+    'Brian Douglas',
+    TRUE
+)
+ON CONFLICT (github_username) DO UPDATE SET
+    is_admin = TRUE,
+    updated_at = NOW();
+
+-- Grant admin role to bdougie
+INSERT INTO user_roles (user_id, role)
+SELECT id, 'admin'
+FROM app_users
+WHERE github_username = 'bdougie'
+ON CONFLICT (user_id, role, is_active) DO NOTHING;
+
+-- =====================================================
+-- ROW LEVEL SECURITY POLICIES
+-- =====================================================
+
+-- Enable RLS on admin tables
+ALTER TABLE app_users ENABLE ROW LEVEL SECURITY;
+ALTER TABLE user_roles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE admin_action_logs ENABLE ROW LEVEL SECURITY;
+
+-- App users policies
+-- Public can read basic user info (for contributor profiles)
+CREATE POLICY "public_read_app_users_basic"
+ON app_users FOR SELECT
+USING (is_active = TRUE);
+
+-- Only admins can insert/update app users
+CREATE POLICY "admin_manage_app_users"
+ON app_users FOR ALL
+USING (
+    EXISTS (
+        SELECT 1 FROM app_users au
+        WHERE au.auth_user_id = auth.uid()
+          AND au.is_admin = TRUE
+          AND au.is_active = TRUE
+    )
+);
+
+-- Users can update their own record
+CREATE POLICY "users_update_own_record"
+ON app_users FOR UPDATE
+USING (auth_user_id = auth.uid());
+
+-- User roles policies
+-- Only admins can manage roles
+CREATE POLICY "admin_manage_user_roles"
+ON user_roles FOR ALL
+USING (
+    EXISTS (
+        SELECT 1 FROM app_users au
+        WHERE au.auth_user_id = auth.uid()
+          AND au.is_admin = TRUE
+          AND au.is_active = TRUE
+    )
+);
+
+-- Users can read their own roles
+CREATE POLICY "users_read_own_roles"
+ON user_roles FOR SELECT
+USING (
+    user_id IN (
+        SELECT id FROM app_users
+        WHERE auth_user_id = auth.uid()
+    )
+);
+
+-- Admin action logs policies
+-- Only admins can read admin logs
+CREATE POLICY "admin_read_action_logs"
+ON admin_action_logs FOR SELECT
+USING (
+    EXISTS (
+        SELECT 1 FROM app_users au
+        WHERE au.auth_user_id = auth.uid()
+          AND au.is_admin = TRUE
+          AND au.is_active = TRUE
+    )
+);
+
+-- Only system can insert admin logs (via functions)
+CREATE POLICY "system_insert_admin_logs"
+ON admin_action_logs FOR INSERT
+WITH CHECK (TRUE); -- Functions handle the actual permission checking
+
+-- =====================================================
+-- TRIGGERS FOR AUTOMATIC UPDATES
+-- =====================================================
+
+-- Trigger to update updated_at timestamp
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Apply trigger to app_users table
+CREATE TRIGGER update_app_users_updated_at
+    BEFORE UPDATE ON app_users
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- =====================================================
+-- COMMENTS AND DOCUMENTATION
+-- =====================================================
+
+COMMENT ON TABLE app_users IS 'Application users linked to Supabase Auth with GitHub OAuth data';
+COMMENT ON TABLE user_roles IS 'Role-based access control system for application users';
+COMMENT ON TABLE admin_action_logs IS 'Audit trail for administrative actions';
+
+COMMENT ON FUNCTION is_user_admin IS 'Checks if a user has admin privileges';
+COMMENT ON FUNCTION user_has_role IS 'Checks if a user has a specific role';
+COMMENT ON FUNCTION upsert_app_user IS 'Creates or updates app user from GitHub OAuth data';
+COMMENT ON FUNCTION grant_user_role IS 'Grants a role to a user (admin only)';
+
+-- Migration completed successfully
+-- Next steps:
+-- 1. Update authentication hooks to use app_users table
+-- 2. Create admin-specific routes and components
+-- 3. Implement user management interface
+-- 4. Move admin tools from /dev to /admin routes

--- a/supabase/migrations/20250629000000_add_admin_system.sql
+++ b/supabase/migrations/20250629000000_add_admin_system.sql
@@ -1,387 +1,246 @@
--- Admin System Database Schema Migration
--- Creates user management and role-based access control system
--- This enables database-driven admin permissions for user "bdougie"
+-- Admin System Migration
+-- Creates user role management and admin functionality
 
--- Enable UUID extension if not already enabled
-CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
-
--- =====================================================
--- ADMIN SYSTEM TABLES
--- =====================================================
-
--- 1. App Users table - tracks application users linked to Supabase Auth
-CREATE TABLE app_users (
-    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    auth_user_id UUID UNIQUE, -- References auth.users(id) but not enforced due to auth schema
-    github_username TEXT UNIQUE NOT NULL,
-    github_user_id BIGINT UNIQUE, -- GitHub user ID for reliable identification
-    email TEXT,
+-- Create app_users table to link Supabase Auth users with GitHub profiles
+CREATE TABLE IF NOT EXISTS app_users (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    auth_user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+    github_id BIGINT UNIQUE NOT NULL,
+    github_username VARCHAR(255) NOT NULL,
+    display_name VARCHAR(255),
     avatar_url TEXT,
-    display_name TEXT,
+    email VARCHAR(255),
     is_admin BOOLEAN DEFAULT FALSE,
-    is_active BOOLEAN DEFAULT TRUE,
-    first_login_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    last_login_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    last_login TIMESTAMP WITH TIME ZONE,
+    UNIQUE(auth_user_id),
+    UNIQUE(github_username)
 );
 
--- 2. User Roles table - flexible role management system
-CREATE TABLE user_roles (
-    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    user_id UUID NOT NULL REFERENCES app_users(id) ON DELETE CASCADE,
-    role TEXT NOT NULL CHECK (role IN ('admin', 'moderator', 'user')),
-    granted_by UUID REFERENCES app_users(id), -- who granted this role
-    granted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    revoked_at TIMESTAMPTZ,
+-- Create user_roles table for flexible role management
+CREATE TABLE IF NOT EXISTS user_roles (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID REFERENCES app_users(id) ON DELETE CASCADE,
+    role_name VARCHAR(50) NOT NULL CHECK (role_name IN ('admin', 'moderator', 'user')),
+    granted_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    granted_by UUID REFERENCES app_users(id),
+    revoked_at TIMESTAMP WITH TIME ZONE,
     revoked_by UUID REFERENCES app_users(id),
-    is_active BOOLEAN DEFAULT TRUE,
-    
-    -- Unique constraint to prevent duplicate active roles
-    CONSTRAINT unique_active_user_role UNIQUE (user_id, role, is_active)
+    is_active BOOLEAN GENERATED ALWAYS AS (revoked_at IS NULL) STORED,
+    UNIQUE(user_id, role_name, is_active) WHERE is_active = TRUE
 );
 
--- 3. Admin Action Logs table - audit trail for admin actions
-CREATE TABLE admin_action_logs (
-    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    admin_user_id UUID NOT NULL REFERENCES app_users(id),
-    action_type TEXT NOT NULL CHECK (action_type IN (
-        'grant_role', 'revoke_role', 'create_user', 'update_user', 
-        'deactivate_user', 'activate_user', 'system_config'
-    )),
-    target_user_id UUID REFERENCES app_users(id), -- user affected by action
-    action_details JSONB, -- additional context about the action
+-- Create admin_action_logs for audit trail
+CREATE TABLE IF NOT EXISTS admin_action_logs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    admin_user_id UUID REFERENCES app_users(id) ON DELETE SET NULL,
+    action_type VARCHAR(100) NOT NULL,
+    target_type VARCHAR(100), -- 'user', 'pull_request', 'repository', etc.
+    target_id VARCHAR(255),
+    details JSONB DEFAULT '{}',
     ip_address INET,
     user_agent TEXT,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
--- =====================================================
--- INDEXES FOR PERFORMANCE
--- =====================================================
+-- Create indexes for performance
+CREATE INDEX IF NOT EXISTS idx_app_users_github_id ON app_users(github_id);
+CREATE INDEX IF NOT EXISTS idx_app_users_github_username ON app_users(github_username);
+CREATE INDEX IF NOT EXISTS idx_app_users_auth_user_id ON app_users(auth_user_id);
+CREATE INDEX IF NOT EXISTS idx_user_roles_user_id ON user_roles(user_id);
+CREATE INDEX IF NOT EXISTS idx_user_roles_active ON user_roles(user_id, is_active) WHERE is_active = TRUE;
+CREATE INDEX IF NOT EXISTS idx_admin_action_logs_admin_user_id ON admin_action_logs(admin_user_id);
+CREATE INDEX IF NOT EXISTS idx_admin_action_logs_created_at ON admin_action_logs(created_at);
 
--- App users indexes
-CREATE INDEX idx_app_users_auth_user_id ON app_users(auth_user_id);
-CREATE INDEX idx_app_users_github_username ON app_users(github_username);
-CREATE INDEX idx_app_users_github_user_id ON app_users(github_user_id);
-CREATE INDEX idx_app_users_is_admin ON app_users(is_admin) WHERE is_admin = TRUE;
-CREATE INDEX idx_app_users_active ON app_users(is_active) WHERE is_active = TRUE;
-
--- User roles indexes
-CREATE INDEX idx_user_roles_user_id ON user_roles(user_id);
-CREATE INDEX idx_user_roles_role ON user_roles(role);
-CREATE INDEX idx_user_roles_active ON user_roles(is_active) WHERE is_active = TRUE;
-CREATE INDEX idx_user_roles_user_role_active ON user_roles(user_id, role, is_active);
-
--- Admin action logs indexes
-CREATE INDEX idx_admin_logs_admin_user ON admin_action_logs(admin_user_id);
-CREATE INDEX idx_admin_logs_target_user ON admin_action_logs(target_user_id);
-CREATE INDEX idx_admin_logs_action_type ON admin_action_logs(action_type);
-CREATE INDEX idx_admin_logs_created_at ON admin_action_logs(created_at DESC);
-
--- =====================================================
--- FUNCTIONS FOR ADMIN OPERATIONS
--- =====================================================
-
--- Function to check if a user is an admin
-CREATE OR REPLACE FUNCTION is_user_admin(user_github_username TEXT)
+-- Function to check if a user is admin
+CREATE OR REPLACE FUNCTION is_user_admin(user_github_id BIGINT)
 RETURNS BOOLEAN AS $$
-DECLARE
-    admin_status BOOLEAN := FALSE;
 BEGIN
-    SELECT is_admin INTO admin_status
-    FROM app_users
-    WHERE github_username = user_github_username
-      AND is_active = TRUE;
-    
-    RETURN COALESCE(admin_status, FALSE);
+    RETURN EXISTS (
+        SELECT 1 
+        FROM app_users 
+        WHERE github_id = user_github_id 
+        AND is_admin = TRUE
+    );
 END;
-$$ LANGUAGE plpgsql STABLE;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
 
 -- Function to check if a user has a specific role
-CREATE OR REPLACE FUNCTION user_has_role(user_github_username TEXT, role_name TEXT)
+CREATE OR REPLACE FUNCTION user_has_role(user_github_id BIGINT, role_name TEXT)
 RETURNS BOOLEAN AS $$
-DECLARE
-    has_role BOOLEAN := FALSE;
 BEGIN
-    SELECT EXISTS(
-        SELECT 1
+    RETURN EXISTS (
+        SELECT 1 
         FROM app_users au
         JOIN user_roles ur ON au.id = ur.user_id
-        WHERE au.github_username = user_github_username
-          AND au.is_active = TRUE
-          AND ur.role = role_name
-          AND ur.is_active = TRUE
-    ) INTO has_role;
-    
-    RETURN has_role;
+        WHERE au.github_id = user_github_id 
+        AND ur.role_name = user_has_role.role_name
+        AND ur.is_active = TRUE
+    );
 END;
-$$ LANGUAGE plpgsql STABLE;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
 
--- Function to create or update app user from GitHub OAuth data
+-- Function to upsert app_user from auth user and GitHub data
 CREATE OR REPLACE FUNCTION upsert_app_user(
     p_auth_user_id UUID,
-    p_github_username TEXT,
-    p_github_user_id BIGINT,
-    p_email TEXT DEFAULT NULL,
+    p_github_id BIGINT,
+    p_github_username VARCHAR(255),
+    p_display_name VARCHAR(255) DEFAULT NULL,
     p_avatar_url TEXT DEFAULT NULL,
-    p_display_name TEXT DEFAULT NULL
+    p_email VARCHAR(255) DEFAULT NULL
 )
 RETURNS UUID AS $$
 DECLARE
     user_id UUID;
-    is_new_user BOOLEAN := FALSE;
 BEGIN
-    -- Try to find existing user by GitHub username or auth_user_id
-    SELECT id INTO user_id
-    FROM app_users
-    WHERE github_username = p_github_username
-       OR auth_user_id = p_auth_user_id;
-    
-    IF user_id IS NULL THEN
-        -- Create new user
-        INSERT INTO app_users (
-            auth_user_id, github_username, github_user_id,
-            email, avatar_url, display_name
-        )
-        VALUES (
-            p_auth_user_id, p_github_username, p_github_user_id,
-            p_email, p_avatar_url, p_display_name
-        )
-        RETURNING id INTO user_id;
-        
-        is_new_user := TRUE;
-    ELSE
-        -- Update existing user
-        UPDATE app_users
-        SET 
-            auth_user_id = p_auth_user_id,
-            github_user_id = p_github_user_id,
-            email = COALESCE(p_email, email),
-            avatar_url = COALESCE(p_avatar_url, avatar_url),
-            display_name = COALESCE(p_display_name, display_name),
-            last_login_at = NOW(),
-            updated_at = NOW()
-        WHERE id = user_id;
-    END IF;
-    
-    -- Assign default 'user' role if new user
-    IF is_new_user THEN
-        INSERT INTO user_roles (user_id, role)
-        VALUES (user_id, 'user');
-    END IF;
+    INSERT INTO app_users (
+        auth_user_id, github_id, github_username, 
+        display_name, avatar_url, email, last_login
+    )
+    VALUES (
+        p_auth_user_id, p_github_id, p_github_username,
+        p_display_name, p_avatar_url, p_email, NOW()
+    )
+    ON CONFLICT (github_id) 
+    DO UPDATE SET
+        auth_user_id = EXCLUDED.auth_user_id,
+        github_username = EXCLUDED.github_username,
+        display_name = COALESCE(EXCLUDED.display_name, app_users.display_name),
+        avatar_url = COALESCE(EXCLUDED.avatar_url, app_users.avatar_url),
+        email = COALESCE(EXCLUDED.email, app_users.email),
+        updated_at = NOW(),
+        last_login = NOW()
+    RETURNING id INTO user_id;
     
     RETURN user_id;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
 
--- Function to grant a role to a user
-CREATE OR REPLACE FUNCTION grant_user_role(
-    target_username TEXT,
-    role_name TEXT,
-    granted_by_username TEXT
+-- Function to log admin actions
+CREATE OR REPLACE FUNCTION log_admin_action(
+    p_admin_github_id BIGINT,
+    p_action_type VARCHAR(100),
+    p_target_type VARCHAR(100) DEFAULT NULL,
+    p_target_id VARCHAR(255) DEFAULT NULL,
+    p_details JSONB DEFAULT '{}',
+    p_ip_address INET DEFAULT NULL,
+    p_user_agent TEXT DEFAULT NULL
 )
-RETURNS BOOLEAN AS $$
+RETURNS UUID AS $$
 DECLARE
-    target_user_id UUID;
-    granter_user_id UUID;
-    granter_is_admin BOOLEAN;
+    admin_user_id UUID;
+    log_id UUID;
 BEGIN
-    -- Get target user ID
-    SELECT id INTO target_user_id
-    FROM app_users
-    WHERE github_username = target_username AND is_active = TRUE;
+    -- Get admin user ID
+    SELECT id INTO admin_user_id 
+    FROM app_users 
+    WHERE github_id = p_admin_github_id;
     
-    IF target_user_id IS NULL THEN
-        RAISE EXCEPTION 'Target user not found: %', target_username;
-    END IF;
-    
-    -- Get granter user ID and check admin status
-    SELECT id, is_admin INTO granter_user_id, granter_is_admin
-    FROM app_users
-    WHERE github_username = granted_by_username AND is_active = TRUE;
-    
-    IF granter_user_id IS NULL THEN
-        RAISE EXCEPTION 'Granter user not found: %', granted_by_username;
-    END IF;
-    
-    IF NOT granter_is_admin THEN
-        RAISE EXCEPTION 'User % is not authorized to grant roles', granted_by_username;
-    END IF;
-    
-    -- Deactivate any existing role of the same type
-    UPDATE user_roles
-    SET is_active = FALSE,
-        revoked_at = NOW(),
-        revoked_by = granter_user_id
-    WHERE user_id = target_user_id
-      AND role = role_name
-      AND is_active = TRUE;
-    
-    -- Grant the new role
-    INSERT INTO user_roles (user_id, role, granted_by)
-    VALUES (target_user_id, role_name, granter_user_id);
-    
-    -- Update admin status if granting admin role
-    IF role_name = 'admin' THEN
-        UPDATE app_users
-        SET is_admin = TRUE, updated_at = NOW()
-        WHERE id = target_user_id;
-    END IF;
-    
-    -- Log the action
+    -- Create log entry
     INSERT INTO admin_action_logs (
-        admin_user_id, action_type, target_user_id,
-        action_details
+        admin_user_id, action_type, target_type, target_id,
+        details, ip_address, user_agent
     )
     VALUES (
-        granter_user_id, 'grant_role', target_user_id,
-        jsonb_build_object('role', role_name, 'target_username', target_username)
-    );
+        admin_user_id, p_action_type, p_target_type, p_target_id,
+        p_details, p_ip_address, p_user_agent
+    )
+    RETURNING id INTO log_id;
     
-    RETURN TRUE;
+    RETURN log_id;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
 
--- =====================================================
--- BOOTSTRAP ADMIN USER
--- =====================================================
-
--- Bootstrap "bdougie" as the initial admin user
--- This will be updated when the user first logs in via OAuth
-INSERT INTO app_users (
-    github_username,
-    github_user_id,
-    email,
-    display_name,
-    is_admin
-)
-VALUES (
-    'bdougie',
-    5713670, -- bdougie's GitHub user ID
-    'hello@bdougie.live',
-    'Brian Douglas',
-    TRUE
-)
-ON CONFLICT (github_username) DO UPDATE SET
-    is_admin = TRUE,
-    updated_at = NOW();
-
--- Grant admin role to bdougie
-INSERT INTO user_roles (user_id, role)
-SELECT id, 'admin'
-FROM app_users
-WHERE github_username = 'bdougie'
-ON CONFLICT (user_id, role, is_active) DO NOTHING;
-
--- =====================================================
--- ROW LEVEL SECURITY POLICIES
--- =====================================================
-
--- Enable RLS on admin tables
+-- Enable Row Level Security
 ALTER TABLE app_users ENABLE ROW LEVEL SECURITY;
 ALTER TABLE user_roles ENABLE ROW LEVEL SECURITY;
 ALTER TABLE admin_action_logs ENABLE ROW LEVEL SECURITY;
 
--- App users policies
--- Public can read basic user info (for contributor profiles)
-CREATE POLICY "public_read_app_users_basic"
-ON app_users FOR SELECT
-USING (is_active = TRUE);
+-- RLS Policies for app_users
+-- Allow public read access (for progressive onboarding)
+CREATE POLICY "Allow public read access to app_users" ON app_users
+    FOR SELECT USING (true);
 
--- Only admins can insert/update app users
-CREATE POLICY "admin_manage_app_users"
-ON app_users FOR ALL
-USING (
-    EXISTS (
-        SELECT 1 FROM app_users au
-        WHERE au.auth_user_id = auth.uid()
-          AND au.is_admin = TRUE
-          AND au.is_active = TRUE
-    )
-);
+-- Allow users to update their own records
+CREATE POLICY "Users can update own record" ON app_users
+    FOR UPDATE USING (auth.uid() = auth_user_id);
 
--- Users can update their own record
-CREATE POLICY "users_update_own_record"
-ON app_users FOR UPDATE
-USING (auth_user_id = auth.uid());
+-- Allow admins full access
+CREATE POLICY "Admins have full access to app_users" ON app_users
+    FOR ALL USING (
+        EXISTS (
+            SELECT 1 FROM app_users 
+            WHERE auth_user_id = auth.uid() 
+            AND is_admin = TRUE
+        )
+    );
 
--- User roles policies
--- Only admins can manage roles
-CREATE POLICY "admin_manage_user_roles"
-ON user_roles FOR ALL
-USING (
-    EXISTS (
-        SELECT 1 FROM app_users au
-        WHERE au.auth_user_id = auth.uid()
-          AND au.is_admin = TRUE
-          AND au.is_active = TRUE
-    )
-);
+-- RLS Policies for user_roles
+-- Allow public read access to active roles
+CREATE POLICY "Allow public read access to active user_roles" ON user_roles
+    FOR SELECT USING (is_active = TRUE);
 
--- Users can read their own roles
-CREATE POLICY "users_read_own_roles"
-ON user_roles FOR SELECT
-USING (
-    user_id IN (
-        SELECT id FROM app_users
-        WHERE auth_user_id = auth.uid()
-    )
-);
+-- Allow admins full access
+CREATE POLICY "Admins have full access to user_roles" ON user_roles
+    FOR ALL USING (
+        EXISTS (
+            SELECT 1 FROM app_users 
+            WHERE auth_user_id = auth.uid() 
+            AND is_admin = TRUE
+        )
+    );
 
--- Admin action logs policies
--- Only admins can read admin logs
-CREATE POLICY "admin_read_action_logs"
-ON admin_action_logs FOR SELECT
-USING (
-    EXISTS (
-        SELECT 1 FROM app_users au
-        WHERE au.auth_user_id = auth.uid()
-          AND au.is_admin = TRUE
-          AND au.is_active = TRUE
-    )
-);
+-- RLS Policies for admin_action_logs
+-- Only admins can read logs
+CREATE POLICY "Only admins can read admin_action_logs" ON admin_action_logs
+    FOR SELECT USING (
+        EXISTS (
+            SELECT 1 FROM app_users 
+            WHERE auth_user_id = auth.uid() 
+            AND is_admin = TRUE
+        )
+    );
 
--- Only system can insert admin logs (via functions)
-CREATE POLICY "system_insert_admin_logs"
-ON admin_action_logs FOR INSERT
-WITH CHECK (TRUE); -- Functions handle the actual permission checking
+-- Only admins can insert logs (via function)
+CREATE POLICY "Only admins can insert admin_action_logs" ON admin_action_logs
+    FOR INSERT WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM app_users 
+            WHERE auth_user_id = auth.uid() 
+            AND is_admin = TRUE
+        )
+    );
 
--- =====================================================
--- TRIGGERS FOR AUTOMATIC UPDATES
--- =====================================================
+-- Bootstrap admin user: bdougie (GitHub ID: 5713670)
+-- Note: This will be updated when they first log in with actual auth_user_id
+INSERT INTO app_users (
+    github_id, 
+    github_username, 
+    display_name,
+    is_admin
+) VALUES (
+    5713670,
+    'bdougie', 
+    'Brian Douglas',
+    TRUE
+) ON CONFLICT (github_id) DO UPDATE SET
+    is_admin = TRUE,
+    updated_at = NOW();
 
--- Trigger to update updated_at timestamp
-CREATE OR REPLACE FUNCTION update_updated_at_column()
-RETURNS TRIGGER AS $$
-BEGIN
-    NEW.updated_at = NOW();
-    RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
+-- Grant admin role to bdougie
+INSERT INTO user_roles (user_id, role_name)
+SELECT id, 'admin'
+FROM app_users 
+WHERE github_username = 'bdougie'
+ON CONFLICT (user_id, role_name, is_active) WHERE is_active = TRUE 
+DO NOTHING;
 
--- Apply trigger to app_users table
-CREATE TRIGGER update_app_users_updated_at
-    BEFORE UPDATE ON app_users
-    FOR EACH ROW
-    EXECUTE FUNCTION update_updated_at_column();
-
--- =====================================================
--- COMMENTS AND DOCUMENTATION
--- =====================================================
-
-COMMENT ON TABLE app_users IS 'Application users linked to Supabase Auth with GitHub OAuth data';
-COMMENT ON TABLE user_roles IS 'Role-based access control system for application users';
+-- Add helpful comments
+COMMENT ON TABLE app_users IS 'Application users linked to Supabase Auth and GitHub profiles';
+COMMENT ON TABLE user_roles IS 'Flexible role management system for users';
 COMMENT ON TABLE admin_action_logs IS 'Audit trail for administrative actions';
-
-COMMENT ON FUNCTION is_user_admin IS 'Checks if a user has admin privileges';
-COMMENT ON FUNCTION user_has_role IS 'Checks if a user has a specific role';
-COMMENT ON FUNCTION upsert_app_user IS 'Creates or updates app user from GitHub OAuth data';
-COMMENT ON FUNCTION grant_user_role IS 'Grants a role to a user (admin only)';
-
--- Migration completed successfully
--- Next steps:
--- 1. Update authentication hooks to use app_users table
--- 2. Create admin-specific routes and components
--- 3. Implement user management interface
--- 4. Move admin tools from /dev to /admin routes
+COMMENT ON FUNCTION is_user_admin(BIGINT) IS 'Check if a GitHub user ID has admin privileges';
+COMMENT ON FUNCTION user_has_role(BIGINT, TEXT) IS 'Check if a GitHub user ID has a specific role';
+COMMENT ON FUNCTION upsert_app_user IS 'Create or update app_user from auth and GitHub data';
+COMMENT ON FUNCTION log_admin_action IS 'Log administrative actions for audit trail';

--- a/supabase/migrations/20250629000001_add_pr_template_support.sql
+++ b/supabase/migrations/20250629000001_add_pr_template_support.sql
@@ -1,0 +1,63 @@
+-- Migration: Add PR Template Support
+-- Add fields to repositories table for caching PR templates and enable repository-specific spam detection
+
+-- Add PR template fields to repositories table
+ALTER TABLE repositories ADD COLUMN IF NOT EXISTS pr_template_content TEXT;
+ALTER TABLE repositories ADD COLUMN IF NOT EXISTS pr_template_url TEXT;
+ALTER TABLE repositories ADD COLUMN IF NOT EXISTS pr_template_hash TEXT;
+ALTER TABLE repositories ADD COLUMN IF NOT EXISTS pr_template_fetched_at TIMESTAMP WITH TIME ZONE;
+
+-- Create repository_spam_patterns table for storing repository-specific spam patterns
+CREATE TABLE IF NOT EXISTS repository_spam_patterns (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  repository_id UUID NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
+  pattern_type TEXT NOT NULL CHECK (pattern_type IN ('template_match', 'empty_sections', 'minimal_effort')),
+  pattern_content TEXT NOT NULL,
+  pattern_description TEXT NOT NULL,
+  weight DECIMAL(3,2) NOT NULL DEFAULT 0.8 CHECK (weight >= 0 AND weight <= 1),
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  
+  -- Ensure unique patterns per repository
+  UNIQUE(repository_id, pattern_type, pattern_content)
+);
+
+-- Create index for efficient pattern lookup
+CREATE INDEX IF NOT EXISTS idx_repository_spam_patterns_repo_id ON repository_spam_patterns(repository_id);
+CREATE INDEX IF NOT EXISTS idx_repository_spam_patterns_type ON repository_spam_patterns(pattern_type);
+
+-- Create trigger to update updated_at timestamp
+CREATE OR REPLACE FUNCTION update_repository_spam_patterns_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_update_repository_spam_patterns_updated_at
+  BEFORE UPDATE ON repository_spam_patterns
+  FOR EACH ROW
+  EXECUTE FUNCTION update_repository_spam_patterns_updated_at();
+
+-- Enable RLS on repository_spam_patterns
+ALTER TABLE repository_spam_patterns ENABLE ROW LEVEL SECURITY;
+
+-- Allow public read access for spam pattern checking
+CREATE POLICY "Allow public read access to repository_spam_patterns"
+  ON repository_spam_patterns FOR SELECT
+  TO PUBLIC
+  USING (true);
+
+-- Allow authenticated users to insert/update patterns (for admin functions)
+CREATE POLICY "Allow authenticated users to manage repository_spam_patterns"
+  ON repository_spam_patterns FOR ALL
+  TO authenticated
+  USING (true);
+
+-- Add comment for documentation
+COMMENT ON TABLE repository_spam_patterns IS 'Repository-specific spam detection patterns generated from PR templates';
+COMMENT ON COLUMN repositories.pr_template_content IS 'Cached content of the repository PR template';
+COMMENT ON COLUMN repositories.pr_template_url IS 'URL of the PR template file on GitHub';
+COMMENT ON COLUMN repositories.pr_template_hash IS 'MD5 hash of template content for change detection';
+COMMENT ON COLUMN repositories.pr_template_fetched_at IS 'Timestamp when template was last fetched from GitHub';

--- a/tasks/prd-spam-detection.md
+++ b/tasks/prd-spam-detection.md
@@ -39,65 +39,65 @@
 **Dependencies**: Database migration
 
 **Deliverables**:
-- Database schema updates for spam scoring
-- Core spam detection algorithms
-- Basic scoring framework
-- Unit tests for detection logic
+- Database schema updates for spam scoring ✅
+- Core spam detection algorithms ✅
+- Basic scoring framework ✅
+- Unit tests for detection logic ✅
 
 **Acceptance Criteria**:
-- `pull_requests` table has spam-related fields
-- SpamDetectionService can analyze PR content
-- Template matching algorithm detects 100% duplicates
-- Account age analysis identifies new contributor patterns
-- All detection methods have >85% accuracy in tests
+- `pull_requests` table has spam-related fields ✅
+- SpamDetectionService can analyze PR content ✅
+- Template matching algorithm detects 100% duplicates ✅
+- Account age analysis identifies new contributor patterns ✅
+- All detection methods have >85% accuracy in tests ✅
 
-### Phase 2: Real-time Detection (HIGH Priority)
+### Phase 2: Real-time Detection (HIGH Priority) ✅
 **Duration**: 4-5 days
 **Dependencies**: Phase 1 complete, PR ingestion pipeline
 
 **Deliverables**:
-- Integration with PR ingestion pipeline
-- Real-time spam analysis during data fetch
-- Batch processing for existing PRs
-- Performance optimization (<100ms per PR)
+- Integration with PR ingestion pipeline ✅
+- Real-time spam analysis during data fetch ✅
+- Batch processing for existing PRs ✅
+- Performance optimization (<100ms per PR) ✅
 
 **Acceptance Criteria**:
-- New PRs automatically analyzed for spam
-- Existing PRs can be reprocessed with spam scores
-- System maintains <100ms processing time
-- Spam scores stored correctly in database
+- New PRs automatically analyzed for spam ✅
+- Existing PRs can be reprocessed with spam scores ✅
+- System maintains <100ms processing time ✅
+- Spam scores stored correctly in database ✅
 
-### Phase 3: Feed Integration (MEDIUM Priority)
+### Phase 3: Feed Integration (MEDIUM Priority) ✅
 **Duration**: 2-3 days
 **Dependencies**: Phase 2 complete
 
 **Deliverables**:
-- Feed filtering based on spam scores
-- User preferences for spam tolerance
-- API endpoints for filtered feeds
-- Frontend integration
+- Feed filtering based on spam scores ✅
+- User preferences for spam tolerance ✅
+- API endpoints for filtered feeds ✅
+- Frontend integration ✅
 
 **Acceptance Criteria**:
-- Feed excludes PRs above spam threshold
-- Users can adjust spam filtering sensitivity
-- API responses include spam metadata
-- Frontend displays filtered results
+- Feed excludes PRs above spam threshold ✅
+- Users can adjust spam filtering sensitivity ✅
+- API responses include spam metadata ✅
+- Frontend displays filtered results ✅
 
-### Phase 4: Admin Dashboard (LOW Priority)
+### Phase 4: Admin Dashboard (LOW Priority) ✅
 **Duration**: 3-4 days
 **Dependencies**: Phase 3 complete
 
 **Deliverables**:
-- Admin interface for reviewing flagged PRs
-- Manual spam marking/unmarking
-- False positive reporting system
-- Spam detection metrics dashboard
+- Admin interface for reviewing flagged PRs ✅
+- Manual spam marking/unmarking ✅
+- False positive reporting system ✅
+- Spam detection metrics dashboard ✅
 
 **Acceptance Criteria**:
-- Admins can review and modify spam flags
-- Dashboard shows detection accuracy metrics
-- False positive feedback improves detection
-- Comprehensive spam analytics available
+- Admins can review and modify spam flags ✅
+- Dashboard shows detection accuracy metrics ✅
+- False positive feedback improves detection ✅
+- Comprehensive spam analytics available ✅
 
 ## Technical Architecture
 

--- a/tasks/prd-spam-detection.md
+++ b/tasks/prd-spam-detection.md
@@ -1,0 +1,231 @@
+# PRD: Spam Detection System for PR Feed
+
+## Project Overview
+
+**Objective**: Implement a comprehensive spam detection system to filter low-quality PRs from the contributor feed, improving content quality and user experience.
+
+**Background**: Current PR feed lacks filtering mechanisms, allowing spam and low-quality content to appear alongside legitimate contributions, degrading the overall user experience.
+
+**Success Metrics**:
+- 80% decrease in low-quality PRs appearing in feed
+- <5% false positive rate for legitimate PRs
+- <100ms processing time per PR analysis
+- Improved user engagement with feed content
+
+## Current State Analysis
+
+### What Exists
+- PR ingestion pipeline that fetches GitHub data
+- Basic PR data storage in `pull_requests` table
+- Feed display functionality showing all PRs
+
+### What's Missing
+- Spam detection logic and scoring system
+- Database fields for spam metrics
+- Filtering mechanisms in feed queries
+- Admin tools for spam management
+
+### Key Problems
+1. Template-matched PRs (100% duplicate descriptions)
+2. Empty or minimal PR descriptions
+3. New accounts creating low-quality PRs
+4. Large PRs with poor documentation
+5. Small PRs with no meaningful context
+
+## Implementation Plan
+
+### Phase 1: Evaluation Framework (HIGH Priority) ✅
+**Duration**: 3-4 days
+**Dependencies**: Database migration
+
+**Deliverables**:
+- Database schema updates for spam scoring
+- Core spam detection algorithms
+- Basic scoring framework
+- Unit tests for detection logic
+
+**Acceptance Criteria**:
+- `pull_requests` table has spam-related fields
+- SpamDetectionService can analyze PR content
+- Template matching algorithm detects 100% duplicates
+- Account age analysis identifies new contributor patterns
+- All detection methods have >85% accuracy in tests
+
+### Phase 2: Real-time Detection (HIGH Priority)
+**Duration**: 4-5 days
+**Dependencies**: Phase 1 complete, PR ingestion pipeline
+
+**Deliverables**:
+- Integration with PR ingestion pipeline
+- Real-time spam analysis during data fetch
+- Batch processing for existing PRs
+- Performance optimization (<100ms per PR)
+
+**Acceptance Criteria**:
+- New PRs automatically analyzed for spam
+- Existing PRs can be reprocessed with spam scores
+- System maintains <100ms processing time
+- Spam scores stored correctly in database
+
+### Phase 3: Feed Integration (MEDIUM Priority)
+**Duration**: 2-3 days
+**Dependencies**: Phase 2 complete
+
+**Deliverables**:
+- Feed filtering based on spam scores
+- User preferences for spam tolerance
+- API endpoints for filtered feeds
+- Frontend integration
+
+**Acceptance Criteria**:
+- Feed excludes PRs above spam threshold
+- Users can adjust spam filtering sensitivity
+- API responses include spam metadata
+- Frontend displays filtered results
+
+### Phase 4: Admin Dashboard (LOW Priority)
+**Duration**: 3-4 days
+**Dependencies**: Phase 3 complete
+
+**Deliverables**:
+- Admin interface for reviewing flagged PRs
+- Manual spam marking/unmarking
+- False positive reporting system
+- Spam detection metrics dashboard
+
+**Acceptance Criteria**:
+- Admins can review and modify spam flags
+- Dashboard shows detection accuracy metrics
+- False positive feedback improves detection
+- Comprehensive spam analytics available
+
+## Technical Architecture
+
+### Database Schema Changes
+```sql
+-- Add to pull_requests table
+ALTER TABLE pull_requests ADD COLUMN spam_score INTEGER DEFAULT 0;
+ALTER TABLE pull_requests ADD COLUMN spam_flags JSONB DEFAULT '{}';
+ALTER TABLE pull_requests ADD COLUMN is_spam BOOLEAN DEFAULT FALSE;
+ALTER TABLE pull_requests ADD COLUMN reviewed_by_admin BOOLEAN DEFAULT FALSE;
+ALTER TABLE pull_requests ADD COLUMN spam_detected_at TIMESTAMP;
+```
+
+### Core Services
+
+**SpamDetectionService**
+- Main orchestrator for spam analysis
+- Coordinates all detection methods
+- Calculates final spam score
+
+**PRAnalysisService**
+- Template matching detection
+- Content quality analysis
+- PR size vs documentation ratio
+
+**AccountAnalysisService**
+- New account pattern detection
+- Contributor history analysis
+- GitHub account metadata evaluation
+
+### Spam Detection Algorithms
+
+1. **Template Matching (Weight: 40%)**
+   - Exact description matching
+   - Common spam template detection
+   - Threshold: 100% match = high spam score
+
+2. **Content Quality (Weight: 30%)**
+   - Description length analysis
+   - Meaningful content detection
+   - Documentation quality assessment
+
+3. **Account Patterns (Weight: 20%)**
+   - Account age analysis
+   - Previous contribution quality
+   - GitHub profile completeness
+
+4. **PR Characteristics (Weight: 10%)**
+   - Size vs documentation ratio
+   - File change patterns
+   - Commit message quality
+
+### Scoring System
+- Score range: 0-100 (0 = likely legitimate, 100 = likely spam)
+- Thresholds:
+  - 0-25: Show in feed (green)
+  - 26-50: Show with warning (yellow)
+  - 51-75: Hide by default, admin review (orange)
+  - 76-100: Auto-hide, flag for review (red)
+
+## Technical Guidelines
+
+### Performance Requirements
+- <100ms processing time per PR
+- Batch processing capability for historical data
+- Efficient database queries with proper indexing
+- Caching for repeated template matching
+
+### Code Organization
+```
+src/
+  services/
+    spam/
+      SpamDetectionService.ts
+      PRAnalysisService.ts
+      AccountAnalysisService.ts
+      templates/
+        TemplateDetector.ts
+        CommonTemplates.ts
+```
+
+### Error Handling
+- Graceful degradation when detection fails
+- Comprehensive logging for debugging
+- Fallback to "unknown" spam status
+- Retry mechanisms for external API calls
+
+## Testing Strategy
+
+### Unit Tests
+- Each detection algorithm independently
+- Edge cases and boundary conditions
+- Performance benchmarks
+- Mock GitHub API responses
+
+### Integration Tests
+- End-to-end PR analysis workflow
+- Database integration
+- API endpoint functionality
+- Feed filtering accuracy
+
+### Performance Tests
+- 100ms processing time validation
+- Batch processing efficiency
+- Database query optimization
+- Memory usage monitoring
+
+## Future Enhancements
+
+### Machine Learning Integration
+- Training data collection from manual reviews
+- Pattern recognition improvements
+- Adaptive threshold adjustment
+- Community feedback integration
+
+### Advanced Features
+- Community reporting system
+- GitHub API spam detection integration
+- Multi-language template detection
+- Collaborative filtering mechanisms
+
+## Implementation Timeline
+
+**Week 1**: Phase 1 - Evaluation Framework
+**Week 2**: Phase 2 - Real-time Detection  
+**Week 3**: Phase 3 - Feed Integration
+**Week 4**: Phase 4 - Admin Dashboard
+
+**Total Estimated Effort**: 3-4 weeks
+**Team Size**: 1-2 developers
+**Priority Level**: HIGH


### PR DESCRIPTION
## Add authenticated spam feed route

Summary

  - Created new authenticated route /{owner}/{repo}/feed/spam for advanced spam analysis
  - Modified feed source toggle to navigate to dedicated spam page when "Spam" is clicked
  - Fixed tab navigation to show Feed tab as active when on spam feed page

  Changes

  New spam feed page
  - Added SpamFeedPage component with authentication requirement
  - Lazy-loaded component for optimal performance
  - Uses existing spam filtering infrastructure with FilteredPRActivity

  Updated routing
  - Added protected route in App.tsx requiring GitHub authentication
  - Route structure: /{owner}/{repo}/feed/spam wraps SpamFeedPage with ProtectedRoute

  Enhanced navigation
  - Modified FeedSourceToggle component to navigate to spam page instead of just switching data source
  - Updated tooltip to indicate authentication requirement
  - Fixed deprecated icon import (Github → GitBranch)

  Fixed tab highlighting
  - Updated getCurrentTab() function in repo-view.tsx to recognize /feed/spam routes
  - Feed tab now correctly shows as active when on spam analysis page

  User Experience

  1. Visit /{owner}/{repo}/feed and see Live/Spam toggle
  2. Click "Spam" to navigate to dedicated spam analysis page
  3. Authenticate via GitHub if not already logged in
  4. Access advanced spam filtering and analysis tools
  5. Feed tab remains highlighted for clear navigation context