### PR TITLE
fix: handle HTTP 206 partial responses in Service Worker

### DIFF
--- a/docs/workspace/http-206-partial-response-fix.md
+++ b/docs/workspace/http-206-partial-response-fix.md
@@ -1,0 +1,100 @@
+# HTTP 206 Partial Response Service Worker Fix
+
+## Issue Summary
+
+**Problem**: Workspace issues consistently failed to load on the first attempt due to Service Worker attempting to cache HTTP 206 (Partial Content) responses from Supabase.
+
+**Error**: 
+```
+TypeError: Failed to execute 'put' on 'Cache': Partial response (status code 206) is unsupported
+```
+
+## Root Cause
+
+1. **Supabase Query**: The workspace page was using `.range(0, 99)` method which triggers Supabase to return HTTP 206 (Partial Content) responses with `Content-Range` headers
+2. **Service Worker Caching**: The Service Worker's caching strategies (`cacheFirst`, `staleWhileRevalidate`, `networkFirst`) were attempting to cache all successful responses, including 206 responses
+3. **Browser Limitation**: Browsers cannot cache partial responses (HTTP 206) in the Cache API, resulting in the error
+
+## Solution Implemented
+
+### 1. Service Worker Updates (`public/sw-enhanced.js`)
+
+Updated all caching strategies to explicitly check for and handle HTTP 206 responses:
+
+#### Cache First Strategy
+```javascript
+// Only cache successful full responses (200 OK), not partial responses (206)
+if (networkResponse.ok && networkResponse.status === 200) {
+  await cache.put(request, addTimestamp(networkResponse.clone()));
+} else if (networkResponse.status === 206) {
+  console.log('[SW] Partial response (206) - not caching:', request.url);
+}
+```
+
+#### Stale While Revalidate Strategy
+```javascript
+// Check if it's a partial response (206) - don't cache these
+if (networkResponse.status === 206) {
+  console.log('[SW] Partial response (206) - not caching:', request.url);
+  return networkResponse;
+}
+
+// Only cache successful full responses (200 OK)
+if (networkResponse.ok && networkResponse.status === 200) {
+  await cache.put(request, addTimestamp(networkResponse.clone()));
+}
+```
+
+### 2. Supabase Query Optimization (`src/pages/workspace-page.tsx`)
+
+Changed the issues query from using `.range()` to `.limit()`:
+
+**Before:**
+```javascript
+.range(0, 99) // Triggers HTTP 206 partial response
+```
+
+**After:**
+```javascript
+.limit(100) // Returns HTTP 200 with full response
+```
+
+## Benefits
+
+1. **Proper Caching**: Service Worker now correctly caches only full responses (HTTP 200)
+2. **No Errors**: Eliminates the "Failed to execute 'put' on 'Cache'" errors
+3. **Better Performance**: Issues load successfully on first attempt
+4. **Fallback Support**: Partial responses are still returned to the client, just not cached
+
+## Testing
+
+To test the fix:
+1. Clear browser cache and Service Worker cache
+2. Navigate to a workspace page (e.g., `/i/test-workspace`)
+3. Open browser DevTools > Network tab
+4. Verify that Supabase API calls return 200 status codes
+5. Check Console for any Service Worker errors
+6. Navigate to the Issues tab and verify it loads without errors
+
+## Future Considerations
+
+1. **Pagination**: If true pagination with `.range()` is needed in the future, consider:
+   - Implementing server-side pagination with cursor-based approach
+   - Using `.limit()` with `.gt()` or `.lt()` filters for pagination
+   - Handling 206 responses separately without caching
+
+2. **Cache Strategy**: Consider implementing a separate caching strategy for API responses that may return partial content
+
+3. **Monitoring**: Add telemetry to track when 206 responses are encountered to understand usage patterns
+
+## Related Files
+
+- `public/sw-enhanced.js` - Service Worker with caching strategies
+- `src/pages/workspace-page.tsx` - Workspace page with Supabase queries
+- `src/lib/service-worker-client.ts` - Service Worker client utilities
+
+## References
+
+- [MDN: HTTP 206 Partial Content](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/206)
+- [Cache API Specification](https://w3c.github.io/ServiceWorker/#cache-interface)
+- [Supabase PostgREST Range Headers](https://postgrest.org/en/stable/api.html#limits-and-pagination)


### PR DESCRIPTION
- Updated Service Worker caching strategies to only cache HTTP 200 responses
- Changed workspace issues query from .range() to .limit() to avoid 206 responses
- Fixed ESLint violations (nested ternaries and .single() usage)
- Prevents 'Failed to execute put on Cache' errors when loading workspace issues

Fixes #562