### PR TITLE
fix: move action timestamps to HTML comments

### DIFF
--- a/.github/workflows/capture-workspace-issues.yml
+++ b/.github/workflows/capture-workspace-issues.yml
@@ -146,7 +146,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: recentIssue.number,
-                body: `Sync failed again at ${new Date().toISOString()}\n\n[View Run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`
+                body: `Sync failed again\n<!-- ${new Date().toISOString()} -->\n\n[View Run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`
               });
               console.log(`Updated existing issue #${recentIssue.number}`);
             } else {
@@ -158,7 +158,7 @@ jobs:
                 body: `The scheduled workspace issues sync workflow failed.
                 
                 **Workflow Run:** [View Run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})
-                **Time:** ${new Date().toISOString()}
+                <!-- Time: ${new Date().toISOString()} -->
                 
                 Please investigate the failure and ensure the sync is working properly.`,
                 labels: ['bug', 'automation']

--- a/.github/workflows/performance-monitoring.yml
+++ b/.github/workflows/performance-monitoring.yml
@@ -83,7 +83,7 @@ jobs:
             
             ${status}
             
-            **Last Updated:** ${new Date().toISOString()}
+            <!-- Last Updated: ${new Date().toISOString()} -->
             **Commit:** ${context.sha.substring(0, 7)}
             
             See the [workflow summary](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for detailed bundle sizes.`;
@@ -345,7 +345,7 @@ jobs:
             - Check the workflow summary for detailed metrics
             - Address any performance warnings or errors
             
-            **Last Updated:** ${new Date().toISOString()}
+            <!-- Last Updated: ${new Date().toISOString()} -->
             **Commit:** ${context.sha.substring(0, 7)}
             
             [View Full Workflow Results](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})`;

--- a/actions/continue-review/index.ts
+++ b/actions/continue-review/index.ts
@@ -317,7 +317,7 @@ async function postReview(
       body = '**✅ Review Complete**\n\n';
     }
     body += review;
-    body += `\n\n---\n*${timestamp} | Powered by [Continue](https://continue.dev)*`;
+    body += `\n\n---\n<!-- ${timestamp} | Powered by Continue (https://continue.dev) -->`;
   }
   
   body = `${marker}\n${body}`;


### PR DESCRIPTION
## Summary
- Converts plain text timestamps to HTML comments in GitHub Actions
- Prevents timestamps from cluttering PR/issue comments while preserving the information
- Fixes #532

## Changes
- **Continue Review action** - Changed the timestamp footer from visible text to an HTML comment
- **Performance monitoring workflow** - Converted "Last Updated" timestamps to HTML comments  
- **Workspace issues capture workflow** - Made timestamps hidden in issue comments

## Test plan
- [x] Build passes successfully
- [ ] Continue Review action still includes timestamp (hidden in HTML comment)
- [ ] Performance monitoring comments show clean format without visible timestamps
- [ ] Workspace issue sync failure comments are cleaner

🤖 Generated with [Claude Code](https://claude.ai/code)