### PR TITLE
hotfix: remove broken release trigger step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,26 +78,6 @@ jobs:
             cp CHANGELOG.md public/CHANGELOG.md
           fi
 
-      - name: Create release trigger commit
-        if: github.event.inputs.release_type != 'auto'
-        run: |
-          echo "Manual release type: ${{ github.event.inputs.release_type }}"
-          
-          # Configure git
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          
-          # Create an empty commit with the appropriate message
-          if [ "${{ github.event.inputs.release_type }}" = "major" ]; then
-            git commit --allow-empty -m "feat!: Manual major release trigger
-
-BREAKING CHANGE: Manually triggered major version bump via GitHub Actions workflow dispatch."
-          elif [ "${{ github.event.inputs.release_type }}" = "minor" ]; then
-            git commit --allow-empty -m "feat: Manual minor release trigger via workflow dispatch"
-          elif [ "${{ github.event.inputs.release_type }}" = "patch" ]; then
-            git commit --allow-empty -m "fix: Manual patch release trigger via workflow dispatch"
-          fi
-
       - name: Create Release
         id: release
         uses: cycjimmy/semantic-release-action@v4


### PR DESCRIPTION
## 🚨 HOTFIX: Release workflow is broken on main

## Problem
The release workflow is failing with a syntax error. PR #427 didn't fully remove the broken "Create release trigger commit" step, which is causing the workflow to fail on main.

## Solution
Completely remove the problematic step that tries to create commits in GitHub Actions (which doesn't work due to detached HEAD state).

## Impact
- Release workflow will work again
- Version bumps will be determined by existing commit messages (as originally intended)

## Test Plan
- [ ] Workflow file has valid YAML syntax
- [ ] Release workflow can be triggered via workflow_dispatch
- [ ] Semantic release analyzes commits correctly

This is a critical hotfix to restore release functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)