### PR TITLE
fix: resolve top 404 errors with webhook redirects and route fixes

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -66,6 +66,20 @@
   node_bundler = "esbuild"
 
 # Specific API routes (these must come first)
+
+# GitHub webhook redirects to Fly.io service
+[[redirects]]
+  from = "/api/github-webhook"
+  to = "https://contributor-info-webhooks.fly.dev/webhook"
+  status = 307
+  force = true
+
+[[redirects]]
+  from = "/api/github/webhook"
+  to = "https://contributor-info-webhooks.fly.dev/webhook"
+  status = 307
+  force = true
+
 [[redirects]]
   from = "/api/health"
   to = "/.netlify/functions/health-check"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
+import { BrowserRouter as Router, Route, Routes, Navigate } from "react-router-dom";
 import { Suspense, lazy, useEffect } from "react";
 import { ThemeProvider } from "@/components/common/theming";
 import { Toaster } from "@/components/ui/sonner";
@@ -262,12 +262,18 @@ function App() {
           <Suspense fallback={<PageSkeleton />}>
             <Routes>
             <Route path="/login" element={<LoginPage />} />
+            
+            {/* Redirect signup to login page */}
+            <Route path="/signup" element={<Navigate to="/login" replace />} />
 
             <Route path="/" element={<Layout />}>
               <Route index element={<Home />} />
               <Route path="/changelog" element={<ChangelogPage />} />
               <Route path="/docs" element={<DocsList />} />
               <Route path="/docs/:slug" element={<DocDetail />} />
+              
+              {/* Redirect search/feedback to docs */}
+              <Route path="/search/feedback" element={<Navigate to="/docs" replace />} />
               <Route path="/widgets" element={<WidgetsPage />} />
               <Route path="/:owner/:repo/widgets" element={<WidgetsPage />} />
               <Route 


### PR DESCRIPTION
Fixes the top 404 errors identified in analytics from Jul 18 - Aug 17:

## Critical Fixes
- ✅ **Webhook redirects**: Added 307 redirects for `/api/github-webhook` and `/api/github/webhook` to Fly.io service
- ✅ **Missing routes**: Added `/signup` → `/login` and `/search/feedback` → `/docs` redirects
- ✅ **SEO compliance**: robots.txt already properly configured
- ✅ **Deprecated API**: `/api/discover-repository` already returns proper 410 status

## Impact
Should eliminate **~9,790 of the reported 404 errors** (99% of the traffic):
- 9,310 webhook errors → Fixed
- 480 user route errors → Fixed
- 73 bot requests → Already handled
- 52 deprecated API → Already handled

## Technical Notes
- Webhook migration to Fly.io completed in Jan 2025
- Using 307 redirects to preserve POST method for webhooks
- All changes validated with successful build

Closes #454

🤖 Generated with [Claude Code](https://claude.ai/code)