### PR TITLE
fix: remove vite-bundle-analyzer to resolve Netlify build failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -132,7 +132,6 @@
         "typescript-eslint": "^8.7.0",
         "unplugin-icons": "^22.2.0",
         "vite": "^6.3.5",
-        "vite-bundle-analyzer": "^1.1.0",
         "vitest": "^3.1.1",
         "wait-on": "^8.0.3"
       },
@@ -25340,16 +25339,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite-bundle-analyzer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/vite-bundle-analyzer/-/vite-bundle-analyzer-1.1.0.tgz",
-      "integrity": "sha512-f/9m+6S5yPOHf/QS00rLOkyQ0icZeF67roM3O5LZZMPTOZFU1bHJTptNHCKMJc2yxXzj0Hunwcetrc+vM2LEQQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "analyze": "dist/bin.js"
       }
     },
     "node_modules/vite-imagetools": {

--- a/package.json
+++ b/package.json
@@ -198,7 +198,6 @@
     "typescript-eslint": "^8.7.0",
     "unplugin-icons": "^22.2.0",
     "vite": "^6.3.5",
-    "vite-bundle-analyzer": "^1.1.0",
     "vitest": "^3.1.1",
     "wait-on": "^8.0.3"
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,20 +2,11 @@ import path from 'path';
 import react from '@vitejs/plugin-react-swc';
 import { defineConfig } from 'vite';
 import { imagetools } from 'vite-imagetools';
-import { analyzer } from 'vite-bundle-analyzer';
 
-export default defineConfig(({ mode }) => ({
+export default defineConfig(() => ({
   base: '/',
   plugins: [
     react(),
-    // Only include bundle analyzer in development or when explicitly requested
-    ...(mode === 'development' || process.env.BUNDLE_ANALYZE === 'true' ? [
-      analyzer({
-        analyzerMode: 'static',
-        fileName: 'bundle-analysis',
-        openAnalyzer: false
-      })
-    ] : []),
     imagetools({
       defaultDirectives: (url) => {
         // Process images for WebP optimization


### PR DESCRIPTION
- Remove vite-bundle-analyzer import and configuration from vite.config.ts
- Uninstall vite-bundle-analyzer package
- Bundle analysis was completed in PR #365, no longer needed

This fixes the Netlify build failure that started after PR #365 merged.

🤖 Generated with [Claude Code](https://claude.ai/code)