### PR TITLE
fix: Add comprehensive schema.org markup for contributor.info

### DIFF
--- a/src/components/common/layout/index.ts
+++ b/src/components/common/layout/index.ts
@@ -2,4 +2,5 @@ export { default as Layout } from './layout';
 export { default as Home } from './home';
 export { default as NotFound } from './not-found';
 export { MetaTagsProvider, SocialMetaTags } from './meta-tags-provider';
+export { SchemaMarkup } from './schema-markup';
 export { Markdown } from './markdown';

--- a/src/components/common/layout/schema-markup.tsx
+++ b/src/components/common/layout/schema-markup.tsx
@@ -1,0 +1,49 @@
+import { Helmet } from "react-helmet-async";
+import { 
+  generateSchemaMarkup, 
+  getPlatformSchemas,
+  type Organization,
+  type SoftwareApplication,
+  type WebSite
+} from "@/lib/schema-org";
+
+interface SchemaMarkupProps {
+  /**
+   * Additional schemas to include beyond the default platform schemas
+   */
+  additionalSchemas?: (Organization | SoftwareApplication | WebSite)[];
+  /**
+   * Whether to include the default platform schemas (SoftwareApplication + WebSite)
+   * @default true
+   */
+  includePlatformSchemas?: boolean;
+}
+
+/**
+ * Component that injects schema.org JSON-LD markup into the page head
+ * Automatically includes platform-level schemas (SoftwareApplication, WebSite, Organization)
+ * and allows for additional page-specific schemas
+ */
+export function SchemaMarkup({ 
+  additionalSchemas = [], 
+  includePlatformSchemas = true 
+}: SchemaMarkupProps) {
+  const schemas = [
+    ...(includePlatformSchemas ? getPlatformSchemas() : []),
+    ...additionalSchemas
+  ];
+
+  if (schemas.length === 0) {
+    return null;
+  }
+
+  const jsonLd = generateSchemaMarkup(schemas);
+
+  return (
+    <Helmet>
+      <script type="application/ld+json">
+        {jsonLd}
+      </script>
+    </Helmet>
+  );
+}

