### PR TITLE
refactor: Update sitemap workflow for deprecated ping endpoints

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,41 +73,48 @@ jobs:
       # Netlify will automatically deploy from main branch via GitHub integration
       # No manual deployment needed here
 
-  submit-sitemap:
-    name: Submit Sitemap to Search Engines
+  verify-sitemap:
+    name: Verify Sitemap Accessibility
     runs-on: ubuntu-latest
     needs: [release]
     if: needs.release.outputs.released == 'true'
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          
       - name: Wait for Netlify deployment
         run: |
           echo "Waiting 2 minutes for Netlify deployment to complete..."
           sleep 120
           
-      - name: Verify sitemap is accessible
+      - name: Verify sitemaps are accessible
         run: |
-          echo "Checking if sitemap is accessible..."
-          curl -f https://contributor.info/sitemap.xml > /dev/null || exit 1
-          echo "✅ Sitemap is accessible"
+          echo "Verifying sitemap accessibility..."
           
-      - name: Submit sitemap to search engines
-        run: |
-          echo "Submitting sitemap to search engines..."
-          node scripts/sitemap/submit-sitemap.js
-        continue-on-error: true
+          # Check main sitemap
+          if curl -f -s https://contributor.info/sitemap.xml > /dev/null; then
+            echo "✅ Main sitemap is accessible"
+          else
+            echo "❌ Main sitemap is NOT accessible"
+            exit 1
+          fi
+          
+          # Check news sitemap
+          if curl -f -s https://contributor.info/sitemap-news.xml > /dev/null; then
+            echo "✅ News sitemap is accessible"
+          else
+            echo "❌ News sitemap is NOT accessible"
+            exit 1
+          fi
+          
+          echo ""
+          echo "📝 Note: Sitemaps must be manually submitted to:"
+          echo "- Google Search Console: https://search.google.com/search-console"
+          echo "- Bing Webmaster Tools: https://www.bing.com/webmasters"
+          echo ""
+          echo "✨ Sitemaps are also referenced in robots.txt for automatic discovery"
 
   notify:
     name: Release Notification
     runs-on: ubuntu-latest
-    needs: [release, submit-sitemap]
+    needs: [release, verify-sitemap]
     if: needs.release.outputs.released == 'true'
     steps:
       - name: Create release summary

--- a/scripts/sitemap/README.md
+++ b/scripts/sitemap/README.md
@@ -40,19 +40,21 @@ npm run build
 ```
 
 ### `submit-sitemap.js`
-Submits generated sitemaps to search engines.
+Verifies sitemap accessibility (ping endpoints deprecated as of June 2023).
 
-**Supported Search Engines:**
-- Google (main and news sitemap)
-- Bing (main and news sitemap)
+**Purpose:**
+- Verifies sitemaps are accessible via HTTP
+- Provides instructions for manual submission
 
 **Usage:**
 ```bash
-# Manual submission (if needed)
+# Verify sitemap accessibility
 node scripts/sitemap/submit-sitemap.js
 ```
 
-**Note:** This script runs automatically after each release via GitHub Actions workflow.
+**Important:** Google and Bing deprecated their ping endpoints in 2023. Sitemaps must now be:
+1. Manually submitted via Search Console/Webmaster Tools
+2. OR discovered automatically via robots.txt (already configured)
 
 ## Generated Files
 
@@ -72,8 +74,8 @@ node scripts/sitemap/submit-sitemap.js
 2. **After Release (Automated):**
    - GitHub Actions workflow triggers after successful release
    - Waits 2 minutes for Netlify deployment to complete
-   - Verifies sitemap accessibility at `https://contributor.info/sitemap.xml`
-   - Automatically submits sitemaps to Google and Bing
+   - Verifies both sitemaps are accessible via HTTP
+   - Logs verification results and submission instructions
    - Adds sitemap link to release summary
 
 ### Manual Process (if needed)
@@ -106,14 +108,14 @@ After submission, monitor sitemap status at:
 
 ## GitHub Actions Integration
 
