### PR TITLE
feat: Black screen

### DIFF
--- a/src/components/features/activity/feed-source-toggle.tsx
+++ b/src/components/features/activity/feed-source-toggle.tsx
@@ -1,10 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { Database, GitBranch } from 'lucide-react';
-import {
-  ToggleGroup,
-  ToggleGroupItem,
-} from '@/components/ui/toggle-group';
+import { Database } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import {
   Tooltip,
   TooltipContent,
@@ -14,13 +11,7 @@ import {
 
 export type FeedSource = 'github' | 'database';
 
-interface FeedSourceToggleProps {
-  value: FeedSource;
-  onChange: (source: FeedSource) => void;
-  className?: string;
-}
-
-export function FeedSourceToggle({ value, onChange, className }: FeedSourceToggleProps) {
+export function FeedSourceToggle({ className }: { className?: string }) {
   const { owner, repo } = useParams<{ owner: string; repo: string }>();
   const navigate = useNavigate();
 
@@ -32,44 +23,25 @@ export function FeedSourceToggle({ value, onChange, className }: FeedSourceToggl
 
   return (
     <TooltipProvider>
-      <ToggleGroup
-        type="single"
-        value={value}
-        onValueChange={(newValue) => {
-          if (newValue === 'database') {
-            handleSpamClick();
-          } else if (newValue) {
-            onChange(newValue as FeedSource);
-          }
-        }}
-        className={className}
-      >
+      <div className={className}>
         <Tooltip>
           <TooltipTrigger asChild>
-            <ToggleGroupItem value="github" aria-label="Use GitHub API">
-              <GitBranch className="h-4 w-4 mr-2" />
-              Live
-            </ToggleGroupItem>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>Fetch latest data directly from GitHub</p>
-            <p className="text-xs text-muted-foreground">Real-time but no spam filtering</p>
-          </TooltipContent>
-        </Tooltip>
-
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <ToggleGroupItem value="database" aria-label="Go to spam analysis page">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleSpamClick}
+              aria-label="Go to spam analysis page"
+            >
               <Database className="h-4 w-4 mr-2" />
               Spam
-            </ToggleGroupItem>
+            </Button>
           </TooltipTrigger>
           <TooltipContent>
             <p>Advanced spam detection and analysis</p>
             <p className="text-xs text-muted-foreground">Requires authentication • Navigate to dedicated spam page</p>
           </TooltipContent>
         </Tooltip>
-      </ToggleGroup>
+      </div>
     </TooltipProvider>
   );
 }

--- a/src/components/features/activity/pr-activity-wrapper.tsx
+++ b/src/components/features/activity/pr-activity-wrapper.tsx
@@ -1,15 +1,12 @@
 import { lazy, Suspense } from 'react';
-import { FeedSourceToggle, useFeedSourcePreference } from './feed-source-toggle';
+import { FeedSourceToggle } from './feed-source-toggle';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Card, CardHeader, CardContent } from '@/components/ui/card';
 
 // Lazy load the components
 const PRActivity = lazy(() => import('./pr-activity'));
-const FilteredPRActivity = lazy(() => import('./pr-activity-filtered'));
 
 export default function PRActivityWrapper() {
-  const [feedSource, setFeedSource] = useFeedSourcePreference('github');
-
   const LoadingFallback = () => (
     <Card>
       <CardHeader>
@@ -29,18 +26,11 @@ export default function PRActivityWrapper() {
   return (
     <div className="space-y-4">
       <div className="flex justify-end">
-        <FeedSourceToggle
-          value={feedSource}
-          onChange={setFeedSource}
-        />
+        <FeedSourceToggle />
       </div>
 
       <Suspense fallback={<LoadingFallback />}>
-        {feedSource === 'github' ? (
-          <PRActivity />
-        ) : (
-          <FilteredPRActivity />
-        )}
+        <PRActivity />
       </Suspense>
     </div>
   );

--- a/src/components/features/feed/spam-feed-page.tsx
+++ b/src/components/features/feed/spam-feed-page.tsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import {
   Card,
   CardContent,
 } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
 import { RepoStatsProvider } from "@/lib/repo-stats-context";
 import FilteredPRActivity from "../activity/pr-activity-filtered";
 import { useTimeRangeStore } from "@/lib/time-range-store";
@@ -13,8 +15,15 @@ import { SocialMetaTags } from "@/components/common/layout";
 
 export default function SpamFeedPage() {
   const { owner, repo } = useParams<{ owner: string; repo: string }>();
+  const navigate = useNavigate();
   const timeRange = useTimeRangeStore((state) => state.timeRange);
   const [includeBots, setIncludeBots] = useState(false);
+
+  const handleBackToFeed = () => {
+    if (owner && repo) {
+      navigate(`/${owner}/${repo}/feed`);
+    }
+  };
 
   // Use our custom hooks
   const { stats, lotteryFactor, directCommitsData } = useCachedRepoData(
@@ -76,6 +85,17 @@ export default function SpamFeedPage() {
         image={`social-cards/repo-${owner}-${repo}.png`}
       />
       
+      <div className="mb-4">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleBackToFeed}
+          className="text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          Back to feed
+        </Button>
+      </div>
 
       <RepoStatsProvider
         value={{

--- a/src/components/features/repository/repo-view.tsx
+++ b/src/components/features/repository/repo-view.tsx
@@ -1,4 +1,4 @@
-import { useState, Suspense, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useParams, useNavigate, useLocation, Outlet } from "react-router-dom";
 import {
   Card,
@@ -22,7 +22,7 @@ import { ExampleRepos } from "./example-repos";
 import { useCachedRepoData } from "@/hooks/use-cached-repo-data";
 import { useRepoSearch } from "@/hooks/use-repo-search";
 import { InsightsSidebar } from "@/components/insights/insights-sidebar";
-import { RepoViewSkeleton, ContributionsSkeleton, DistributionSkeleton, HealthSkeleton, FeedSkeleton } from "@/components/skeletons";
+import { RepoViewSkeleton } from "@/components/skeletons";
 import { SocialMetaTags } from "@/components/common/layout";
 import RepoNotFound from "./repo-not-found";
 import { createChartShareUrl, getDubConfig } from "@/lib/dub";
@@ -268,7 +268,7 @@ export default function RepoView() {
 // Route components
 export function LotteryFactorRoute() {
   return (
-    <ProgressiveChartWrapper skeletonType="health">
+    <ProgressiveChartWrapper>
       <RepositoryHealthCard />
     </ProgressiveChartWrapper>
   );
@@ -285,7 +285,7 @@ export function ContributionsRoute() {
   return (
     <div className="space-y-8">
       {/* Progressive loading: Charts load independently */}
-      <ProgressiveChartWrapper skeletonType="contributions">
+      <ProgressiveChartWrapper>
         <Contributions />
       </ProgressiveChartWrapper>
       
@@ -302,54 +302,19 @@ export function ContributionsRoute() {
 
 export function DistributionRoute() {
   return (
-    <ProgressiveChartWrapper skeletonType="distribution">
+    <ProgressiveChartWrapper>
       <Distribution />
     </ProgressiveChartWrapper>
   );
 }
 
-// Progressive Chart Wrapper - loads individual components with detailed skeletons
-type SkeletonType = 'contributions' | 'health' | 'distribution' | 'feed' | 'generic';
-
+// Progressive Chart Wrapper - simplified since routes are already lazy loaded
 function ProgressiveChartWrapper({ 
-  children, 
-  skeletonType = 'generic' 
+  children 
 }: { 
   children: React.ReactNode;
-  skeletonType?: SkeletonType;
 }) {
-  const getSkeleton = () => {
-    switch (skeletonType) {
-      case 'contributions':
-        return <ContributionsSkeleton />;
-      case 'health':
-        return <HealthSkeleton />;
-      case 'distribution':
-        return <DistributionSkeleton />;
-      case 'feed':
-        return <FeedSkeleton />;
-      default:
-        // Generic fallback skeleton
-        return (
-          <Card>
-            <CardContent className="p-6">
-              <div className="animate-pulse space-y-3">
-                <div className="h-4 bg-muted rounded w-1/3"></div>
-                <div className="h-48 bg-muted rounded"></div>
-                <div className="flex gap-4">
-                  <div className="h-8 bg-muted rounded w-16"></div>
-                  <div className="h-8 bg-muted rounded w-16"></div>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        );
-    }
-  };
-
-  return (
-    <Suspense fallback={getSkeleton()}>
-      {children}
-    </Suspense>
-  );
+  // Remove Suspense here since the routes are already lazy loaded with Suspense in App.tsx
+  // This double Suspense was causing the blank page issue
+  return <>{children}</>;
 }


### PR DESCRIPTION
Somehow this broke and I fixed it again. Need to calm down with the agent stuff.

This pull request focuses on simplifying the UI components and improving navigation across the application. The changes include replacing toggle groups with buttons, removing unused imports and components, and simplifying the progressive chart wrapper to avoid redundant skeleton loading. Below is a breakdown of the most important changes:

### UI Simplification
* Replaced the `ToggleGroup` component in `FeedSourceToggle` with a simpler `Button` component for better clarity and usability. The `onChange` prop and `FeedSource` state management were removed as they are no longer needed. (`src/components/features/activity/feed-source-toggle.tsx`, [[1]](diffhunk://#diff-26bfdcb6506dd7ecdc6920b0193ac9f581db8ed101ea622745f68165ecbe9520L3-R4) [[2]](diffhunk://#diff-26bfdcb6506dd7ecdc6920b0193ac9f581db8ed101ea622745f68165ecbe9520L17-R14) [[3]](diffhunk://#diff-26bfdcb6506dd7ecdc6920b0193ac9f581db8ed101ea622745f68165ecbe9520L35-R44)
* Removed the `FilteredPRActivity` component and its associated logic from `PRActivityWrapper`, simplifying the component to only display `PRActivity`. (`src/components/features/activity/pr-activity-wrapper.tsx`, [[1]](diffhunk://#diff-d868671f0fa8fa9e04a47f1f1a7b97c325d1cd05cc11d2653511d87162d4d3ecL2-L12) [[2]](diffhunk://#diff-d868671f0fa8fa9e04a47f1f1a7b97c325d1cd05cc11d2653511d87162d4d3ecL32-L43)

### Navigation Improvements
* Added a "Back to feed" button in `SpamFeedPage` to improve navigation. This button uses the `useNavigate` hook to return to the feed page. (`src/components/features/feed/spam-feed-page.tsx`, [[1]](diffhunk://#diff-21698dd0935404db31887ca7bd3614737e35e53e6d4cd5067d9c9f8d5dfa9728L2-R8) [[2]](diffhunk://#diff-21698dd0935404db31887ca7bd3614737e35e53e6d4cd5067d9c9f8d5dfa9728R18-R27) [[3]](diffhunk://#diff-21698dd0935404db31887ca7bd3614737e35e53e6d4cd5067d9c9f8d5dfa9728R88-R98)

### Codebase Cleanup
* Removed unused imports such as `Suspense` and skeleton components in `RepoView` and simplified the `ProgressiveChartWrapper` by eliminating detailed skeleton logic. This avoids redundant suspense loading and resolves a blank page issue. (`src/components/features/repository/repo-view.tsx`, [[1]](diffhunk://#diff-dab235cd1a3d4fdc5b8eeaae8d3a954ac302db81e539fc225663161dbf848fedL1-R1) [[2]](diffhunk://#diff-dab235cd1a3d4fdc5b8eeaae8d3a954ac302db81e539fc225663161dbf848fedL25-R25) [[3]](diffhunk://#diff-dab235cd1a3d4fdc5b8eeaae8d3a954ac302db81e539fc225663161dbf848fedL271-R271) [[4]](diffhunk://#diff-dab235cd1a3d4fdc5b8eeaae8d3a954ac302db81e539fc225663161dbf848fedL288-R288) [[5]](diffhunk://#diff-dab235cd1a3d4fdc5b8eeaae8d3a954ac302db81e539fc225663161dbf848fedL305-R319)