### PR TITLE
Fix Gemini workflow command execution errors

### DIFF
--- a/.github/workflows/gemini-issue-automated-triage.yml
+++ b/.github/workflows/gemini-issue-automated-triage.yml
@@ -93,18 +93,26 @@ jobs:
             tools to gather information; do not ask for information to be
             provided.
 
+            ## Issue Details
+
+            **Title:** ${{ toJSON(github.event.issue.title) }}
+            
+            **Body:** 
+            ${{ toJSON(github.event.issue.body) }}
+            
+            **Issue Number:** ${{ github.event.issue.number }}
+
             ## Steps
 
             1. Run: `gh label list` to get all available labels.
-            2. Review the issue title and body provided in the environment
-               variables: "${ISSUE_TITLE}" and "${ISSUE_BODY}".
+            2. Review the issue title and body provided above.
             3. Select the most relevant labels from the existing labels. If
                available, set labels that follow the `kind/*`, `area/*`, and
                `priority/*` patterns.
             4. Apply the selected labels to this issue using:
-               `gh issue edit "${ISSUE_NUMBER}" --add-label "label1,label2"`
+               `gh issue edit "${{ github.event.issue.number }}" --add-label "label1,label2"`
             5. If the "status/needs-triage" label is present, remove it using:
-               `gh issue edit "${ISSUE_NUMBER}" --remove-label "status/needs-triage"`
+               `gh issue edit "${{ github.event.issue.number }}" --remove-label "status/needs-triage"`
 
             ## Guidelines
 
@@ -112,7 +120,6 @@ jobs:
             - Do not add comments or modify the issue content
             - Triage only the current issue
             - Assign all applicable labels based on the issue content
-            - Reference all shell variables as "${VAR}" (with quotes and braces)
 
       - name: 'Post Issue Triage Failure Comment'
         if: |-

--- a/.github/workflows/gemini-issue-automated-triage.yml
+++ b/.github/workflows/gemini-issue-automated-triage.yml
@@ -16,7 +16,7 @@ on:
         type: 'number'
 
 concurrency:
-  group: '${{ github.workflow }}-${{ github.event.issue.number }}'
+  group: '${{ github.workflow }}-${{ github.event.issue.number || inputs.issue_number }}'
   cancel-in-progress: true
 
 defaults:
@@ -55,14 +55,25 @@ jobs:
           app-id: '${{ vars.APP_ID }}'
           private-key: '${{ secrets.APP_PRIVATE_KEY }}'
 
+      - name: 'Fetch Issue Details for Workflow Dispatch'
+        id: 'fetch_issue'
+        if: |-
+          ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          GH_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
+        run: |
+          issue_data=$(gh issue view ${{ inputs.issue_number }} --json title,body)
+          echo "title=$(echo "$issue_data" | jq -r '.title')" >> $GITHUB_OUTPUT
+          echo "body=$(echo "$issue_data" | jq -r '.body')" >> $GITHUB_OUTPUT
+
       - name: 'Run Gemini Issue Triage'
         uses: 'google-github-actions/run-gemini-cli@v0'
         id: 'gemini_issue_triage'
         env:
           GITHUB_TOKEN: '${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}'
-          ISSUE_TITLE: '${{ github.event.issue.title }}'
-          ISSUE_BODY: '${{ github.event.issue.body }}'
-          ISSUE_NUMBER: '${{ github.event.issue.number }}'
+          ISSUE_TITLE: '${{ github.event.issue.title || steps.fetch_issue.outputs.title }}'
+          ISSUE_BODY: '${{ github.event.issue.body || steps.fetch_issue.outputs.body }}'
+          ISSUE_NUMBER: '${{ github.event.issue.number || inputs.issue_number }}'
           REPOSITORY: '${{ github.repository }}'
         with:
           gemini_cli_version: '${{ vars.GEMINI_CLI_VERSION }}'
@@ -95,12 +106,12 @@ jobs:
 
             ## Issue Details
 
-            **Title:** ${{ toJSON(github.event.issue.title) }}
+            **Title:** ${{ toJSON(github.event.issue.title || steps.fetch_issue.outputs.title) }}
             
             **Body:** 
-            ${{ toJSON(github.event.issue.body) }}
+            ${{ toJSON(github.event.issue.body || steps.fetch_issue.outputs.body) }}
             
