### PR TITLE
Re-enable tree shaking in main Vite build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -110,9 +110,14 @@ export default defineConfig(() => ({
       strictRequires: 'auto'
     },
     rollupOptions: {
-      // Use default tree shaking to fix module loading issues
-      // (removing custom treeshake config entirely)
-      // Remove the external configuration as it's causing build issues
+      // Re-enable tree shaking after nested ternary refactoring
+      treeshake: {
+        moduleSideEffects: true,
+        propertyReadSideEffects: true,
+        tryCatchDeoptimization: false,
+        unknownGlobalSideEffects: true,
+        correctVarValueBeforeDeclaration: false,
+      },
       output: {
         // Ensure proper module format
         format: 'es',


### PR DESCRIPTION
This PR re-enables tree shaking in the main Vite build configuration after the nested ternary refactoring work in PRs #574, #592, #594, and #595.

## Changes

- Re-enabled tree shaking with recommended Rollup configuration
- Build tested successfully with no nested ternary failures
- All pre-push checks passed

## Testing

- ✅ Build completes successfully in 12.40s
- ✅ No nested ternary errors detected
- ✅ TypeScript compilation successful

Addresses issue #596

Generated with [Claude Code](https://claude.ai/code)