### PR TITLE
fix: repository filtering now updates overall metrics

### DIFF
--- a/public/sitemap-news.xml
+++ b/public/sitemap-news.xml
@@ -20,7 +20,7 @@
         <news:name>Contributor.info</news:name>
         <news:language>en</news:language>
       </news:publication>
-      <news:publication_date>2025-08-27T14:02:21.658Z</news:publication_date>
+      <news:publication_date>2025-08-27T20:21:54.011Z</news:publication_date>
       <news:title>pytorch/pytorch - Contributor Updates</news:title>
     </news:news>
   </url>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -392,6 +392,24 @@
     <lastmod>2025-06-29T17:34:00.380Z</lastmod>
   </url>
   <url>
+    <loc>https://contributor.info/pytorch/pytorch</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+    <lastmod>2025-08-27T20:21:54.011Z</lastmod>
+  </url>
+  <url>
+    <loc>https://contributor.info/pytorch/pytorch/health</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+    <lastmod>2025-08-27T20:21:54.011Z</lastmod>
+  </url>
+  <url>
+    <loc>https://contributor.info/pytorch/pytorch/distribution</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+    <lastmod>2025-08-27T20:21:54.011Z</lastmod>
+  </url>
+  <url>
     <loc>https://contributor.info/Supabase/supabase</loc>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
@@ -446,16 +464,16 @@
     <lastmod>2025-08-08T17:32:38.572Z</lastmod>
   </url>
   <url>
-    <loc>https://contributor.info/Robdel12/DraftPatch</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.7</priority>
-    <lastmod>2025-07-05T14:45:32.107Z</lastmod>
-  </url>
-  <url>
     <loc>https://contributor.info/Ad-Astra-Innovia/frontend</loc>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
     <lastmod>2025-08-07T17:46:04.172Z</lastmod>
+  </url>
+  <url>
+    <loc>https://contributor.info/dlt-hub/dlt</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.7</priority>
+    <lastmod>2025-08-13T20:56:48.000Z</lastmod>
   </url>
   <url>
     <loc>https://contributor.info/analogjs/analog</loc>
@@ -524,28 +542,10 @@
     <lastmod>2025-08-04T15:09:53.258Z</lastmod>
   </url>
   <url>
-    <loc>https://contributor.info/pytorch/pytorch</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.9</priority>
-    <lastmod>2025-08-27T14:02:21.658Z</lastmod>
-  </url>
-  <url>
-    <loc>https://contributor.info/pytorch/pytorch/health</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
-    <lastmod>2025-08-27T14:02:21.658Z</lastmod>
-  </url>
-  <url>
-    <loc>https://contributor.info/pytorch/pytorch/distribution</loc>
-    <changefreq>daily</changefreq>
-    <priority>0.8</priority>
-    <lastmod>2025-08-27T14:02:21.658Z</lastmod>
-  </url>
-  <url>
-    <loc>https://contributor.info/dlt-hub/dlt</loc>
+    <loc>https://contributor.info/Robdel12/DraftPatch</loc>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
-    <lastmod>2025-08-13T20:56:48.000Z</lastmod>
+    <lastmod>2025-07-05T14:45:32.107Z</lastmod>
   </url>
   <url>
     <loc>https://contributor.info/lodash/lodash</loc>


### PR DESCRIPTION
Fixes #563

This PR resolves the issue where filtering to a single repository didn't update the overall metrics (stars, PR numbers, contributors).

## Changes
- Modified `generateMockMetrics` function to accept `selectedRepoIds` parameter
- Added `selectedRepositories` to useEffect dependencies to recalculate on filter change
- Updated all `generateMockMetrics` calls to pass repository filter
- Enhanced PR data fetching to respect repository selection
- Fixed issue where metrics showed aggregate data instead of filtered data

## Testing
- ✅ Build completed successfully with no TypeScript errors
- ✅ All pre-push hooks passed

Generated with [Claude Code](https://claude.ai/code)