### PR TITLE
fix: resolve webhook service failures by updating dependencies

### DIFF
--- a/fly-github-webhooks/package-lock.json
+++ b/fly-github-webhooks/package-lock.json
@@ -14,7 +14,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
-        "express-rate-limit": "^7.1.5",
+        "express-rate-limit": "^8.0.1",
         "helmet": "^8.0.0"
       },
       "devDependencies": {
@@ -1627,10 +1627,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.0.1.tgz",
+      "integrity": "sha512-aZVCnybn7TVmxO4BtlmnvX+nuz8qHW124KKJ8dumsBsmv5ZLxE0pYu7S2nwyRBGHHCAzdmnGyrc5U/rksSPO7Q==",
       "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -1832,6 +1835,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",


### PR DESCRIPTION
## Summary
- Fixed GitHub App webhook service that was failing on Fly.io
- Updated package-lock.json dependency versions that were causing deployment issues
- Webhook service is now healthy and running at https://contributor-info-webhooks.fly.dev/

## Problem
The GitHub App webhook handler was completely down (503 errors) due to:
1. Missing Supabase environment variables in Fly.io deployment
2. Package-lock.json out of sync with package.json (express-rate-limit version mismatch)

## Solution
1. Added missing `SUPABASE_URL` and `SUPABASE_ANON_KEY` secrets to Fly.io deployment
2. Updated package-lock.json to resolve dependency conflicts
3. Successfully redeployed the webhook service

## Test Plan
- [x] Verified webhook service health endpoint: https://contributor-info-webhooks.fly.dev/health
- [x] Checked metrics endpoint showing service is ready: https://contributor-info-webhooks.fly.dev/metrics
- [x] Confirmed Fly.io machine status is "started" with passing health checks

## Related Issues
Fixes #342 (webhook failures)
Related to #411 (webhook handler migration)

🤖 Generated with [Claude Code](https://claude.ai/code)