-            **Issue Number:** ${{ github.event.issue.number }}
+            **Issue Number:** ${{ github.event.issue.number || inputs.issue_number }}
 
             ## Steps
 
@@ -110,9 +121,9 @@ jobs:
                available, set labels that follow the `kind/*`, `area/*`, and
                `priority/*` patterns.
             4. Apply the selected labels to this issue using:
-               `gh issue edit "${{ github.event.issue.number }}" --add-label "label1,label2"`
+               `gh issue edit "${{ github.event.issue.number || inputs.issue_number }}" --add-label "label1,label2"`
             5. If the "status/needs-triage" label is present, remove it using:
-               `gh issue edit "${{ github.event.issue.number }}" --remove-label "status/needs-triage"`
+               `gh issue edit "${{ github.event.issue.number || inputs.issue_number }}" --remove-label "status/needs-triage"`
 
             ## Guidelines
 
@@ -131,6 +142,6 @@ jobs:
             github.rest.issues.createComment({
               owner: '${{ github.repository }}'.split('/')[0],
               repo: '${{ github.repository }}'.split('/')[1],
-              issue_number: '${{ github.event.issue.number }}',
+              issue_number: '${{ github.event.issue.number || inputs.issue_number }}',
               body: 'There is a problem with the Gemini CLI issue triaging. Please check the [action logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.'
             })

--- a/.github/workflows/gemini-issue-scheduled-triage.yml
+++ b/.github/workflows/gemini-issue-scheduled-triage.yml
@@ -85,10 +85,8 @@ jobs:
             {
               "maxSessionTurns": 25,
               "coreTools": [
-                "run_shell_command(echo)",
                 "run_shell_command(gh label list)",
-                "run_shell_command(gh issue edit)",
-                "run_shell_command(gh issue list)"
+                "run_shell_command(gh issue edit)"
               ],
               "telemetry": {
                 "enabled": false,
@@ -102,22 +100,26 @@ jobs:
             appropriate labels. Use the available tools to gather information;
             do not ask for information to be provided.
 
+            ## Issues to Triage
+
+            The following issues need triage:
+            ${{ toJSON(steps.find_issues.outputs.issues_to_triage) }}
+
             ## Steps
 
             1. Run: `gh label list`
-            2. Check environment variable: "${ISSUES_TO_TRIAGE}" (JSON array
-               of issues)
+            2. Review the issues provided above (JSON array format)
             3. For each issue, apply labels:
-               `gh issue edit "${ISSUE_NUMBER}" --add-label "label1,label2"`.
+               `gh issue edit [ISSUE_NUMBER] --add-label "label1,label2"`.
                If available, set labels that follow the `kind/*`, `area/*`,
                and `priority/*` patterns.
             4. For each issue, if the `status/needs-triage` label is present,
                remove it using:
-               `gh issue edit "${ISSUE_NUMBER}" --remove-label "status/needs-triage"`
+               `gh issue edit [ISSUE_NUMBER] --remove-label "status/needs-triage"`
 
             ## Guidelines
 
             - Only use existing repository labels
             - Do not add comments
             - Triage each issue independently
-            - Reference all shell variables as "${VAR}" (with quotes and braces)
+            - Use the issue numbers from the JSON data provided above


### PR DESCRIPTION
## Problem
The Gemini issue triage workflows were failing with the error:
```
Error executing tool run_shell_command: Command(s) not in the allowed commands list.
```

This was happening because the Gemini CLI was trying to access environment variables (`${ISSUE_TITLE}`, `${ISSUE_BODY}`, etc.) using shell commands, but these commands weren't in the allowed commands list.

## Solution
- Embed issue data directly in the prompt using GitHub Actions expressions (`${{ github.event.issue.title }}`)
- Remove references to environment variables in prompts
- Clean up allowed commands list to only include necessary commands

## Changes
- **gemini-issue-automated-triage.yml**: 
  - Added "Issue Details" section with embedded data
  - Replaced environment variable references with direct values
- **gemini-issue-scheduled-triage.yml**: 
  - Embedded issues JSON directly in prompt
  - Removed unnecessary `echo` and `gh issue list` from allowed commands

## Testing
- YAML syntax validated with `npx yaml-lint`
- Workflows will be tested on next issue creation/triage

## Related
- Failed workflow run: https://github.com/bdougie/contributor.info/actions/runs/17016179028
- Issue #453 that triggered the failure