### PR TITLE
Fix Netlify function routing for Inngest

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -69,12 +69,13 @@
   [headers.values]
     Content-Type = "application/wasm"
 
-# Redirect rules for SPA behavior
+# Redirect rules for SPA behavior (exclude functions and API routes)
 [[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200
   force = false
+  conditions = {path = ["!/.netlify/functions/*", "!/api/*"]}
 
 # Font and image optimizations
 [[headers]]

--- a/netlify/functions/inngest-simple.js
+++ b/netlify/functions/inngest-simple.js
@@ -1,0 +1,28 @@
+// Simple Inngest function for Netlify
+const { Inngest } = require("inngest");
+const { serve } = require("inngest/lambda");
+
+// Create Inngest client with environment variables
+const inngest = new Inngest({ 
+  id: process.env.VITE_INNGEST_APP_ID || 'contributor-info',
+  isDev: process.env.INNGEST_DEV === '1' ? true : false,
+  eventKey: process.env.INNGEST_EVENT_KEY,
+  signingKey: process.env.INNGEST_SIGNING_KEY,
+  env: process.env.INNGEST_ENV,
+});
+
+// Simple test function
+const testFunction = inngest.createFunction(
+  { id: "test-function" },
+  { event: "test/hello" },
+  async ({ event, step }) => {
+    console.log("Test function executed!", event);
+    return { message: "Hello from Inngest!", timestamp: new Date().toISOString() };
+  }
+);
+
+// Create and export the Netlify handler
+module.exports.handler = serve({
+  client: inngest,
+  functions: [testFunction],
+});

--- a/netlify/functions/inngest-test.js
+++ b/netlify/functions/inngest-test.js
@@ -1,0 +1,15 @@
+// Simple test function to verify Netlify functions work
+exports.handler = async (event, context) => {
+  return {
+    statusCode: 200,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      message: 'Netlify function is working!',
+      method: event.httpMethod,
+      path: event.path,
+      timestamp: new Date().toISOString(),
+    }),
+  };
+};


### PR DESCRIPTION
## Summary
- Fix redirect rules to exclude /.netlify/functions/* from SPA redirect
- Add simplified Inngest function using CommonJS (avoids TypeScript build issues)
- Add test function to verify Netlify function deployment works

## Fixes
- Resolves issue where Inngest function was returning main site HTML instead of function response
- Enables proper Inngest registration and webhook handling

## Test plan
- [ ] Test function endpoints respond correctly
- [ ] Verify Inngest can discover and register functions
- [ ] Confirm production environment variables work

🤖 Generated with [Claude Code](https://claude.ai/code)