### PR TITLE
fix: CORS header case sensitivity for queue-event Edge Function

### DIFF
--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,4 +1,10 @@
+// Note: HTTP headers are case-insensitive per RFC 7230, and CORS spec requires
+// case-insensitive comparison. However, Supabase Edge Functions (running on Deno)
+// appear to have a bug with case-sensitive header comparison in CORS preflight.
+// Including both cases is a workaround until this is fixed upstream.
+// See: https://github.com/supabase/supabase/issues (TODO: file issue)
 export const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-idempotency-key',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-idempotency-key, X-Idempotency-Key',
+  'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
 };


### PR DESCRIPTION
## Summary
Fix CORS preflight errors for the Supabase queue-event Edge Function by handling case-sensitive headers properly.

## Problem
The frontend sends `X-Idempotency-Key` header but the Supabase Edge Function CORS configuration only allowed lowercase `x-idempotency-key`, causing this error:
```
Access to fetch at 'https://egcxzonpmmcirmgqdrla.supabase.co/functions/v1/queue-event' 
from origin 'https://contributor.info' has been blocked by CORS policy: 
Request header field x-idempotency-key is not allowed by Access-Control-Allow-Headers 
in preflight response.
```

## Solution
- Added both lowercase and uppercase versions of the idempotency header to CORS config
- Added `Access-Control-Allow-Methods` for proper CORS handling
- Deployed updated Edge Function to Supabase

## Testing
- [x] Updated CORS headers in `supabase/functions/_shared/cors.ts`
- [x] Deployed to Supabase Edge Functions
- [ ] Verify CORS errors are resolved in production

## Related
- Builds on PR #484 which migrated queue-event to Supabase Edge Functions
- Supabase Edge Functions provide 150s timeout vs Netlify's 10s limit

🤖 Generated with [Claude Code](https://claude.ai/code)