### PR TITLE
feat: update leaderboard cards to match workspace contributor card styling

### DIFF
--- a/src/components/features/contributor/contributor-card.tsx
+++ b/src/components/features/contributor/contributor-card.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/lib/utils";
+import { cn, humanizeNumber } from "@/lib/utils";
 import { MonthlyContributor } from "@/lib/types";
 import { OptimizedAvatar } from "@/components/ui/optimized-avatar";
 import { Badge } from "@/components/ui/badge";
@@ -109,25 +109,34 @@ export function ContributorCard({
             )}
           </div>
           
-          <div className="flex items-center gap-4 mt-1 text-xs text-muted-foreground">
-            <div className="flex items-center gap-1">
-              <GitPullRequest className="h-3 w-3" />
-              <span>{activity.pullRequests}</span>
+          <div className="grid grid-cols-3 gap-2 mt-3">
+            <div className="text-center">
+              <div className="flex items-center justify-center gap-1">
+                <GitPullRequest className="h-3 w-3 text-muted-foreground" />
+                <span className="text-sm font-medium">{humanizeNumber(activity.pullRequests)}</span>
+              </div>
+              <p className="text-xs text-muted-foreground">PRs</p>
             </div>
-            <div className="flex items-center gap-1">
-              <GitPullRequestDraft className="h-3 w-3" />
-              <span>{activity.reviews}</span>
+            <div className="text-center">
+              <div className="flex items-center justify-center gap-1">
+                <GitPullRequestDraft className="h-3 w-3 text-muted-foreground" />
+                <span className="text-sm font-medium">{humanizeNumber(activity.reviews)}</span>
+              </div>
+              <p className="text-xs text-muted-foreground">Reviews</p>
             </div>
-            <div className="flex items-center gap-1">
-              <MessageSquare className="h-3 w-3" />
-              <span>{activity.comments}</span>
+            <div className="text-center">
+              <div className="flex items-center justify-center gap-1">
+                <MessageSquare className="h-3 w-3 text-muted-foreground" />
+                <span className="text-sm font-medium">{humanizeNumber(activity.comments)}</span>
+              </div>
+              <p className="text-xs text-muted-foreground">Comments</p>
             </div>
           </div>
-          
-          <div className="mt-2">
-            <span className="text-xs font-medium">
+
+          <div className="flex items-center justify-end pt-3 border-t mt-3">
+            <Badge variant="secondary" className="text-xs">
               Score: {activity.totalScore}
-            </span>
+            </Badge>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Updates the leaderboard cards to match the styling of workspace contributor cards as requested in #527.

## Changes
- Changed layout from horizontal stats to 3-column grid layout
- Added stat labels below numbers (PRs, Reviews, Comments)
- Moved score to bottom-right badge with border separator
- Added humanizeNumber for consistent number formatting
- Maintained existing rank badge functionality

## Impact
Leaderboard cards now have consistent styling with workspace contributor cards, providing a more cohesive user experience.

Fixes #527

Generated with [Claude Code](https://claude.ai/code)