### PR TITLE
fix: Remove non-existent pull_request_number column references

### DIFF
--- a/src/lib/inngest/functions/capture-pr-details-graphql.ts
+++ b/src/lib/inngest/functions/capture-pr-details-graphql.ts
@@ -17,7 +17,6 @@ interface ReviewComment {
   repository_id: string;
   pull_request_id: string;
   github_id: number;
-  pull_request_number: number;
   review_id?: number;
   body: string;
   path?: string;
@@ -283,7 +282,6 @@ export const capturePrDetailsGraphQL = inngest.createFunction(
           repository_id: string;
           pull_request_id: string;
           github_id: number;
-          pull_request_number: number;
           state: string;
           body: string;
           author_id: string;
@@ -297,7 +295,6 @@ export const capturePrDetailsGraphQL = inngest.createFunction(
               repository_id: repositoryId,
               pull_request_id: prInternalId,
               github_id: review.databaseId,
-              pull_request_number: pullRequest.number,
               state: review.state?.toLowerCase(),
               body: review.body,
               author_id: reviewAuthorId,
@@ -331,7 +328,6 @@ export const capturePrDetailsGraphQL = inngest.createFunction(
           repository_id: string;
           pull_request_id: string;
           github_id: number;
-          pull_request_number: number;
           body: string;
           commenter_id: string;
           created_at: string;
@@ -345,7 +341,6 @@ export const capturePrDetailsGraphQL = inngest.createFunction(
               repository_id: repositoryId,
               pull_request_id: prInternalId,
               github_id: comment.databaseId,
-              pull_request_number: pullRequest.number,
               body: comment.body,
               commenter_id: commenterId,
               created_at: comment.createdAt,
@@ -396,7 +391,6 @@ export const capturePrDetailsGraphQL = inngest.createFunction(
               repository_id: repositoryId,
               pull_request_id: prInternalId,
               github_id: comment.databaseId,
-              pull_request_number: pullRequest.number,
               review_id: review.databaseId,
               body: comment.body,
               path: comment.path,


### PR DESCRIPTION
## Summary
- Removed all references to `pull_request_number` column from the capture-pr-details-graphql function
- Fixed schema cache errors that were preventing reviews and comments from being stored
- The database tables use `pull_request_id` (UUID) instead of `pull_request_number`

## Problem
The inngest function was failing with this error:
```
Error: Failed to store reviews: Could not find the 'pull_request_number' column of 'reviews' in the schema cache
```

## Solution
Removed `pull_request_number` from:
- ReviewComment interface definition
- reviewsToStore array type and data
- issueCommentsToStore array type and data
- reviewCommentsToStore data

The tables already have `pull_request_id` which properly references the pull_requests table.

## Test plan
- [x] Build passes without TypeScript errors
- [ ] Deploy and verify PR data capture works without schema errors
- [ ] Check that reviews and comments are stored correctly

🤖 Generated with [Claude Code](https://claude.ai/code)