### PR TITLE
feat: Update workspace navigation to use slugs instead of IDs

### DIFF
--- a/src/components/features/contributor/contributor-of-month-wrapper.tsx
+++ b/src/components/features/contributor/contributor-of-month-wrapper.tsx
@@ -77,9 +77,9 @@ export default function ContributorOfTheMonthWrapper() {
           open={showWorkspaceModal}
           onOpenChange={setShowWorkspaceModal}
           source="home"
-          onSuccess={(workspaceId) => {
+          onSuccess={(workspaceSlug) => {
             setShowWorkspaceModal(false);
-            navigate(`/workspaces/${workspaceId}`);
+            navigate(`/i/${workspaceSlug}`);
           }}
         />
       </>

--- a/src/components/features/contributor/contributor-of-the-month.tsx
+++ b/src/components/features/contributor/contributor-of-the-month.tsx
@@ -225,9 +225,9 @@ export function ContributorOfTheMonth({
         open={showWorkspaceModal}
         onOpenChange={setShowWorkspaceModal}
         source="home"
-        onSuccess={(workspaceId) => {
+        onSuccess={(workspaceSlug) => {
           setShowWorkspaceModal(false);
-          navigate(`/workspaces/${workspaceId}`);
+          navigate(`/i/${workspaceSlug}`);
         }}
       />
     </>

--- a/src/components/features/workspace/WorkspaceCreateModal.tsx
+++ b/src/components/features/workspace/WorkspaceCreateModal.tsx
@@ -21,7 +21,7 @@ import type { User } from '@supabase/supabase-js';
 export interface WorkspaceCreateModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onSuccess?: (workspaceId: string) => void;
+  onSuccess?: (workspaceSlug: string) => void;
   mode?: 'create' | 'edit';
   initialValues?: Partial<CreateWorkspaceRequest>;
   workspaceId?: string;
@@ -141,12 +141,12 @@ export function WorkspaceCreateModal({
 
           // Call optional success callback
           if (onSuccess) {
-            onSuccess(response.data.id);
+            onSuccess(response.data.slug);
           }
 
           // Navigate to the workspace if creating new one
           if (mode === 'create') {
-            navigate(`/i/${response.data.id}`);
+            navigate(`/i/${response.data.slug}`);
           }
         } else {
           setError(

--- a/src/components/features/workspace/WorkspacePreviewCard.tsx
+++ b/src/components/features/workspace/WorkspacePreviewCard.tsx
@@ -191,7 +191,7 @@ export function WorkspacePreviewCard({
         )}
 
         <Button asChild className="w-full">
-          <Link to={`/i/${workspace.id}`}>
+          <Link to={`/i/${workspace.slug}`}>
             View Full Workspace
             <ExternalLink className="ml-2 h-4 w-4" />
           </Link>

--- a/src/components/navigation/WorkspaceSwitcher.tsx
+++ b/src/components/navigation/WorkspaceSwitcher.tsx
@@ -111,7 +111,7 @@ export function WorkspaceSwitcher({
   const handleViewCurrentWorkspace = (): void => {
     setOpen(false);
     if (activeWorkspace) {
-      navigate(`/workspaces/${activeWorkspace.id}`);
+      navigate(`/i/${activeWorkspace.slug}`);
     }
   };
 

--- a/src/pages/billing/BillingDashboard.tsx
+++ b/src/pages/billing/BillingDashboard.tsx
@@ -48,7 +48,7 @@ export function BillingDashboard() {
     if (success === 'true' && primaryWorkspace) {
       // Redirect to workspace after successful payment
       const redirectTimer = setTimeout(() => {
-        navigate(`/workspaces/${primaryWorkspace.id}`);
+        navigate(`/i/${primaryWorkspace.slug}`);
       }, 2000); // Give user time to see success state
       return () => clearTimeout(redirectTimer);
     }

--- a/src/pages/workspace-new-page.tsx
+++ b/src/pages/workspace-new-page.tsx
@@ -76,7 +76,7 @@ export default function WorkspaceNewPage() {
         }
 
         toast.success('Workspace created successfully!');
-        navigate(`/i/${response.data.id}`);
+        navigate(`/i/${response.data.slug}`);
       } else {
         setError(response.error || 'Failed to create workspace');
 

--- a/src/pages/workspace-page.tsx
+++ b/src/pages/workspace-page.tsx
@@ -2716,9 +2716,9 @@ function WorkspacePage() {
 
   const handleTabChange = (value: string) => {
     if (value === 'overview') {
-      navigate(`/i/${workspaceId}`);
+      navigate(`/i/${workspace?.slug || workspaceId}`);
     } else {
-      navigate(`/i/${workspaceId}/${value}`);
+      navigate(`/i/${workspace?.slug || workspaceId}/${value}`);
     }
   };
 


### PR DESCRIPTION
## Summary
- Replace workspace ID-based navigation with slug-based URLs across the application
- Improve URL readability and SEO while maintaining backward compatibility

## Changes
- **WorkspaceSwitcher**: Updated dropdown to navigate using workspace slugs (`/i/${workspace.slug}`)
- **WorkspacePreviewCard**: Updated home page links to use slugs
- **Workspace page**: Updated tab navigation with slug fallback to ID
- **New workspace creation**: Navigate to slug after creating workspace
- **WorkspaceCreateModal**: Changed onSuccess callback to pass slug instead of ID
- **BillingDashboard**: Updated redirect after payment to use slug
- **Contributor components**: Updated navigation to use slugs

## Benefits
- More readable and SEO-friendly URLs (e.g., `/i/my-workspace` instead of `/i/uuid-123-456`)
- Backward compatibility maintained - existing ID-based URLs still work
- Consistent navigation pattern across the application

## Test Plan
- [x] Build passes without TypeScript errors
- [x] Development server runs successfully
- [ ] Navigate between workspaces using dropdown
- [ ] Create new workspace and verify redirect uses slug
- [ ] Access workspace via old ID-based URL (backward compatibility)
- [ ] Test workspace tab navigation

🤖 Generated with [Claude Code](https://claude.ai/code)