### PR TITLE
fix: round daily PR volume to whole numbers and update labels to 'Last 30 days'

### DIFF
--- a/src/components/features/workspace/WorkspaceDashboard.tsx
+++ b/src/components/features/workspace/WorkspaceDashboard.tsx
@@ -111,7 +111,7 @@ export function WorkspaceDashboard({
 
         <MetricCard
           title="Open PRs"
-          subtitle="Currently open"
+          subtitle="Last 30 days"
           value={metrics.totalPRs}
           description="Active development and contributions"
           icon={<GitPullRequest className="h-4 w-4" />}
@@ -126,7 +126,7 @@ export function WorkspaceDashboard({
 
         <MetricCard
           title="Open Issues"
-          subtitle="Currently open"
+          subtitle="Last 30 days"
           value={metrics.totalIssues || 0}
           description="Tasks and feature requests"
           icon={<AlertCircle className="h-4 w-4" />}

--- a/src/lib/insights/trends-metrics.ts
+++ b/src/lib/insights/trends-metrics.ts
@@ -176,8 +176,8 @@ export async function calculateTrendMetrics(
     const trends: TrendData[] = [
       {
         metric: `Daily PR Volume`,
-        current: Math.round(dailyPRVolumeCurrent * 10) / 10, // Round to 1 decimal
-        previous: Math.round(dailyPRVolumePrevious * 10) / 10,
+        current: Math.round(dailyPRVolumeCurrent), // Round to whole number
+        previous: Math.round(dailyPRVolumePrevious), // Round to whole number
         change: dailyVolumeChange,
         trend: getTrendDirection(dailyVolumeChange),
         icon: 'GitPullRequest',


### PR DESCRIPTION
**Summary**
- Fix Daily PR Volume metric to display whole numbers instead of decimals (e.g., '18' instead of '18.200000000000003')
- Update 'Currently open' labels to 'Last 30 days' for PRs and issues in workspace dashboard

**Changes**
- `src/lib/insights/trends-metrics.ts` - Round Daily PR Volume to whole numbers
- `src/components/features/workspace/WorkspaceDashboard.tsx` - Update subtitle labels to clarify time range

Closes #673

Generated with [Claude Code](https://claude.ai/code)