### PR TITLE
fix: resolve JSON parsing errors in compliance-secure workflow

### DIFF
--- a/.github/workflows/compliance-secure.yml
+++ b/.github/workflows/compliance-secure.yml
@@ -148,16 +148,22 @@ jobs:
       - name: Save check results
         if: always()
         run: |
-          cat > check-results.json << EOF
-          {
-            "conventional_commits": "${{ steps.conventional.outputs.result }}",
-            "code_quality": "${{ steps.quality.outputs.result }}",
-            "security_audit": "${{ steps.security.outputs.result }}",
-            "bundle_size": "${{ steps.bundle.outputs.result }}",
-            "bundle_details": "${{ steps.bundle.outputs.details }}",
-            "file_validation": "${{ steps.files.outputs.result }}"
-          }
-          EOF
+          # Use jq to properly escape JSON values, handling multiline strings
+          jq -n \
+            --arg conventional "${{ steps.conventional.outputs.result }}" \
+            --arg quality "${{ steps.quality.outputs.result }}" \
+            --arg security "${{ steps.security.outputs.result }}" \
+            --arg bundle "${{ steps.bundle.outputs.result }}" \
+            --arg details "${{ steps.bundle.outputs.details }}" \
+            --arg files "${{ steps.files.outputs.result }}" \
+            '{
+              conventional_commits: $conventional,
+              code_quality: $quality,
+              security_audit: $security,
+              bundle_size: $bundle,
+              bundle_details: $details,
+              file_validation: $files
+            }' > check-results.json
 
       - name: Upload results
         if: always()


### PR DESCRIPTION
## Summary
Fixes the JSON parsing error in the `Post Results Comment` job that is currently affecting ALL PRs.

## Problem
The `compliance-secure.yml` workflow uses `pull_request_target` which means it **runs from the main branch code**, not the PR branch. It's creating a `check-results.json` file with unescaped values causing:
```
SyntaxError: Bad control character in string literal in JSON at position 163
```

## Solution
- Replace heredoc JSON generation with `jq` which properly escapes all values
- This ensures multiline strings and special characters are correctly handled

## Important Notes
⚠️ **This PR must be merged to main for the fix to take effect**
- The workflow runs from main branch (not PR branch) due to `pull_request_target`
- Once merged, ALL PRs will automatically have the fix applied
- The `Post Results Comment` check will start passing for all PRs

## Testing
- This PR itself will show the error until merged (expected behavior)
- After merge, all PRs including #621 will have working `Post Results Comment` checks

## Related
- Fixes the issue affecting PR #621 and all other PRs