### PR TITLE
feat: implement mobile breadcrumb navigation with sticky positioning

### DIFF
--- a/src/components/common/layout/breadcrumbs.tsx
+++ b/src/components/common/layout/breadcrumbs.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useLocation, useParams, Link } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
+import { ChevronLeftIcon } from '@radix-ui/react-icons';
 import {
   Breadcrumb,
   BreadcrumbList,
@@ -9,6 +10,8 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb';
+import { useIsMobile } from '@/lib/utils/mobile-detection';
+import { cn } from '@/lib/utils';
 
 const breadcrumbNameMap: { [key: string]: string } = {
   '': 'home',
@@ -24,6 +27,7 @@ export const Breadcrumbs = () => {
   const location = useLocation();
   const params = useParams();
   const { owner, repo } = params;
+  const isMobile = useIsMobile();
   const pathnames = location.pathname.split('/').filter((x) => x);
 
   const breadcrumbs = pathnames.map((value, index) => {
@@ -34,29 +38,64 @@ export const Breadcrumbs = () => {
     if (index === 0 && owner) name = owner;
     if (index === 1 && repo) name = repo;
 
-    // Make owner/org breadcrumb clickable now that org page exists
-
     return {
       name,
       to,
       isLast,
-      isStatic: false, // Now clickable since org page is implemented
+      isStatic: false,
     };
   });
 
   const homeBreadcrumb = { name: 'home', to: '/', isLast: pathnames.length === 0, isStatic: false };
   const allBreadcrumbs = [homeBreadcrumb, ...breadcrumbs];
 
-  const items = allBreadcrumbs.map((crumb) => (
-    <React.Fragment key={crumb.to}>
+  // Mobile-optimized breadcrumb logic
+  const getMobileBreadcrumbs = () => {
+    if (allBreadcrumbs.length <= 2) {
+      return allBreadcrumbs;
+    }
+    
+    // For mobile, show: Home > ... > Current (max 3 items)
+    const current = allBreadcrumbs[allBreadcrumbs.length - 1];
+    const parent = allBreadcrumbs[allBreadcrumbs.length - 2];
+    
+    return [
+      homeBreadcrumb,
+      ...(allBreadcrumbs.length > 3 ? [{ name: '…', to: '', isLast: false, isStatic: true }] : []),
+      ...(parent ? [parent] : []),
+      current
+    ];
+  };
+
+  const displayBreadcrumbs = isMobile ? getMobileBreadcrumbs() : allBreadcrumbs;
+  
+  // Back button for mobile navigation
+  const getBackButton = () => {
+    if (!isMobile || allBreadcrumbs.length <= 1) return null;
+    
+    const parentCrumb = allBreadcrumbs[allBreadcrumbs.length - 2];
+    return (
+      <Link
+        to={parentCrumb.to}
+        className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors py-2"
+        aria-label={`Go back to ${parentCrumb.name}`}
+      >
+        <ChevronLeftIcon className="h-4 w-4" />
+        <span className="truncate">{parentCrumb.name}</span>
+      </Link>
+    );
+  };
+
+  const items = displayBreadcrumbs.map((crumb) => (
+    <React.Fragment key={crumb.to || crumb.name}>
       <BreadcrumbItem>
         {crumb.isLast ? (
-          <BreadcrumbPage>{crumb.name}</BreadcrumbPage>
+          <BreadcrumbPage className={cn(isMobile && 'text-sm font-medium')}>{crumb.name}</BreadcrumbPage>
         ) : crumb.isStatic ? (
           <span className="text-muted-foreground">{crumb.name}</span>
         ) : (
           <BreadcrumbLink asChild>
-            <Link to={crumb.to}>{crumb.name}</Link>
+            <Link to={crumb.to} className={cn(isMobile && 'text-sm')}>{crumb.name}</Link>
           </BreadcrumbLink>
         )}
       </BreadcrumbItem>
@@ -80,9 +119,25 @@ export const Breadcrumbs = () => {
       <Helmet>
         <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
       </Helmet>
-      <Breadcrumb className="hidden md:flex mb-4">
-        <BreadcrumbList>{items}</BreadcrumbList>
-      </Breadcrumb>
+      
+      {/* Mobile: Pinned breadcrumb with back button */}
+      {isMobile ? (
+        <div className="sticky top-0 z-40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b md:hidden">
+          <div className="container px-4 py-2">
+            {getBackButton()}
+            <div className="overflow-x-auto overflow-y-hidden" style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}>
+              <Breadcrumb className="whitespace-nowrap" style={{ WebkitScrollbar: 'none' } as React.CSSProperties}>
+                <BreadcrumbList className="flex-nowrap">{items}</BreadcrumbList>
+              </Breadcrumb>
+            </div>
+          </div>
+        </div>
+      ) : (
+        /* Desktop: Standard breadcrumb */
+        <Breadcrumb className="hidden md:flex mb-4">
+          <BreadcrumbList>{items}</BreadcrumbList>
+        </Breadcrumb>
+      )}
     </>
   );
 };


### PR DESCRIPTION
## Mobile Breadcrumbs Implementation

Implements mobile-responsive breadcrumb navigation with sticky positioning as requested in #321.

### Features
- ✅ Sticky top positioning for mobile screens
- ✅ Back button navigation with parent breadcrumb
- ✅ Smart truncation for long navigation paths
- ✅ Horizontal scroll support for overflow content
- ✅ Responsive design (mobile vs desktop)
- ✅ Maintains existing desktop behavior and SEO

### Technical Details
- Uses existing `useIsMobile()` hook for responsive detection
- Preserves schema.org structured data for SEO
- No breaking changes to existing breadcrumb API
- Modern backdrop blur effects for native mobile feel

Closes #321

Generated with [Claude Code](https://claude.ai/code)