### PR TITLE
test: intentionally break build to test CI pipeline

### DIFF
--- a/src/components/features/repository/repo-view.tsx
+++ b/src/components/features/repository/repo-view.tsx
@@ -40,7 +40,7 @@ export default function RepoView() {
   const navigate = useNavigate();
   const location = useLocation();
   const timeRange = useTimeRangeStore((state) => state.timeRange);
-  const [includeBots, setIncludeBots] = useState(false);
+  const [includeBots, setIncludeBots]: string = useState(false);
   const [isGeneratingUrl, setIsGeneratingUrl] = useState(false);
   const [hasSearchedOnce, setHasSearchedOnce] = useState(false);
   const [showSkeleton, setShowSkeleton] = useState(true);


### PR DESCRIPTION
This commit introduces a TypeScript type error to test that our CI/CD pipeline properly catches and prevents broken builds from being deployed.

Generated with [Continue](https://continue.dev)