### PR TITLE
feat: improve workspace table links and layout

### DIFF
--- a/src/components/features/workspace/WorkspaceIssuesTable.tsx
+++ b/src/components/features/workspace/WorkspaceIssuesTable.tsx
@@ -137,12 +137,31 @@ export function WorkspaceIssuesTable({
           },
           size: 100,
         }),
+        columnHelper.accessor('number', {
+          header: 'Number',
+          cell: ({ row }) => {
+            const issue = row.original;
+            return issue.url ? (
+              <a
+                href={issue.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium hover:text-primary transition-colors"
+              >
+                #{issue.number}
+              </a>
+            ) : (
+              <span className="font-medium text-muted-foreground">#{issue.number}</span>
+            );
+          },
+          size: 80,
+        }),
         columnHelper.accessor('title', {
-          header: 'Issue',
+          header: 'Title',
           cell: ({ row }) => {
             const issue = row.original;
             const truncatedTitle =
-              issue.title.length > 50 ? issue.title.substring(0, 50) + '...' : issue.title;
+              issue.title.length > 60 ? issue.title.substring(0, 60) + '...' : issue.title;
 
             return (
               <div className="flex flex-col gap-1">
@@ -160,22 +179,18 @@ export function WorkspaceIssuesTable({
                               onIssueClick(issue);
                             }
                           }}
-                          className="font-medium hover:text-primary transition-colors text-left inline-flex items-center gap-1"
+                          className="font-medium hover:text-primary transition-colors text-left block"
                         >
                           <span className="line-clamp-1">{truncatedTitle}</span>
-                          <span className="text-muted-foreground">#{issue.number}</span>
                         </a>
                       ) : (
-                        <span className="font-medium text-muted-foreground text-left inline-flex items-center gap-1">
+                        <span className="font-medium text-muted-foreground text-left block">
                           <span className="line-clamp-1">{truncatedTitle}</span>
-                          <span className="text-muted-foreground">#{issue.number}</span>
                         </span>
                       )}
                     </TooltipTrigger>
                     <TooltipContent className="max-w-md">
-                      <p>
-                        {issue.title} #{issue.number}
-                      </p>
+                      <p>{issue.title}</p>
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
@@ -233,15 +248,25 @@ export function WorkspaceIssuesTable({
           header: 'Author',
           cell: ({ row }) => {
             const author = row.original.author;
+            const repo = row.original.repository;
+            const authorFilterUrl = `https://github.com/${repo.owner}/${repo.name}/issues?q=is%3Aissue+author%3A${author.username}`;
+
             return (
               <TooltipProvider>
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <img
-                      src={author.avatar_url}
-                      alt={author.username}
-                      className="h-6 w-6 rounded-full cursor-pointer hover:ring-2 hover:ring-primary transition-all"
-                    />
+                    <a
+                      href={authorFilterUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-block"
+                    >
+                      <img
+                        src={author.avatar_url}
+                        alt={author.username}
+                        className="h-6 w-6 rounded-full cursor-pointer hover:ring-2 hover:ring-primary transition-all"
+                      />
+                    </a>
                   </TooltipTrigger>
                   <TooltipContent>
                     <p>{author.username}</p>

--- a/src/components/features/workspace/WorkspacePullRequestsTable.tsx
+++ b/src/components/features/workspace/WorkspacePullRequestsTable.tsx
@@ -150,14 +150,32 @@ export function WorkspacePullRequestsTable({
             );
           },
         }),
+        columnHelper.accessor('number', {
+          size: 80,
+          minSize: 70,
+          header: 'Number',
+          cell: ({ row }) => {
+            const pr = row.original;
+            return (
+              <a
+                href={pr.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-medium hover:text-primary transition-colors"
+              >
+                #{pr.number}
+              </a>
+            );
+          },
+        }),
         columnHelper.accessor('title', {
           size: 350,
           minSize: 250,
-          header: 'Pull Request',
+          header: 'Title',
           cell: ({ row }) => {
             const pr = row.original;
             const truncatedTitle =
-              pr.title.length > 50 ? pr.title.substring(0, 50) + '...' : pr.title;
+              pr.title.length > 60 ? pr.title.substring(0, 60) + '...' : pr.title;
 
             return (
               <TooltipProvider>
@@ -173,16 +191,13 @@ export function WorkspacePullRequestsTable({
                           onPullRequestClick(pr);
                         }
                       }}
-                      className="font-medium hover:text-primary transition-colors text-left inline-flex items-center gap-1"
+                      className="font-medium hover:text-primary transition-colors text-left block"
                     >
                       <span className="line-clamp-1">{truncatedTitle}</span>
-                      <span className="text-muted-foreground">#{pr.number}</span>
                     </a>
                   </TooltipTrigger>
                   <TooltipContent className="max-w-md">
-                    <p>
-                      {pr.title} #{pr.number}
-                    </p>
+                    <p>{pr.title}</p>
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>
@@ -222,15 +237,23 @@ export function WorkspacePullRequestsTable({
           header: 'Author',
           cell: ({ row }) => {
             const author = row.original.author;
+            const repo = row.original.repository;
+            const authorFilterUrl = `https://github.com/${repo.owner}/${repo.name}/pulls?q=is%3Apr+author%3A${author.username}`;
+
             return (
-              <div className="flex items-center gap-2">
+              <a
+                href={authorFilterUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2 hover:text-primary transition-colors"
+              >
                 <img
                   src={author.avatar_url}
                   alt={author.username}
                   className="h-6 w-6 rounded-full"
                 />
                 <span className="text-sm truncate">{author.username}</span>
-              </div>
+              </a>
             );
           },
         }),


### PR DESCRIPTION
## Summary
- Added separate Number column for PR/issue numbers with clickable links
- Split title and number into distinct columns for cleaner layout
- Enhanced author interaction with GitHub filter links

## Changes
- **Workspace PR Table**: Added Number column, author names/avatars now link to filtered PR list
- **Workspace Issues Table**: Added Number column, author avatars now link to filtered issues list  
- **Improved UX**: All links open in new tabs with proper GitHub query parameters

## Test Plan
- [ ] Verify PR number links open correct PR in GitHub
- [ ] Verify issue number links open correct issue in GitHub
- [ ] Test author avatar/name links filter correctly by author
- [ ] Confirm title tooltips display full text on hover
- [ ] Check responsive layout with new column structure

🤖 Generated with [Claude Code](https://claude.ai/code)