### PR TITLE
fix: add user notifications for untracked repository searches

### DIFF
--- a/scripts/test-new-repo-tracking.mjs
+++ b/scripts/test-new-repo-tracking.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+import { createClient } from '@supabase/supabase-js';
+import 'dotenv/config';
+
+const supabaseUrl = process.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = process.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  console.error('Missing required environment variables');
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+async function testNewRepoTracking() {
+  // Test repository that likely doesn't exist in our database
+  const testOwner = 'pytorch';
+  const testRepo = 'pytorch';
+  
+  console.log(`\nTesting repository tracking for: ${testOwner}/${testRepo}`);
+  console.log('================================================\n');
+  
+  // Check if repository exists
+  const { data: repoData, error: repoError } = await supabase
+    .from('repositories')
+    .select('id, owner, name')
+    .eq('owner', testOwner)
+    .eq('name', testRepo)
+    .single();
+    
+  if (repoError && repoError.code === 'PGRST116') {
+    console.log('✅ Repository not found in database (as expected for test)');
+    console.log('   This would trigger the new repository notification\n');
+  } else if (repoData) {
+    console.log('⚠️  Repository already exists in database:');
+    console.log(`   ID: ${repoData.id}`);
+    console.log(`   Repository: ${repoData.owner}/${repoData.name}\n`);
+  }
+  
+  // Check tracked_repositories table
+  const { data: trackedData, error: trackedError } = await supabase
+    .from('tracked_repositories')
+    .select('*')
+    .eq('organization_name', testOwner)
+    .eq('repository_name', testRepo)
+    .single();
+    
+  if (trackedError && trackedError.code === 'PGRST116') {
+    console.log('✅ Repository not in tracked_repositories table');
+    console.log('   Would be added when user searches for it\n');
+  } else if (trackedData) {
+    console.log('📊 Repository tracking status:');
+    console.log(`   Tracking enabled: ${trackedData.tracking_enabled}`);
+    console.log(`   Priority: ${trackedData.priority}`);
+    console.log(`   Size: ${trackedData.size || 'Not calculated yet'}`);
+    console.log(`   Created: ${new Date(trackedData.created_at).toLocaleString()}\n`);
+  }
+  
+  console.log('🎯 Expected behavior when user searches for this repo:');
+  console.log('   1. Show notification: "Setting up pytorch/pytorch..."');
+  console.log('   2. Add to tracked_repositories table');
+  console.log('   3. Trigger Inngest jobs for data sync');
+  console.log('   4. Show welcome message with 1-2 minute estimate');
+  console.log('   5. Display skeleton loaders while data loads');
+}
+
+testNewRepoTracking().catch(console.error);

--- a/src/components/features/repository/repo-view.tsx
+++ b/src/components/features/repository/repo-view.tsx
@@ -30,6 +30,7 @@ import { useGitHubAuth } from "@/hooks/use-github-auth";
 import { DataProcessingIndicator } from "./data-processing-indicator";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { RepositoryInlineMetadata } from "@/components/ui/repository-inline-metadata";
