### PR TITLE
feat: Add filtering capabilities to Workspace PRs and Issues tables

### DIFF
--- a/src/components/features/workspace/WorkspaceIssuesTable.tsx
+++ b/src/components/features/workspace/WorkspaceIssuesTable.tsx
@@ -518,97 +518,111 @@ export function WorkspaceIssuesTable({
           </div>
         ) : (
           <>
-            <div className="rounded-md border">
-              <div className="overflow-x-auto">
-                <table className="w-full min-w-[800px]">
-                  <thead>
-                    {table.getHeaderGroups().map((headerGroup) => (
-                      <tr key={headerGroup.id} className="border-b">
-                        {headerGroup.headers.map((header) => (
-                          <th
-                            key={header.id}
-                            className={cn(
-                              'px-4 py-3 font-medium text-sm whitespace-nowrap',
-                              header.column.id === 'comments_count' ? 'text-center' : 'text-left'
-                            )}
-                            style={{
-                              width: header.column.columnDef.size,
-                              minWidth: header.column.columnDef.minSize,
-                              maxWidth: header.column.columnDef.maxSize,
-                            }}
-                          >
-                            {flexRender(header.column.columnDef.header, header.getContext())}
-                          </th>
-                        ))}
-                      </tr>
-                    ))}
-                  </thead>
-                  <tbody>
-                    {table.getRowModel().rows.map((row) => (
-                      <tr key={row.id} className="border-b hover:bg-muted/50 transition-colors">
-                        {row.getVisibleCells().map((cell) => (
-                          <td key={cell.id} className="px-4 py-4">
-                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                          </td>
-                        ))}
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
+            {filteredIssues.length === 0 && globalFilter === '' ? (
+              <div className="flex flex-col items-center justify-center py-12 text-center">
+                <XCircle className="h-12 w-12 text-muted-foreground mb-4" />
+                <p className="text-lg font-medium text-muted-foreground mb-2">
+                  No issues match your filters
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  Try adjusting your filter settings or reset filters to see all issues
+                </p>
               </div>
-            </div>
+            ) : (
+              <div className="rounded-md border">
+                <div className="overflow-x-auto">
+                  <table className="w-full min-w-[800px]">
+                    <thead>
+                      {table.getHeaderGroups().map((headerGroup) => (
+                        <tr key={headerGroup.id} className="border-b">
+                          {headerGroup.headers.map((header) => (
+                            <th
+                              key={header.id}
+                              className={cn(
+                                'px-4 py-3 font-medium text-sm whitespace-nowrap',
+                                header.column.id === 'comments_count' ? 'text-center' : 'text-left'
+                              )}
+                              style={{
+                                width: header.column.columnDef.size,
+                                minWidth: header.column.columnDef.minSize,
+                                maxWidth: header.column.columnDef.maxSize,
+                              }}
+                            >
+                              {flexRender(header.column.columnDef.header, header.getContext())}
+                            </th>
+                          ))}
+                        </tr>
+                      ))}
+                    </thead>
+                    <tbody>
+                      {table.getRowModel().rows.map((row) => (
+                        <tr key={row.id} className="border-b hover:bg-muted/50 transition-colors">
+                          {row.getVisibleCells().map((cell) => (
+                            <td key={cell.id} className="px-4 py-4">
+                              {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                            </td>
+                          ))}
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            )}
 
             {/* Pagination */}
-            <div className="flex items-center justify-between mt-4">
-              <div className="text-sm text-muted-foreground">
-                {filteredIssues.length > 0 ? (
-                  <>
-                    Showing {table.getState().pagination.pageIndex * 10 + 1} to{' '}
-                    {Math.min(
-                      (table.getState().pagination.pageIndex + 1) * 10,
-                      filteredIssues.length
-                    )}{' '}
-                    of {filteredIssues.length} issues
-                    {filteredIssues.length < issues.length && (
-                      <span className="text-muted-foreground">
-                        {' '}
-                        (filtered from {issues.length})
-                      </span>
-                    )}
-                  </>
-                ) : (
-                  <>
-                    No issues found
-                    {issues.length > 0 && (
-                      <span className="text-muted-foreground">
-                        {' '}
-                        (filtered from {issues.length})
-                      </span>
-                    )}
-                  </>
-                )}
+            {filteredIssues.length > 0 && (
+              <div className="flex items-center justify-between mt-4">
+                <div className="text-sm text-muted-foreground">
+                  {filteredIssues.length > 0 ? (
+                    <>
+                      Showing {table.getState().pagination.pageIndex * 10 + 1} to{' '}
+                      {Math.min(
+                        (table.getState().pagination.pageIndex + 1) * 10,
+                        filteredIssues.length
+                      )}{' '}
+                      of {filteredIssues.length} issues
+                      {filteredIssues.length < issues.length && (
+                        <span className="text-muted-foreground">
+                          {' '}
+                          (filtered from {issues.length})
+                        </span>
+                      )}
+                    </>
+                  ) : (
+                    <>
+                      No issues found
+                      {issues.length > 0 && (
+                        <span className="text-muted-foreground">
+                          {' '}
+                          (filtered from {issues.length})
+                        </span>
+                      )}
+                    </>
+                  )}
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => table.previousPage()}
+                    disabled={!table.getCanPreviousPage()}
+                  >
+                    <ChevronLeft className="h-4 w-4" />
+                    Previous
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => table.nextPage()}
+                    disabled={!table.getCanNextPage()}
+                  >
+                    Next
+                    <ChevronRight className="h-4 w-4" />
+                  </Button>
+                </div>
               </div>
-              <div className="flex items-center gap-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => table.previousPage()}
-                  disabled={!table.getCanPreviousPage()}
-                >
-                  <ChevronLeft className="h-4 w-4" />
-                  Previous
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => table.nextPage()}
-                  disabled={!table.getCanNextPage()}
-                >
-                  Next
-                  <ChevronRight className="h-4 w-4" />
-                </Button>
-              </div>
-            </div>
+            )}
           </>
         )}
       </CardContent>

--- a/src/components/features/workspace/WorkspaceIssuesTable.tsx
+++ b/src/components/features/workspace/WorkspaceIssuesTable.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo } from 'react';
 import {
   useReactTable,
   getCoreRowModel,
@@ -113,8 +113,6 @@ export function WorkspaceIssuesTable({
   const [sorting, setSorting] = useState<SortingState>([{ id: 'updated_at', desc: true }]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [globalFilter, setGlobalFilter] = useState('');
-  const [hasBots, setHasBots] = useState(false);
-
   // Get filter state from store
   const {
     issueStates,
@@ -126,12 +124,11 @@ export function WorkspaceIssuesTable({
     resetIssueFilters,
   } = useWorkspaceFiltersStore();
 
-  // Check if there are any bot issues
-  useEffect(() => {
-    const hasAnyBots = issues.some(
+  // Check if there are any bot issues - using useMemo for performance
+  const hasBots = useMemo(() => {
+    return issues.some(
       (issue) => issue.author.isBot === true || issue.author.username.toLowerCase().includes('bot')
     );
-    setHasBots(hasAnyBots);
   }, [issues]);
 
   // Filter issues based on state, bot settings, and assignment

--- a/src/components/features/workspace/WorkspacePullRequestsTable.tsx
+++ b/src/components/features/workspace/WorkspacePullRequestsTable.tsx
@@ -472,102 +472,116 @@ export function WorkspacePullRequestsTable({
           </div>
         ) : (
           <>
-            <div className="rounded-md border">
-              <div className="overflow-x-auto">
-                <table className="w-full min-w-[800px] md:min-w-[1400px]">
-                  <thead>
-                    {table.getHeaderGroups().map((headerGroup) => (
-                      <tr key={headerGroup.id} className="border-b">
-                        {headerGroup.headers.map((header) => (
-                          <th
-                            key={header.id}
-                            className="px-4 py-3 text-left font-medium text-sm whitespace-nowrap"
-                            style={{
-                              width: header.column.columnDef.size,
-                              minWidth: header.column.columnDef.minSize,
-                            }}
-                          >
-                            {flexRender(header.column.columnDef.header, header.getContext())}
-                          </th>
-                        ))}
-                      </tr>
-                    ))}
-                  </thead>
-                  <tbody>
-                    {table.getRowModel().rows.map((row) => (
-                      <tr key={row.id} className="border-b hover:bg-muted/50 transition-colors">
-                        {row.getVisibleCells().map((cell) => (
-                          <td
-                            key={cell.id}
-                            className="px-4 py-4"
-                            style={{
-                              width: cell.column.columnDef.size,
-                              minWidth: cell.column.columnDef.minSize,
-                            }}
-                          >
-                            {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                          </td>
-                        ))}
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
+            {filteredPullRequests.length === 0 && globalFilter === '' ? (
+              <div className="flex flex-col items-center justify-center py-12 text-center">
+                <GitPullRequest className="h-12 w-12 text-muted-foreground mb-4" />
+                <p className="text-lg font-medium text-muted-foreground mb-2">
+                  No pull requests match your filters
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  Try adjusting your filter settings or reset filters to see all pull requests
+                </p>
               </div>
-            </div>
+            ) : (
+              <div className="rounded-md border">
+                <div className="overflow-x-auto">
+                  <table className="w-full min-w-[800px] md:min-w-[1400px]">
+                    <thead>
+                      {table.getHeaderGroups().map((headerGroup) => (
+                        <tr key={headerGroup.id} className="border-b">
+                          {headerGroup.headers.map((header) => (
+                            <th
+                              key={header.id}
+                              className="px-4 py-3 text-left font-medium text-sm whitespace-nowrap"
+                              style={{
+                                width: header.column.columnDef.size,
+                                minWidth: header.column.columnDef.minSize,
+                              }}
+                            >
+                              {flexRender(header.column.columnDef.header, header.getContext())}
+                            </th>
+                          ))}
+                        </tr>
+                      ))}
+                    </thead>
+                    <tbody>
+                      {table.getRowModel().rows.map((row) => (
+                        <tr key={row.id} className="border-b hover:bg-muted/50 transition-colors">
+                          {row.getVisibleCells().map((cell) => (
+                            <td
+                              key={cell.id}
+                              className="px-4 py-4"
+                              style={{
+                                width: cell.column.columnDef.size,
+                                minWidth: cell.column.columnDef.minSize,
+                              }}
+                            >
+                              {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                            </td>
+                          ))}
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            )}
 
             {/* Pagination */}
-            <div className="flex flex-col sm:flex-row items-center justify-between mt-4 gap-4">
-              <div className="text-sm text-muted-foreground order-2 sm:order-1">
-                {filteredPullRequests.length > 0 ? (
-                  <>
-                    Showing {table.getState().pagination.pageIndex * 10 + 1} to{' '}
-                    {Math.min(
-                      (table.getState().pagination.pageIndex + 1) * 10,
-                      filteredPullRequests.length
-                    )}{' '}
-                    of {filteredPullRequests.length} pull requests
-                    {filteredPullRequests.length < pullRequests.length && (
-                      <span className="text-muted-foreground">
-                        {' '}
-                        (filtered from {pullRequests.length})
-                      </span>
-                    )}
-                  </>
-                ) : (
-                  <>
-                    No pull requests found
-                    {pullRequests.length > 0 && (
-                      <span className="text-muted-foreground">
-                        {' '}
-                        (filtered from {pullRequests.length})
-                      </span>
-                    )}
-                  </>
-                )}
+            {filteredPullRequests.length > 0 && (
+              <div className="flex flex-col sm:flex-row items-center justify-between mt-4 gap-4">
+                <div className="text-sm text-muted-foreground order-2 sm:order-1">
+                  {filteredPullRequests.length > 0 ? (
+                    <>
+                      Showing {table.getState().pagination.pageIndex * 10 + 1} to{' '}
+                      {Math.min(
+                        (table.getState().pagination.pageIndex + 1) * 10,
+                        filteredPullRequests.length
+                      )}{' '}
+                      of {filteredPullRequests.length} pull requests
+                      {filteredPullRequests.length < pullRequests.length && (
+                        <span className="text-muted-foreground">
+                          {' '}
+                          (filtered from {pullRequests.length})
+                        </span>
+                      )}
+                    </>
+                  ) : (
+                    <>
+                      No pull requests found
+                      {pullRequests.length > 0 && (
+                        <span className="text-muted-foreground">
+                          {' '}
+                          (filtered from {pullRequests.length})
+                        </span>
+                      )}
+                    </>
+                  )}
+                </div>
+                <div className="flex items-center gap-2 order-1 sm:order-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => table.previousPage()}
+                    disabled={!table.getCanPreviousPage()}
+                    className="min-h-[44px] px-3"
+                  >
+                    <ChevronLeft className="h-4 w-4" />
+                    <span className="hidden sm:inline ml-2">Previous</span>
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => table.nextPage()}
+                    disabled={!table.getCanNextPage()}
+                    className="min-h-[44px] px-3"
+                  >
+                    <span className="hidden sm:inline mr-2">Next</span>
+                    <ChevronRight className="h-4 w-4" />
+                  </Button>
+                </div>
               </div>
-              <div className="flex items-center gap-2 order-1 sm:order-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => table.previousPage()}
-                  disabled={!table.getCanPreviousPage()}
-                  className="min-h-[44px] px-3"
-                >
-                  <ChevronLeft className="h-4 w-4" />
-                  <span className="hidden sm:inline ml-2">Previous</span>
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => table.nextPage()}
-                  disabled={!table.getCanNextPage()}
-                  className="min-h-[44px] px-3"
-                >
-                  <span className="hidden sm:inline mr-2">Next</span>
-                  <ChevronRight className="h-4 w-4" />
-                </Button>
-              </div>
-            </div>
+            )}
           </>
         )}
       </CardContent>

--- a/src/components/features/workspace/WorkspacePullRequestsTable.tsx
+++ b/src/components/features/workspace/WorkspacePullRequestsTable.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo } from 'react';
 import {
   useReactTable,
   getCoreRowModel,
@@ -117,18 +117,16 @@ export function WorkspacePullRequestsTable({
   const [sorting, setSorting] = useState<SortingState>([{ id: 'updated_at', desc: true }]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [globalFilter, setGlobalFilter] = useState('');
-  const [hasBots, setHasBots] = useState(false);
 
   // Get filter state from store
   const { prStates, prIncludeBots, togglePRState, setPRIncludeBots, resetPRFilters } =
     useWorkspaceFiltersStore();
 
-  // Check if there are any bot PRs
-  useEffect(() => {
-    const hasAnyBots = pullRequests.some(
+  // Check if there are any bot PRs - using useMemo for performance
+  const hasBots = useMemo(() => {
+    return pullRequests.some(
       (pr) => pr.author.isBot === true || pr.author.username.toLowerCase().includes('bot')
     );
-    setHasBots(hasAnyBots);
   }, [pullRequests]);
 
   // Filter pull requests based on state and bot settings

--- a/src/components/features/workspace/filters/TableFilters.tsx
+++ b/src/components/features/workspace/filters/TableFilters.tsx
@@ -1,0 +1,162 @@
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import {
+  type PRState,
+  type IssueState,
+  type IssueAssignmentFilter,
+} from '@/lib/workspace-filters-store';
+
+interface PRFiltersProps {
+  selectedStates: PRState[];
+  includeBots: boolean;
+  onToggleState: (state: PRState) => void;
+  onIncludeBotsChange: (include: boolean) => void;
+  onReset?: () => void;
+  hasBots?: boolean;
+}
+
+interface IssueFiltersProps {
+  selectedStates: IssueState[];
+  includeBots: boolean;
+  assignmentFilter: IssueAssignmentFilter;
+  onToggleState: (state: IssueState) => void;
+  onIncludeBotsChange: (include: boolean) => void;
+  onAssignmentFilterChange: (filter: IssueAssignmentFilter) => void;
+  onReset?: () => void;
+  hasBots?: boolean;
+}
+
+export function PRFilters({
+  selectedStates,
+  includeBots,
+  onToggleState,
+  onIncludeBotsChange,
+  onReset,
+  hasBots = false,
+}: PRFiltersProps) {
+  const prStateLabels: Record<PRState, string> = {
+    open: 'Open',
+    closed: 'Closed',
+    merged: 'Merged',
+    draft: 'Draft',
+  };
+
+  return (
+    <div className="flex flex-wrap gap-4 mb-4">
+      {(Object.keys(prStateLabels) as PRState[]).map((state) => (
+        <div key={state} className="flex items-center space-x-2">
+          <Switch
+            id={`filter-pr-${state}`}
+            checked={selectedStates.includes(state)}
+            onCheckedChange={() => onToggleState(state)}
+          />
+          <Label htmlFor={`filter-pr-${state}`} className="text-sm">
+            {prStateLabels[state]}
+          </Label>
+        </div>
+      ))}
+
+      {hasBots && (
+        <div className="flex items-center space-x-2">
+          <Switch id="filter-pr-bots" checked={includeBots} onCheckedChange={onIncludeBotsChange} />
+          <Label htmlFor="filter-pr-bots" className="text-sm">
+            Show Bots
+          </Label>
+        </div>
+      )}
+
+      {onReset && (
+        <Button variant="ghost" size="sm" onClick={onReset} className="ml-auto">
+          Reset Filters
+        </Button>
+      )}
+    </div>
+  );
+}
+
+export function IssueFilters({
+  selectedStates,
+  includeBots,
+  assignmentFilter,
+  onToggleState,
+  onIncludeBotsChange,
+  onAssignmentFilterChange,
+  onReset,
+  hasBots = false,
+}: IssueFiltersProps) {
+  const issueStateLabels: Record<IssueState, string> = {
+    open: 'Open',
+    closed: 'Closed',
+  };
+
+  return (
+    <div className="flex flex-wrap gap-4 mb-4">
+      {(Object.keys(issueStateLabels) as IssueState[]).map((state) => (
+        <div key={state} className="flex items-center space-x-2">
+          <Switch
+            id={`filter-issue-${state}`}
+            checked={selectedStates.includes(state)}
+            onCheckedChange={() => onToggleState(state)}
+          />
+          <Label htmlFor={`filter-issue-${state}`} className="text-sm">
+            {issueStateLabels[state]}
+          </Label>
+        </div>
+      ))}
+
+      <div className="flex items-center space-x-2">
+        <Switch
+          id="filter-issue-assigned"
+          checked={assignmentFilter === 'assigned'}
+          onCheckedChange={(checked) => {
+            if (checked) {
+              onAssignmentFilterChange('assigned');
+            } else {
+              onAssignmentFilterChange('all');
+            }
+          }}
+        />
+        <Label htmlFor="filter-issue-assigned" className="text-sm">
+          Assigned
+        </Label>
+      </div>
+
+      <div className="flex items-center space-x-2">
+        <Switch
+          id="filter-issue-unassigned"
+          checked={assignmentFilter === 'unassigned'}
+          onCheckedChange={(checked) => {
+            if (checked) {
+              onAssignmentFilterChange('unassigned');
+            } else {
+              onAssignmentFilterChange('all');
+            }
+          }}
+        />
+        <Label htmlFor="filter-issue-unassigned" className="text-sm">
+          Unassigned
+        </Label>
+      </div>
+
+      {hasBots && (
+        <div className="flex items-center space-x-2">
+          <Switch
+            id="filter-issue-bots"
+            checked={includeBots}
+            onCheckedChange={onIncludeBotsChange}
+          />
+          <Label htmlFor="filter-issue-bots" className="text-sm">
+            Show Bots
+          </Label>
+        </div>
+      )}
+
+      {onReset && (
+        <Button variant="ghost" size="sm" onClick={onReset} className="ml-auto">
+          Reset Filters
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/components/features/workspace/filters/TableFilters.tsx
+++ b/src/components/features/workspace/filters/TableFilters.tsx
@@ -50,6 +50,7 @@ export function PRFilters({
             id={`filter-pr-${state}`}
             checked={selectedStates.includes(state)}
             onCheckedChange={() => onToggleState(state)}
+            aria-label={`Filter pull requests by ${prStateLabels[state]} state`}
           />
           <Label htmlFor={`filter-pr-${state}`} className="text-sm">
             {prStateLabels[state]}
@@ -59,7 +60,12 @@ export function PRFilters({
 
       {hasBots && (
         <div className="flex items-center space-x-2">
-          <Switch id="filter-pr-bots" checked={includeBots} onCheckedChange={onIncludeBotsChange} />
+          <Switch
+            id="filter-pr-bots"
+            checked={includeBots}
+            onCheckedChange={onIncludeBotsChange}
+            aria-label="Show or hide pull requests from bots"
+          />
           <Label htmlFor="filter-pr-bots" className="text-sm">
             Show Bots
           </Label>
@@ -67,7 +73,13 @@ export function PRFilters({
       )}
 
       {onReset && (
-        <Button variant="ghost" size="sm" onClick={onReset} className="ml-auto">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onReset}
+          className="ml-auto"
+          aria-label="Reset all pull request filters to default"
+        >
           Reset Filters
         </Button>
       )}
@@ -98,6 +110,7 @@ export function IssueFilters({
             id={`filter-issue-${state}`}
             checked={selectedStates.includes(state)}
             onCheckedChange={() => onToggleState(state)}
+            aria-label={`Filter issues by ${issueStateLabels[state]} state`}
           />
           <Label htmlFor={`filter-issue-${state}`} className="text-sm">
             {issueStateLabels[state]}
@@ -116,6 +129,7 @@ export function IssueFilters({
               onAssignmentFilterChange('all');
             }
           }}
+          aria-label="Show only assigned issues"
         />
         <Label htmlFor="filter-issue-assigned" className="text-sm">
           Assigned
@@ -133,6 +147,7 @@ export function IssueFilters({
               onAssignmentFilterChange('all');
             }
           }}
+          aria-label="Show only unassigned issues"
         />
         <Label htmlFor="filter-issue-unassigned" className="text-sm">
           Unassigned
@@ -145,6 +160,7 @@ export function IssueFilters({
             id="filter-issue-bots"
             checked={includeBots}
             onCheckedChange={onIncludeBotsChange}
+            aria-label="Show or hide issues from bots"
           />
           <Label htmlFor="filter-issue-bots" className="text-sm">
             Show Bots
@@ -153,7 +169,13 @@ export function IssueFilters({
       )}
 
       {onReset && (
-        <Button variant="ghost" size="sm" onClick={onReset} className="ml-auto">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onReset}
+          className="ml-auto"
+          aria-label="Reset all issue filters to default"
+        >
           Reset Filters
         </Button>
       )}

--- a/src/lib/utils/bot-detection.ts
+++ b/src/lib/utils/bot-detection.ts
@@ -1,0 +1,39 @@
+/**
+ * Utility functions for bot detection across the application
+ */
+
+/**
+ * Determines if a user is a bot based on their properties
+ * @param user - User object with isBot flag and username
+ * @returns true if the user is identified as a bot
+ */
+export function isBot(user: { isBot?: boolean; username: string }): boolean {
+  return user.isBot === true || user.username.toLowerCase().includes('bot');
+}
+
+/**
+ * Filters items based on bot inclusion preferences
+ * @param items - Array of items with author property
+ * @param includeBots - Whether to include bots in the results
+ * @returns Filtered array based on bot inclusion preference
+ */
+export function filterByBotPreference<T extends { author: { isBot?: boolean; username: string } }>(
+  items: T[],
+  includeBots: boolean
+): T[] {
+  if (includeBots) {
+    return items;
+  }
+  return items.filter((item) => !isBot(item.author));
+}
+
+/**
+ * Checks if any items in an array are from bot users
+ * @param items - Array of items with author property
+ * @returns true if any item is from a bot
+ */
+export function hasBotAuthors<T extends { author: { isBot?: boolean; username: string } }>(
+  items: T[]
+): boolean {
+  return items.some((item) => isBot(item.author));
+}

--- a/src/lib/workspace-filters-store.ts
+++ b/src/lib/workspace-filters-store.ts
@@ -74,6 +74,34 @@ export const useWorkspaceFiltersStore = create<WorkspaceFiltersState>()(
     }),
     {
       name: 'workspace-filters',
+      // Add storage error handling
+      storage: {
+        getItem: (name) => {
+          try {
+            const str = localStorage.getItem(name);
+            return str ? JSON.parse(str) : null;
+          } catch (err) {
+            console.warn('Failed to load workspace filters from localStorage:', err);
+            return null; // Return null to use default values
+          }
+        },
+        setItem: (name, value) => {
+          try {
+            localStorage.setItem(name, JSON.stringify(value));
+          } catch (err) {
+            console.warn('Failed to save workspace filters to localStorage:', err);
+            // Silently fail - the app will continue to work without persistence
+          }
+        },
+        removeItem: (name) => {
+          try {
+            localStorage.removeItem(name);
+          } catch (err) {
+            console.warn('Failed to remove workspace filters from localStorage:', err);
+            // Silently fail
+          }
+        },
+      },
     }
   )
 );

--- a/src/lib/workspace-filters-store.ts
+++ b/src/lib/workspace-filters-store.ts
@@ -1,0 +1,79 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type PRState = 'open' | 'closed' | 'merged' | 'draft';
+export type IssueState = 'open' | 'closed';
+export type IssueAssignmentFilter = 'all' | 'assigned' | 'unassigned';
+
+interface WorkspaceFiltersState {
+  // PR Filters
+  prStates: PRState[];
+  prIncludeBots: boolean;
+  setPRStates: (states: PRState[]) => void;
+  setPRIncludeBots: (include: boolean) => void;
+  togglePRState: (state: PRState) => void;
+
+  // Issue Filters
+  issueStates: IssueState[];
+  issueIncludeBots: boolean;
+  issueAssignmentFilter: IssueAssignmentFilter;
+  setIssueStates: (states: IssueState[]) => void;
+  setIssueIncludeBots: (include: boolean) => void;
+  setIssueAssignmentFilter: (filter: IssueAssignmentFilter) => void;
+  toggleIssueState: (state: IssueState) => void;
+
+  // Reset filters
+  resetPRFilters: () => void;
+  resetIssueFilters: () => void;
+}
+
+const DEFAULT_PR_STATES: PRState[] = ['open', 'closed', 'merged', 'draft'];
+const DEFAULT_ISSUE_STATES: IssueState[] = ['open', 'closed'];
+
+export const useWorkspaceFiltersStore = create<WorkspaceFiltersState>()(
+  persist(
+    (set) => ({
+      // PR Filter State
+      prStates: DEFAULT_PR_STATES,
+      prIncludeBots: true,
+      setPRStates: (states) => set({ prStates: states }),
+      setPRIncludeBots: (include) => set({ prIncludeBots: include }),
+      togglePRState: (state) =>
+        set((current) => ({
+          prStates: current.prStates.includes(state)
+            ? current.prStates.filter((s) => s !== state)
+            : [...current.prStates, state],
+        })),
+
+      // Issue Filter State
+      issueStates: DEFAULT_ISSUE_STATES,
+      issueIncludeBots: true,
+      issueAssignmentFilter: 'all',
+      setIssueStates: (states) => set({ issueStates: states }),
+      setIssueIncludeBots: (include) => set({ issueIncludeBots: include }),
+      setIssueAssignmentFilter: (filter) => set({ issueAssignmentFilter: filter }),
+      toggleIssueState: (state) =>
+        set((current) => ({
+          issueStates: current.issueStates.includes(state)
+            ? current.issueStates.filter((s) => s !== state)
+            : [...current.issueStates, state],
+        })),
+
+      // Reset methods
+      resetPRFilters: () =>
+        set({
+          prStates: DEFAULT_PR_STATES,
+          prIncludeBots: true,
+        }),
+      resetIssueFilters: () =>
+        set({
+          issueStates: DEFAULT_ISSUE_STATES,
+          issueIncludeBots: true,
+          issueAssignmentFilter: 'all',
+        }),
+    }),
+    {
+      name: 'workspace-filters',
+    }
+  )
+);

--- a/src/lib/workspace-filters-store.ts
+++ b/src/lib/workspace-filters-store.ts
@@ -39,11 +39,17 @@ export const useWorkspaceFiltersStore = create<WorkspaceFiltersState>()(
       setPRStates: (states) => set({ prStates: states }),
       setPRIncludeBots: (include) => set({ prIncludeBots: include }),
       togglePRState: (state) =>
-        set((current) => ({
-          prStates: current.prStates.includes(state)
+        set((current) => {
+          const isCurrentlySelected = current.prStates.includes(state);
+          const newStates = isCurrentlySelected
             ? current.prStates.filter((s) => s !== state)
-            : [...current.prStates, state],
-        })),
+            : [...current.prStates, state];
+
+          // Prevent empty state selection - keep at least one state selected
+          return {
+            prStates: newStates.length > 0 ? newStates : [state],
+          };
+        }),
 
       // Issue Filter State
       issueStates: DEFAULT_ISSUE_STATES,
@@ -53,11 +59,17 @@ export const useWorkspaceFiltersStore = create<WorkspaceFiltersState>()(
       setIssueIncludeBots: (include) => set({ issueIncludeBots: include }),
       setIssueAssignmentFilter: (filter) => set({ issueAssignmentFilter: filter }),
       toggleIssueState: (state) =>
-        set((current) => ({
-          issueStates: current.issueStates.includes(state)
+        set((current) => {
+          const isCurrentlySelected = current.issueStates.includes(state);
+          const newStates = isCurrentlySelected
             ? current.issueStates.filter((s) => s !== state)
-            : [...current.issueStates, state],
-        })),
+            : [...current.issueStates, state];
+
+          // Prevent empty state selection - keep at least one state selected
+          return {
+            issueStates: newStates.length > 0 ? newStates : [state],
+          };
+        }),
 
       // Reset methods
       resetPRFilters: () =>

--- a/src/pages/workspace-page.tsx
+++ b/src/pages/workspace-page.tsx
@@ -579,6 +579,7 @@ function WorkspaceIssues({
             updated_at,
             closed_at,
             labels,
+            assignees,
             comments_count,
             repository_id,
             repositories(
@@ -619,6 +620,11 @@ function WorkspaceIssues({
             updated_at: string;
             closed_at: string | null;
             labels: IssueLabel[] | null;
+            assignees: Array<{
+              login?: string;
+              username?: string;
+              avatar_url?: string;
+            }> | null;
             comments_count: number | null;
             repository_id: string;
             repositories?: {
@@ -661,6 +667,12 @@ function WorkspaceIssues({
                       color: label.color || '000000',
                     }))
                     .filter((l) => l.name) // Filter out labels without names
+                : [],
+              assignees: Array.isArray(issue.assignees)
+                ? issue.assignees.map((assignee) => ({
+                    login: assignee.login || assignee.username || 'unknown',
+                    avatar_url: assignee.avatar_url || '',
+                  }))
                 : [],
               // Improved URL construction with validation
               url:


### PR DESCRIPTION
## Summary

This PR adds comprehensive filtering capabilities to the Workspace PRs and Issues tables, matching the functionality available in repo-view.

## Changes

- **Filter State Management**: Added Zustand store for persistent filter preferences
- **Reusable Filter Components**: Created `PRFilters` and `IssueFilters` components  
- **PR Filters**: Open, Closed, Merged, Draft states + bot filtering
- **Issue Filters**: Open, Closed states + Assigned/Unassigned (mutually exclusive) + bot filtering
- **Auto Bot Detection**: Automatically detects bots and only shows filter when relevant

## Implementation Details

### State Persistence
Filter preferences are saved to localStorage using Zustand, maintaining user preferences across sessions.

### Assignment Filtering
- Added support for assigned/unassigned issue filtering
- Filters are mutually exclusive (can't select both)
- Both can be unselected to show all issues

### Bot Detection
Automatically detects bot authors through:
- `isBot` field in author data
- Username containing "bot" (case-insensitive)

Fixes #696

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>