### PR TITLE
feat: improve scatterplot enhancement toggle UX

### DIFF
--- a/src/components/features/activity/contributions.tsx
+++ b/src/components/features/activity/contributions.tsx
@@ -50,7 +50,10 @@ function ContributionsChart({ isRepositoryTracked = true }: ContributionsChartPr
   const { stats, includeBots: contextIncludeBots } = useContext(RepoStatsContext);
   const { effectiveTimeRange } = useTimeRange();
   const { owner, repo } = useParams<{ owner: string; repo: string }>();
-  const [isLogarithmic, setIsLogarithmic] = useState(false);
+  // Default to enhanced mode on mobile devices
+  const [isLogarithmic, setIsLogarithmic] = useState(
+    typeof window !== 'undefined' && window.innerWidth < 768
+  );
   const [maxFilesModified, setMaxFilesModified] = useState(10);
   const [localIncludeBots, setLocalIncludeBots] = useState(contextIncludeBots);
   const [statusFilter, setStatusFilter] = useState<'all' | 'open' | 'merged' | 'closed'>('all');
@@ -71,7 +74,12 @@ function ContributionsChart({ isRepositoryTracked = true }: ContributionsChartPr
         clearTimeout(functionTimeout.current);
       }
       functionTimeout.current = setTimeout(() => {
-        setIsMobile(window.innerWidth < 768);
+        const newIsMobile = window.innerWidth < 768;
+        setIsMobile(newIsMobile);
+        // Auto-enable enhanced mode when switching to mobile
+        if (newIsMobile && !isLogarithmic) {
+          setIsLogarithmic(true);
+        }
       }, 150); // Throttle resize events
     };
 
@@ -82,7 +90,7 @@ function ContributionsChart({ isRepositoryTracked = true }: ContributionsChartPr
         clearTimeout(functionTimeout.current);
       }
     };
-  }, []);
+  }, [isLogarithmic]);
 
   useEffect(() => {
     // Calculate max files modified for scale
@@ -670,7 +678,7 @@ function ContributionsChart({ isRepositoryTracked = true }: ContributionsChartPr
                 onCheckedChange={handleSetLogarithmic}
               />
               <Label htmlFor="logarithmic-scale" className="text-sm">
-                Enhance
+                {isLogarithmic ? 'Enhanced' : 'Enhance'}
               </Label>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Toggle label changes from "Enhance" to "Enhanced" when enabled
- Enhanced mode now defaults to ON for mobile devices
- Auto-enables enhanced mode when browser resizes to mobile viewport

## Changes Made

### 1. Dynamic Toggle Label
- The enhancement toggle now shows "Enhance" when OFF and "Enhanced" when ON
- Provides clearer visual feedback about the current state

### 2. Mobile-First Enhancement
- Enhanced mode automatically defaults to ON for mobile devices (< 768px width)
- When users resize their browser to mobile dimensions, enhanced mode auto-enables
- Improves visualization on smaller screens where enhanced mode is most beneficial

## Implementation Details
- Modified `useState` initialization to detect mobile on component mount
- Updated resize handler to auto-enable enhancement when switching to mobile
- Changed label to use conditional rendering based on `isLogarithmic` state

## Testing
- [x] Enhanced mode defaults to ON on mobile devices
- [x] Label changes between "Enhance" and "Enhanced" correctly
- [x] Auto-enables when resizing to mobile viewport
- [x] Manual toggle still works as expected
- [x] Desktop behavior unchanged (defaults to OFF)

🤖 Generated with [Claude Code](https://claude.ai/code)