-The sitemap submission is integrated into the release workflow (`.github/workflows/release.yml`):
+The sitemap verification is integrated into the release workflow (`.github/workflows/release.yml`):
 
 - **Trigger:** Runs automatically after a successful release
-- **Job:** `submit-sitemap` 
+- **Job:** `verify-sitemap` 
 - **Steps:**
   1. Waits for Netlify deployment (2 minutes)
-  2. Verifies sitemap is accessible
-  3. Submits to search engines
+  2. Verifies both sitemaps are accessible
+  3. Logs verification results
   4. Updates release summary with sitemap link
 
 ## Notes
@@ -122,5 +124,5 @@ The sitemap submission is integrated into the release workflow (`.github/workflo
 - Repository subpages (/health, /distribution) are only included for high-priority repos (>= 0.75)
 - Sitemap is regenerated on every build to ensure fresh data
 - XML escaping is applied to all dynamic content for safety
-- Sitemap submission runs with `continue-on-error: true` to prevent release failures
-- Search engine submission happens automatically - no manual intervention needed
+- Since ping endpoints are deprecated (2023), sitemaps must be manually submitted via webmaster tools
+- Sitemaps are automatically discovered via robots.txt by search engine crawlers

--- a/scripts/sitemap/submit-sitemap.js
+++ b/scripts/sitemap/submit-sitemap.js
@@ -1,8 +1,14 @@
 #!/usr/bin/env node
 
 /**
- * Script to submit sitemap to search engines
- * Run this after deploying to production
+ * Script to verify sitemap accessibility
+ * 
+ * NOTE: As of June 2023, Google and Bing have deprecated their sitemap ping endpoints.
+ * Sitemaps must now be submitted manually through:
+ * - Google Search Console: https://search.google.com/search-console
+ * - Bing Webmaster Tools: https://www.bing.com/webmasters
+ * 
+ * Since sitemaps are referenced in robots.txt, search engines will also discover them automatically.
  */
 
 // Use native fetch (available in Node 18+) or https as fallback
@@ -12,65 +18,46 @@ const SITE_URL = 'https://contributor.info';
 const SITEMAP_URL = `${SITE_URL}/sitemap.xml`;
 const NEWS_SITEMAP_URL = `${SITE_URL}/sitemap-news.xml`;
 
-// Search engine submission endpoints
-const SUBMISSION_URLS = {
-  google: `https://www.google.com/ping?sitemap=${encodeURIComponent(SITEMAP_URL)}`,
-  googleNews: `https://www.google.com/ping?sitemap=${encodeURIComponent(NEWS_SITEMAP_URL)}`,
-  bing: `https://www.bing.com/ping?sitemap=${encodeURIComponent(SITEMAP_URL)}`,
-  bingNews: `https://www.bing.com/ping?sitemap=${encodeURIComponent(NEWS_SITEMAP_URL)}`
-};
-
-function submitSitemap(name, url) {
+function verifySitemap(url) {
   return new Promise((resolve) => {
-    console.log(`📤 Submitting to ${name}...`);
-    
     https.get(url, (res) => {
       if (res.statusCode === 200) {
-        console.log(`✅ Successfully submitted to ${name}`);
         resolve(true);
       } else {
-        console.error(`❌ Failed to submit to ${name}: ${res.statusCode} ${res.statusMessage}`);
         resolve(false);
       }
-    }).on('error', (error) => {
-      console.error(`❌ Error submitting to ${name}:`, error.message);
+    }).on('error', () => {
       resolve(false);
     });
   });
 }
 
 async function main() {
-  console.log('🚀 Starting sitemap submission to search engines...\n');
+  console.log('🔍 Verifying sitemap accessibility...\n');
   console.log(`📍 Main sitemap: ${SITEMAP_URL}`);
   console.log(`📰 News sitemap: ${NEWS_SITEMAP_URL}\n`);
   
-  const results = [];
+  // Verify sitemaps are accessible
+  const mainAccessible = await verifySitemap(SITEMAP_URL);
+  const newsAccessible = await verifySitemap(NEWS_SITEMAP_URL);
   
-  for (const [name, url] of Object.entries(SUBMISSION_URLS)) {
-    const success = await submitSitemap(name, url);
-    results.push({ name, success });
-    
-    // Add a small delay between submissions
-    await new Promise(resolve => setTimeout(resolve, 1000));
-  }
+  console.log('📊 Verification Results:');
+  console.log(`Main sitemap: ${mainAccessible ? '✅ Accessible' : '❌ Not accessible'}`);
+  console.log(`News sitemap: ${newsAccessible ? '✅ Accessible' : '❌ Not accessible'}`);
   
-  console.log('\n📊 Summary:');
-  const successful = results.filter(r => r.success);
-  const failed = results.filter(r => !r.success);
-  
-  if (successful.length > 0) {
-    console.log(`✅ Successful submissions: ${successful.map(r => r.name).join(', ')}`);
-  }
-  
-  if (failed.length > 0) {
-    console.log(`❌ Failed submissions: ${failed.map(r => r.name).join(', ')}`);
-  }
-  
-  console.log('\n💡 Additional steps:');
-  console.log('1. Submit sitemap via Google Search Console: https://search.google.com/search-console');
-  console.log('2. Submit sitemap via Bing Webmaster Tools: https://www.bing.com/webmasters');
-  console.log('3. Verify robots.txt is accessible: https://contributor.info/robots.txt');
-  console.log('4. Monitor indexing status in search console dashboards');
+  console.log('\n⚠️  IMPORTANT: Sitemap ping endpoints have been deprecated!');
+  console.log('Google deprecated ping in June 2023: https://developers.google.com/search/blog/2023/06/sitemaps-lastmod-ping');
+  console.log('\n📝 Manual submission required:');
+  console.log('1. Google Search Console: https://search.google.com/search-console');
+  console.log('   - Add property for contributor.info if not already done');
+  console.log('   - Navigate to Sitemaps section');
+  console.log('   - Submit both sitemap URLs');
+  console.log('\n2. Bing Webmaster Tools: https://www.bing.com/webmasters');
+  console.log('   - Add site if not already done');
+  console.log('   - Go to Sitemaps section');
+  console.log('   - Submit both sitemap URLs');
+  console.log('\n✨ Good news: Since sitemaps are in robots.txt, search engines will discover them automatically!');
+  console.log('   Robots.txt: https://contributor.info/robots.txt');
 }
 
 main().catch(error => {


### PR DESCRIPTION
## Summary
Updated the sitemap submission workflow to reflect that Google and Bing have deprecated their ping endpoints as of 2023.

## Context
After the sitemap feature was merged (#313), we discovered that the ping endpoints return:
- Google: 404 with message "Sitemaps ping is deprecated" 
- Bing: 410 Gone

## Changes Made

### Workflow Updates
- Renamed job from `submit-sitemap` to `verify-sitemap`
- Removed Node.js setup (now just uses curl for verification)
- Job now only verifies sitemap accessibility, doesn't attempt submission
- Added instructions in workflow output about manual submission

### Script Updates
- Updated `submit-sitemap.js` to only verify accessibility
- Added deprecation notice with link to Google's announcement
- Provides clear instructions for manual submission

### Documentation Updates
- Updated README to reflect deprecation
- Clarified that sitemaps must be manually submitted or discovered via robots.txt
- Updated GitHub Actions integration section

## Impact
- ✅ Sitemaps are still generated during build
- ✅ Sitemaps are verified as accessible after deployment
- ✅ Sitemaps are referenced in robots.txt for automatic discovery
- ℹ️ Manual submission required through Google Search Console and Bing Webmaster Tools

## Next Steps
The sitemaps have already been manually submitted to:
- Google Search Console
- Bing Webmaster Tools

They will also be automatically discovered by search engines via robots.txt.

🤖 Generated with Claude Code