### PR TITLE
🐛 Fix CORS error when loading GitHub identicons for unknown users

### DIFF
--- a/public/sitemap-news.xml
+++ b/public/sitemap-news.xml
@@ -9,7 +9,7 @@
         <news:name>Contributor.info</news:name>
         <news:language>en</news:language>
       </news:publication>
-      <news:publication_date>2025-08-21T19:20:43.436Z</news:publication_date>
+      <news:publication_date>2025-08-22T00:37:21.497Z</news:publication_date>
       <news:title>pytorch/pytorch - Contributor Updates</news:title>
     </news:news>
   </url>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -389,19 +389,19 @@
     <loc>https://contributor.info/pytorch/pytorch</loc>
     <changefreq>daily</changefreq>
     <priority>0.9</priority>
-    <lastmod>2025-08-21T19:20:43.436Z</lastmod>
+    <lastmod>2025-08-22T00:37:21.497Z</lastmod>
   </url>
   <url>
     <loc>https://contributor.info/pytorch/pytorch/health</loc>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
-    <lastmod>2025-08-21T19:20:43.436Z</lastmod>
+    <lastmod>2025-08-22T00:37:21.497Z</lastmod>
   </url>
   <url>
     <loc>https://contributor.info/pytorch/pytorch/distribution</loc>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
-    <lastmod>2025-08-21T19:20:43.436Z</lastmod>
+    <lastmod>2025-08-22T00:37:21.497Z</lastmod>
   </url>
   <url>
     <loc>https://contributor.info/Supabase/supabase</loc>

--- a/src/components/features/activity/contributions.tsx
+++ b/src/components/features/activity/contributions.tsx
@@ -319,11 +319,14 @@ function ContributionsChart({ isRepositoryTracked = true }: ContributionsChartPr
                 }}
                 crossOrigin="anonymous"
                 onError={(e) => {
-                  // Fallback to GitHub identicon on error, but only once
+                  // Fallback to GitHub avatar API on error, but only once
                   const target = e.target as HTMLImageElement;
                   if (!target.dataset.retried) {
                     target.dataset.retried = 'true';
-                    target.src = `https://github.com/identicons/${props.node.data.contributor}.png`;
+                    // Use avatars.githubusercontent.com which provides CORS headers
+                    // Using user ID if available, otherwise a default avatar
+                    const userId = props.node.data._pr?.user?.id || 0;
+                    target.src = `https://avatars.githubusercontent.com/u/${userId}?v=4`;
                   }
                 }}
               />

--- a/src/lib/supabase-avatar-cache.ts
+++ b/src/lib/supabase-avatar-cache.ts
@@ -147,7 +147,8 @@ class SupabaseAvatarCache {
       }
 
       // Return GitHub default avatar as last resort
-      const defaultUrl = `https://github.com/identicons/${username}.png`;
+      // Use avatars.githubusercontent.com which provides CORS headers
+      const defaultUrl = `https://avatars.githubusercontent.com/u/${githubId}?v=4`;
       const result: CachedAvatarResult = {
         url: defaultUrl,
         isCached: false,
@@ -175,9 +176,9 @@ class SupabaseAvatarCache {
         };
       }
 
-      // Final fallback
+      // Final fallback - use GitHub avatar API with CORS headers
       return {
-        url: `https://github.com/identicons/${username}.png`,
+        url: `https://avatars.githubusercontent.com/u/${githubId}?v=4`,
         isCached: false,
         source: 'github'
       };
@@ -264,8 +265,8 @@ class SupabaseAvatarCache {
                 this.queueCacheUpdate(contributor.githubId, contributor.username, contributor.fallbackUrl);
               }
             } else {
-              // Use GitHub default
-              const defaultUrl = `https://github.com/identicons/${contributor.username}.png`;
+              // Use GitHub default - avatars API with CORS headers
+              const defaultUrl = `https://avatars.githubusercontent.com/u/${contributor.githubId}?v=4`;
               const result: CachedAvatarResult = {
                 url: defaultUrl,
                 isCached: false,
@@ -282,8 +283,9 @@ class SupabaseAvatarCache {
       for (const contributor of uncachedContributors) {
         if (!results.has(contributor.githubId)) {
           const localCached = localCache.get(contributor.username);
+          // Use GitHub avatar API with CORS headers as final fallback
           const url = localCached || contributor.fallbackUrl || 
-                     `https://github.com/identicons/${contributor.username}.png`;
+                     `https://avatars.githubusercontent.com/u/${contributor.githubId}?v=4`;
           const result: CachedAvatarResult = {
             url,
             isCached: !!localCached,


### PR DESCRIPTION
## Summary
Fixes the CORS errors that occur when the application tries to load GitHub identicons for unknown users. GitHub doesn't serve identicon images with proper CORS headers, causing browser errors.

## Problem
- Application was using `https://github.com/identicons/username.png` for fallback avatars
- GitHub doesn't provide `Access-Control-Allow-Origin` headers for identicon images
- This resulted in CORS errors and broken images in the browser

## Solution
Replaced all GitHub identicon URLs with the GitHub Avatar API which provides proper CORS headers:
- Changed from: `https://github.com/identicons/username.png`
- Changed to: `https://avatars.githubusercontent.com/u/{userId}?v=4`

## Changes
- Updated `src/lib/supabase-avatar-cache.ts` - replaced 4 instances of identicon URLs
- Updated `src/components/features/activity/contributions.tsx` - fixed error fallback handler

## Testing
- ✅ No TypeScript errors
- ✅ Build completes successfully
- ✅ Dev server runs without CORS errors
- ✅ Unknown users now show proper fallback avatars

Fixes #470

🤖 Generated with [Claude Code](https://claude.ai/code)