+import { useTrackRepositoryWithNotification } from "@/hooks/use-track-repository-with-notification";
 
 export default function RepoView() {
   const { owner, repo } = useParams();
@@ -41,6 +42,13 @@ export default function RepoView() {
   const [hasSearchedOnce, setHasSearchedOnce] = useState(false);
   const dubConfig = getDubConfig();
   const { isLoggedIn } = useGitHubAuth();
+  
+  // Auto-track repository with user notifications
+  const trackingState = useTrackRepositoryWithNotification({
+    owner,
+    repo,
+    enabled: Boolean(owner && repo)
+  });
 
   // Determine current tab based on URL
   const getCurrentTab = () => {
@@ -141,25 +149,29 @@ export default function RepoView() {
                            stats.error.includes('does not exist') ||
                            stats.error.includes('404');
     
-    if (isRepoNotFound) {
+    // If it's a new repository being tracked, don't show error
+    if (isRepoNotFound && trackingState.isNewRepository) {
+      // Continue to show the normal view with skeleton loaders
+      // The tracking notification will inform the user
+    } else if (isRepoNotFound) {
       return <RepoNotFound />;
+    } else {
+      // For other errors, show the generic error card
+      return (
+        <div className="container mx-auto py-2">
+          <Card>
+            <CardContent className="p-8">
+              <div className="text-center">
+                <h2 className="text-2xl font-semibold text-destructive mb-2">
+                  Error
+                </h2>
+                <p className="text-muted-foreground">{stats.error}</p>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      );
     }
-
-    // For other errors, show the generic error card
-    return (
-      <div className="container mx-auto py-2">
-        <Card>
-          <CardContent className="p-8">
-            <div className="text-center">
-              <h2 className="text-2xl font-semibold text-destructive mb-2">
-                Error
-              </h2>
-              <p className="text-muted-foreground">{stats.error}</p>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-    );
   }
 
   const repoTitle = `${owner}/${repo} - Contributor Analysis`;
@@ -260,12 +272,34 @@ export default function RepoView() {
               </TabsList>
             </Tabs>
 
-            {/* Show data processing indicator */}
+            {/* Show data processing indicator or new repository message */}
             {owner && repo && (
-              <DataProcessingIndicator 
-                repository={`${owner}/${repo}`} 
-                className="mt-4" 
-              />
+              <>
+                <DataProcessingIndicator 
+                  repository={`${owner}/${repo}`} 
+                  className="mt-4" 
+                />
+                {trackingState.isNewRepository && !stats.loading && (
+                  <div className="mt-4 p-4 bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-lg">
+                    <div className="flex items-start space-x-3">
+                      <div className="flex-shrink-0">
+                        <svg className="h-5 w-5 text-blue-600 dark:text-blue-400 animate-pulse" fill="currentColor" viewBox="0 0 20 20">
+                          <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
+                        </svg>
+                      </div>
+                      <div className="flex-1">
+                        <h3 className="text-sm font-medium text-blue-800 dark:text-blue-200">
+                          Welcome to {owner}/{repo}!
+                        </h3>
+                        <p className="mt-1 text-sm text-blue-700 dark:text-blue-300">
+                          This is a new repository. We're gathering contributor data and it will be ready in about 1-2 minutes. 
+                          You can explore the interface while we work in the background.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </>
             )}
 
             <div className="mt-6">

--- a/src/hooks/use-track-repository-with-notification.ts
+++ b/src/hooks/use-track-repository-with-notification.ts
@@ -1,0 +1,216 @@
+import { useEffect, useRef, useState } from 'react'
+import { supabase } from '@/lib/supabase'
+import { inngest } from '@/lib/inngest/client'
+import { ProgressiveCaptureNotifications } from '@/lib/progressive-capture/ui-notifications'
+import { toast } from 'sonner'
+
+interface TrackRepositoryWithNotificationOptions {
+  owner: string | undefined
+  repo: string | undefined
+  enabled?: boolean
+}
+
+interface TrackingState {
+  isNewRepository: boolean
+  isTracking: boolean
+  hasData: boolean
+}
+
+export function useTrackRepositoryWithNotification({
+  owner,
+  repo,
+  enabled = true
+}: TrackRepositoryWithNotificationOptions): TrackingState {
+  const [state, setState] = useState<TrackingState>({
+    isNewRepository: false,
+    isTracking: false,
+    hasData: false
+  })
+  const hasCheckedRef = useRef(false)
+  const notificationShownRef = useRef(false)
+
+  useEffect(() => {
+    if (!enabled || !owner || !repo || hasCheckedRef.current) {
+      return
+    }
+
+    const checkAndTrackRepository = async () => {
+      try {
+        // Check if repository exists in our database
+        const { data: repoData, error: repoError } = await supabase
+          .from('repositories')
+          .select('id')
+          .eq('owner', owner)
+          .eq('name', repo)
+          .single()
+
+        if (repoError && repoError.code === 'PGRST116') {
+          // Repository not found - this is a new repository
+          setState(prev => ({ ...prev, isNewRepository: true }))
+          
+          // Show user-friendly notification only once
+          if (!notificationShownRef.current) {
+            notificationShownRef.current = true
+            toast.info(`Setting up ${owner}/${repo}...`, {
+              description: "This is a new repository! We're gathering contributor data for you. This usually takes 1-2 minutes.",
+              duration: 8000,
+              action: {
+                label: 'Learn More',
+                onClick: () => {
+                  toast.info('How it works', {
+                    description: 'We analyze pull requests, reviews, and contributions to show you insights about this repository.',
+                    duration: 6000
+                  })
+                }
+              }
+            })
+          }
+
+          // Check if repository is already being tracked
+          const { data: existing, error: checkError } = await supabase
+            .from('tracked_repositories')
+            .select('id, repository_id, size, size_calculated_at')
+            .eq('organization_name', owner)
+            .eq('repository_name', repo)
+            .single()
+
+          if (checkError && checkError.code !== 'PGRST116') {
+            console.error('Error checking tracked repositories:', checkError)
+            return
+          }
+
+          // If repository is not tracked, add it
+          if (!existing) {
+            setState(prev => ({ ...prev, isTracking: true }))
+            
+            const { data: newRepo, error: insertError } = await supabase
+              .from('tracked_repositories')
+              .insert({
+                organization_name: owner,
+                repository_name: repo,
+                tracking_enabled: true,
+                priority: 'medium', // Higher priority for user-initiated searches
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString()
+              })
+              .select()
+              .single()
+
+            if (insertError) {
+              console.error('Failed to track repository:', insertError)
+              toast.error('Failed to set up repository', {
+                description: 'Please try refreshing the page.',
+                duration: 6000
+              })
+              return
+            }
+
+            if (newRepo) {
+              hasCheckedRef.current = true
+              
+              // Trigger initial data sync with higher priority
+              try {
+                // Send multiple events for comprehensive initial sync
+                await Promise.all([
+                  // Size classification
+                  inngest.send({
+                    name: 'classify/repository.single',
+                    data: {
+                      repositoryId: newRepo.id,
+                      owner,
+                      repo
+                    }
+                  }),
+                  // Initial data capture
+                  inngest.send({
+                    name: 'capture/repository.sync',
+                    data: {
+                      owner,
+                      repo,
+                      priority: 'high',
+                      source: 'user-search'
+                    }
+                  })
+                ])
+
+                // Show processing notification
+                ProgressiveCaptureNotifications.showProcessingStarted(
+                  `${owner}/${repo}`,
+                  'inngest',
+                  60000 // 1 minute estimate
+                )
+              } catch (error) {
+                console.error('Failed to trigger repository sync:', error)
+              }
+            }
+          } else {
+            // Repository is tracked but no data yet
+            hasCheckedRef.current = true
+            setState(prev => ({ ...prev, isTracking: true }))
+            
+            // Trigger data sync
+            try {
+              await inngest.send({
+                name: 'capture/repository.sync',
+                data: {
+                  owner,
+                  repo,
+                  priority: 'high',
+                  source: 'user-search-retry'
+                }
+              })
+            } catch (error) {
+              console.error('Failed to trigger repository sync:', error)
+            }
+          }
+        } else if (repoData) {
+          // Repository exists in our database
+          hasCheckedRef.current = true
+          setState(prev => ({ ...prev, hasData: true }))
+          
+          // Check if we have recent PR data
+          const { data: prData, error: prError } = await supabase
+            .from('pull_requests')
+            .select('id')
+            .eq('repository_id', repoData.id)
+            .order('created_at', { ascending: false })
+            .limit(1)
+
+          if (!prError && (!prData || prData.length === 0)) {
+            // Repository exists but has no data - trigger sync
+            toast.info(`Refreshing ${owner}/${repo}...`, {
+              description: "We're updating this repository with the latest data.",
+              duration: 6000
+            })
+            
+            try {
+              await inngest.send({
+                name: 'capture/repository.sync',
+                data: {
+                  owner,
+                  repo,
+                  priority: 'high',
+                  source: 'user-search-empty'
+                }
+              })
+            } catch (error) {
+              console.error('Failed to trigger repository sync:', error)
+            }
+          }
+        }
+      } catch (error) {
+        console.error('Error in repository tracking:', error)
+      }
+    }
+
+    checkAndTrackRepository()
+  }, [owner, repo, enabled])
+
+  // Reset tracking flag when repository changes
+  useEffect(() => {
+    hasCheckedRef.current = false
+    notificationShownRef.current = false
+  }, [owner, repo])
+
+  return state
+}


### PR DESCRIPTION
## Summary
- Added user-friendly notifications when searching for untracked repositories
- Implemented automatic repository tracking with background data sync
- Shows clear messaging that data is being gathered (1-2 minute estimate)

## Problem
When users searched for repositories not yet in our database (like PyTorch), the search would appear to hang with no feedback. This created a poor user experience as reported in issue #222.

## Solution
Created a new hook `useTrackRepositoryWithNotification` that:
1. Detects when a searched repository isn't tracked
2. Shows a friendly toast notification explaining what's happening
3. Automatically adds the repository to tracking
4. Triggers high-priority background sync via Inngest
5. Displays a welcome message with time estimate
6. Prevents "not found" errors during initial setup

## Test plan
- [x] Search for a new repository (e.g., pytorch/pytorch)
- [x] Verify toast notification appears
- [x] Confirm welcome message is displayed
- [x] Check that repository gets added to tracked_repositories table
- [x] Ensure data loads after 1-2 minutes
- [x] Test with already-tracked repositories to ensure no regression

Fixes #222

🤖 Generated with [Claude Code](https://claude.ai/code)