### PR TITLE
fix: display specific time ranges in workspace metrics trend labels

### DIFF
--- a/src/components/features/workspace/WorkspaceDashboard.tsx
+++ b/src/components/features/workspace/WorkspaceDashboard.tsx
@@ -3,6 +3,7 @@ import { MetricCard } from "./MetricCard";
 import { TrendChart } from "./TrendChart";
 import { ActivityChart, type ActivityDataPoint } from "./ActivityChart";
 import { RepositoryList, type Repository } from "./RepositoryList";
+import { TimeRange } from "./TimeRangeSelector";
 import { 
   Star, 
   GitPullRequest, 
@@ -40,12 +41,22 @@ export interface WorkspaceDashboardProps {
   repositories: Repository[];
   loading?: boolean;
   tier?: 'free' | 'pro' | 'enterprise';
+  timeRange?: TimeRange;
   onAddRepository?: () => void;
   onRepositoryClick?: (repo: Repository) => void;
   onSettingsClick?: () => void;
   onUpgradeClick?: () => void;
   className?: string;
 }
+
+// Time range labels for trend comparison
+const timeRangeComparisonLabels: Record<TimeRange, string> = {
+  '7d': 'vs previous 7 days',
+  '30d': 'vs previous 30 days', 
+  '90d': 'vs previous 90 days',
+  '1y': 'vs previous year',
+  'all': 'vs previous period',
+};
 
 export function WorkspaceDashboard({
   workspaceId: _workspaceId,
@@ -56,6 +67,7 @@ export function WorkspaceDashboard({
   repositories,
   loading = false,
   tier: _tier = 'free',
+  timeRange = '30d',
   onAddRepository,
   onRepositoryClick,
   onSettingsClick: _onSettingsClick,
@@ -66,6 +78,9 @@ export function WorkspaceDashboard({
     new Set(repositories.filter(r => r.is_pinned).map(r => r.id))
   );
   const [expandedChart, setExpandedChart] = useState<'trends' | 'activity' | null>(null);
+  
+  // Get the trend comparison label based on selected time range
+  const trendLabel = timeRangeComparisonLabels[timeRange];
 
   const handlePinToggle = (repo: Repository) => {
     setPinnedRepos(prev => {
@@ -96,7 +111,7 @@ export function WorkspaceDashboard({
           icon={<Star className="h-4 w-4" />}
           trend={{
             value: metrics.starsTrend,
-            label: "vs last period"
+            label: trendLabel
           }}
           format="compact"
           color="gray"
@@ -111,7 +126,7 @@ export function WorkspaceDashboard({
           icon={<GitPullRequest className="h-4 w-4" />}
           trend={{
             value: metrics.prsTrend,
-            label: "vs last period"
+            label: trendLabel
           }}
           format="number"
           color="green"
@@ -126,7 +141,7 @@ export function WorkspaceDashboard({
           icon={<Users className="h-4 w-4" />}
           trend={{
             value: metrics.contributorsTrend,
-            label: "vs last period"
+            label: trendLabel
           }}
           format="number"
           color="blue"
@@ -141,7 +156,7 @@ export function WorkspaceDashboard({
           icon={<GitCommit className="h-4 w-4" />}
           trend={{
             value: metrics.commitsTrend,
-            label: "vs last period"
+            label: trendLabel
           }}
           format="compact"
           color="purple"

--- a/src/pages/workspace-page.tsx
+++ b/src/pages/workspace-page.tsx
@@ -1500,6 +1500,7 @@ export default function WorkspacePage() {
             activityData={activityData}
             repositories={repositories}
             tier={workspace.tier as 'free' | 'pro' | 'enterprise'}
+            timeRange={timeRange}
             onAddRepository={handleAddRepository}
             onRepositoryClick={handleRepositoryClick}
             onSettingsClick={handleSettingsClick}


### PR DESCRIPTION
Instead of generic "vs last period", metrics cards now show specific time ranges like:
- "vs previous 7 days" 
- "vs previous 30 days"
- "vs previous 90 days"

Changes:
- Added timeRange prop to WorkspaceDashboard component
- Added timeRangeComparisonLabels mapping for dynamic trend labels
- Updated workspace page to pass selected time range to dashboard
- All metric cards (Stars, PRs, Contributors, Commits) now use dynamic labels

Fixes #534

🤖 Generated with [Claude Code](https://claude.ai/code)