--- a/src/lib/schema-org.ts
+++ b/src/lib/schema-org.ts
@@ -1,0 +1,159 @@
+/**
+ * Schema.org structured data utilities for contributor.info
+ * Provides JSON-LD markup for better search engine understanding
+ */
+
+interface ContactPoint {
+  '@type': 'ContactPoint';
+  contactType: string;
+  url: string;
+}
+
+export interface Organization {
+  '@context': 'https://schema.org';
+  '@type': 'Organization';
+  name: string;
+  url: string;
+  logo?: string;
+  description?: string;
+  contactPoint?: ContactPoint[];
+  foundingDate?: string;
+  sameAs?: string[];
+}
+
+export interface SoftwareApplication {
+  '@context': 'https://schema.org';
+  '@type': 'SoftwareApplication';
+  name: string;
+  description: string;
+  url: string;
+  applicationCategory: string;
+  operatingSystem: string;
+  browserRequirements?: string;
+  offers?: {
+    '@type': 'Offer';
+    price: string;
+    priceCurrency: string;
+  };
+  author?: Organization;
+  datePublished?: string;
+  version?: string;
+  aggregateRating?: {
+    '@type': 'AggregateRating';
+    ratingValue: string;
+    ratingCount: string;
+  };
+}
+
+interface SearchAction {
+  '@type': 'SearchAction';
+  target: {
+    '@type': 'EntryPoint';
+    urlTemplate: string;
+  };
+  'query-input': string;
+}
+
+export interface WebSite {
+  '@context': 'https://schema.org';
+  '@type': 'WebSite';
+  name: string;
+  url: string;
+  description?: string;
+  potentialAction?: SearchAction;
+  publisher?: Organization;
+}
+
+/**
+ * Get the organization schema for contributor.info
+ */
+export function getOrganizationSchema(): Organization {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    name: 'contributor.info',
+    url: 'https://contributor.info',
+    logo: 'https://contributor.info/social.webp',
+    description: 'Open source platform for visualizing GitHub contributors and their contributions',
+    contactPoint: [
+      {
+        '@type': 'ContactPoint',
+        contactType: 'customer service',
+        url: 'https://github.com/bdougie/contributor.info/issues'
+      }
+    ],
+    foundingDate: '2024',
+    sameAs: [
+      'https://github.com/bdougie/contributor.info',
+      'https://twitter.com/bdougieYO'
+    ]
+  };
+}
+
+/**
+ * Get the software application schema for contributor.info
+ */
+export function getSoftwareApplicationSchema(): SoftwareApplication {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareApplication',
+    name: 'contributor.info',
+    description: 'Discover and visualize GitHub contributors and their contributions. Track open source activity, analyze contribution patterns, and celebrate community impact.',
+    url: 'https://contributor.info',
+    applicationCategory: 'DeveloperApplication',
+    operatingSystem: 'Any',
+    browserRequirements: 'Requires JavaScript. Modern browser required.',
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'USD'
+    },
+    author: getOrganizationSchema(),
+    datePublished: '2024',
+    version: '1.0'
+  };
+}
+
+/**
+ * Get the website schema with search action for contributor.info
+ */
+export function getWebSiteSchema(): WebSite {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: 'contributor.info',
+    url: 'https://contributor.info',
+    description: 'Discover and visualize GitHub contributors and their contributions. Track open source activity, analyze contribution patterns, and celebrate community impact.',
+    potentialAction: {
+      '@type': 'SearchAction',
+      target: {
+        '@type': 'EntryPoint',
+        urlTemplate: 'https://contributor.info/{owner}/{repo}'
+      },
+      'query-input': 'required name=owner,repo'
+    },
+    publisher: getOrganizationSchema()
+  };
+}
+
+/**
+ * Generate JSON-LD script tag content for schema markup
+ */
+export function generateSchemaMarkup(schemas: (Organization | SoftwareApplication | WebSite)[]): string {
+  if (schemas.length === 1) {
+    return JSON.stringify(schemas[0], null, 0);
+  }
+  
+  // Multiple schemas - wrap in array
+  return JSON.stringify(schemas, null, 0);
+}
+
+/**
+ * Get all platform-level schemas for the main application
+ */
+export function getPlatformSchemas(): (Organization | SoftwareApplication | WebSite)[] {
+  return [
+    getSoftwareApplicationSchema(),
+    getWebSiteSchema()
+  ];
+}

--- a/src/lib/schema-org.ts
+++ b/src/lib/schema-org.ts
@@ -130,7 +130,7 @@ export function getWebSiteSchema(): WebSite {
         '@type': 'EntryPoint',
         urlTemplate: 'https://contributor.info/{owner}/{repo}'
       },
-      'query-input': 'required name=owner,repo'
+      'query-input': 'required name=search_term_string'
     },
     publisher: getOrganizationSchema()
   };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import './index.css';
-import { MetaTagsProvider } from './components/common/layout';
+import { MetaTagsProvider, SchemaMarkup } from './components/common/layout';
 
 // Sentry removed - was causing React hooks conflicts
 
@@ -30,6 +30,7 @@ const root = createRoot(rootElement);
 root.render(
   <StrictMode>
     <MetaTagsProvider>
+      <SchemaMarkup />
       <App />
     </MetaTagsProvider>
   </StrictMode>


### PR DESCRIPTION
Implements platform-level schema.org JSON-LD markup to improve search engine understanding.

## Changes
- Add SoftwareApplication schema describing contributor.info as a developer tool
- Include Organization schema with logo, contact info, and social links
- Add WebSite schema with SearchAction for `{owner}/{repo}` discovery
- Integrate schemas into all pages via main entry point
- Create reusable schema utilities and React components

## Validation
All schema types are ready for Google Rich Results Test validation.

Fixes #267

Generated with [Claude Code](https://claude.ai/code)