### PR TITLE
fix: resolve unused variable warnings in functions and tests

### DIFF
--- a/actions/continue-review/github-app-auth.ts
+++ b/actions/continue-review/github-app-auth.ts
@@ -8,8 +8,8 @@ import * as github from '@actions/github';
  */
 export async function getAuthenticatedOctokit(
   githubToken: string,
-  owner: string,
-  repo: string
+  _owner: string,
+  _repo: string
 ): Promise<ReturnType<typeof github.getOctokit>> {
   // Validate that we have a token
   if (!githubToken) {

--- a/src/app/services/__tests__/git-history.test.ts
+++ b/src/app/services/__tests__/git-history.test.ts
@@ -28,7 +28,6 @@ vi.mock('../../../lib/supabase', () => ({
 describe('Git History Service', () => {
   let mockOctokit: Partial<Octokit>;
   let mockRepository: Repository;
-  let mockLogger: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -67,7 +66,6 @@ describe('Git History Service', () => {
     } as Partial<Octokit>;
 
     // Logger instance is already mocked
-    mockLogger = mockLoggerInstance;
   });
 
   describe('Structured Logging', () => {

--- a/src/app/services/__tests__/issue-similarity.test.ts
+++ b/src/app/services/__tests__/issue-similarity.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Mock dependencies BEFORE importing anything that uses them
 vi.mock('../../../lib/supabase', () => ({
   supabase: {
-    from: vi.fn((table: string) => {
+    from: vi.fn((_table: string) => {
       const chainObj = {
         insert: vi.fn().mockReturnThis(),
         select: vi.fn().mockReturnThis(),
@@ -21,7 +21,7 @@ vi.mock('../../../lib/supabase', () => ({
 }));
 
 vi.mock('@xenova/transformers', () => ({
-  pipeline: vi.fn(() => Promise.resolve((text: string, options: any) => ({
+  pipeline: vi.fn(() => Promise.resolve((_text: string, _options: any) => ({
     data: new Float32Array(384).fill(0.1), // Mock 384-dimensional embedding
     tolist: () => [[...new Float32Array(384).fill(0.1)]]
   }))),

--- a/src/hooks/__tests__/use-intersection-loader-basic.test.ts
+++ b/src/hooks/__tests__/use-intersection-loader-basic.test.ts
@@ -69,7 +69,7 @@ describe('useIntersectionLoader - Basic Tests', () => {
     // Try to load and catch the error
     try {
       await result.current.load();
-    } catch (e) {
+    } catch (_e) {
       // Error is expected
     }
 


### PR DESCRIPTION
Fixes unused variable warnings following the established pattern from #537

## Changes
- Prefix unused function parameters with underscore in actions/continue-review/github-app-auth.ts
- Remove unused mockLogger variable in git-history.test.ts
- Prefix unused mock parameters in issue-similarity.test.ts
- Fix unused catch parameter in use-intersection-loader-basic.test.ts

## Testing
- Build passes without regressions
- TypeScript compilation successful
- Pre-push hooks pass

Closes #543

🤖 Generated with [Claude Code](https://claude.ai/code)