### PR TITLE
fix: resolve JSON parsing error in repository tracking

### DIFF
--- a/src/components/features/repository/repository-tracking-card.tsx
+++ b/src/components/features/repository/repository-tracking-card.tsx
@@ -5,6 +5,7 @@ import { BarChart3, Lock, Loader2, AlertCircle } from '@/components/ui/icon';
 import { useGitHubAuth } from '@/hooks/use-github-auth';
 import { toast } from 'sonner';
 import { trackEvent } from '@/lib/posthog-lazy';
+import { handleApiResponse } from '@/lib/utils/api-helpers';
 
 interface RepositoryTrackingCardProps {
   owner: string;
@@ -122,22 +123,7 @@ export function RepositoryTrackingCard({
         body: JSON.stringify({ owner, repo }),
       });
 
-      if (!response.ok) {
-        // Check content-type to determine how to parse error
-        const contentType = response.headers.get('content-type');
-        if (!contentType || !contentType.includes('application/json')) {
-          const responseText = await response.text();
-          console.error('Non-JSON error response received:', responseText.substring(0, 200));
-          throw new Error('Invalid response format from server - expected JSON but received HTML');
-        }
-
-        const result = await response.json();
-        console.log('Track repository error response: %o', result);
-        throw new Error(result.message || 'Failed to track repository');
-      }
-
-      // Parse successful response
-      const result = await response.json();
+      const result = await handleApiResponse(response, 'track-repository');
       console.log('Track repository response: %o', result);
 
       // Check if tracking was successful

--- a/src/lib/utils/api-helpers.test.ts
+++ b/src/lib/utils/api-helpers.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { parseJsonResponse, handleApiResponse } from './api-helpers';
+
+describe('API Helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  describe('parseJsonResponse', () => {
+    it('should parse valid JSON response', async () => {
+      const mockData = { success: true, data: 'test' };
+      const response = new Response(JSON.stringify(mockData), {
+        headers: { 'content-type': 'application/json' },
+      });
+
+      const result = await parseJsonResponse(response);
+      expect(result).toEqual(mockData);
+    });
+
+    it('should throw error for HTML response', async () => {
+      const htmlContent = '<!DOCTYPE html><html><body>404 Not Found</body></html>';
+      const response = new Response(htmlContent, {
+        headers: { 'content-type': 'text/html' },
+      });
+
+      await expect(parseJsonResponse(response)).rejects.toThrow(
+        'Invalid response format from server - expected JSON but received HTML'
+      );
+      expect(console.error).toHaveBeenCalledWith(
+        'Non-JSON response received:',
+        expect.stringContaining('<!DOCTYPE html>')
+      );
+    });
+
+    it('should throw error when content-type is missing', async () => {
+      const response = new Response('Some text content', {
+        headers: {},
+      });
+
+      await expect(parseJsonResponse(response)).rejects.toThrow(
+        'Invalid response format from server - expected JSON but received HTML'
+      );
+    });
+
+    it('should include context in error message when provided', async () => {
+      const response = new Response('Error page', {
+        headers: { 'content-type': 'text/plain' },
+      });
+
+      await expect(parseJsonResponse(response, 'test-context')).rejects.toThrow(
+        'Invalid response format from server - expected JSON but received HTML'
+      );
+      expect(console.error).toHaveBeenCalledWith(
+        'Non-JSON response received (test-context):',
+        'Error page'
+      );
+    });
+
+    it('should handle application/json with charset', async () => {
+      const mockData = { test: 'data' };
+      const response = new Response(JSON.stringify(mockData), {
+        headers: { 'content-type': 'application/json; charset=utf-8' },
+      });
+
+      const result = await parseJsonResponse(response);
+      expect(result).toEqual(mockData);
+    });
+  });
+
+  describe('handleApiResponse', () => {
+    it('should return parsed JSON for successful response', async () => {
+      const mockData = { success: true, id: '123' };
+      const response = new Response(JSON.stringify(mockData), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+
+      const result = await handleApiResponse(response);
+      expect(result).toEqual(mockData);
+    });
+
+    it('should throw error with server message for error response', async () => {
+      const errorData = { message: 'Repository not found' };
+      const response = new Response(JSON.stringify(errorData), {
+        status: 404,
+        headers: { 'content-type': 'application/json' },
+      });
+
+      await expect(handleApiResponse(response)).rejects.toThrow('Repository not found');
+    });
+
+    it('should throw generic error for error response without message', async () => {
+      const errorData = { error: 'SOME_ERROR_CODE' };
+      const response = new Response(JSON.stringify(errorData), {
+        status: 500,
+        headers: { 'content-type': 'application/json' },
+      });
+
+      await expect(handleApiResponse(response)).rejects.toThrow(
+        'Request failed with status 500'
+      );
+    });
+
+    it('should handle HTML error pages gracefully', async () => {
+      const htmlError = '<!DOCTYPE html><html><body>503 Service Unavailable</body></html>';
+      const response = new Response(htmlError, {
+        status: 503,
+        headers: { 'content-type': 'text/html' },
+      });
+
+      await expect(handleApiResponse(response)).rejects.toThrow(
+        'Request failed with status 503'
+      );
+      expect(console.error).toHaveBeenCalled();
+    });
+
+    it('should handle network errors', async () => {
+      // Simulate a network error with status 500 (as status 0 is not valid in Response constructor)
+      const response = new Response('Network error occurred', {
+        status: 500,
+        statusText: 'Internal Server Error',
+        headers: { 'content-type': 'text/plain' },
+      });
+
+      await expect(handleApiResponse(response)).rejects.toThrow(
+        'Request failed with status 500'
+      );
+    });
+
+    it('should handle 401 unauthorized with JSON error', async () => {
+      const errorData = { message: 'Please login to continue' };
+      const response = new Response(JSON.stringify(errorData), {
+        status: 401,
+        headers: { 'content-type': 'application/json' },
+      });
+
+      await expect(handleApiResponse(response)).rejects.toThrow('Please login to continue');
+    });
+
+    it('should handle rate limit errors', async () => {
+      const errorData = { message: 'Rate limit exceeded', retryAfter: 60 };
+      const response = new Response(JSON.stringify(errorData), {
+        status: 429,
+        headers: { 'content-type': 'application/json' },
+      });
+
+      await expect(handleApiResponse(response)).rejects.toThrow('Rate limit exceeded');
+    });
+  });
+});

--- a/src/lib/utils/api-helpers.ts
+++ b/src/lib/utils/api-helpers.ts
@@ -1,0 +1,52 @@
+/**
+ * Utility functions for API response handling
+ */
+
+/**
+ * Safely parse JSON response, with special handling for error responses
+ * that might be HTML (e.g., 404 pages) instead of JSON
+ *
+ * @param response - The fetch Response object
+ * @param context - Optional context for better error messages
+ * @returns Parsed JSON object
+ * @throws Error if response is not JSON
+ */
+export async function parseJsonResponse(response: Response, context?: string): Promise<any> {
+  const contentType = response.headers.get('content-type');
+
+  if (!contentType || !contentType.includes('application/json')) {
+    const text = await response.text();
+    const contextMsg = context ? ` (${context})` : '';
+    console.error(`Non-JSON response received${contextMsg}:`, text.substring(0, 200));
+    throw new Error('Invalid response format from server - expected JSON but received HTML');
+  }
+
+  return response.json();
+}
+
+/**
+ * Handle API response with proper error checking and JSON parsing
+ *
+ * @param response - The fetch Response object
+ * @param context - Optional context for better error messages
+ * @returns Parsed JSON for successful responses
+ * @throws Error with message from server or generic error
+ */
+export async function handleApiResponse(response: Response, context?: string): Promise<any> {
+  if (!response.ok) {
+    // Try to parse error response as JSON, but handle HTML error pages
+    let errorData;
+    try {
+      errorData = await parseJsonResponse(response, context);
+    } catch {
+      // If we can't parse as JSON, throw a generic error with status
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+
+    // Throw error with message from server if available
+    throw new Error(errorData.message || `Request failed with status ${response.status}`);
+  }
+
+  // Parse successful response
+  return response.json();
+}


### PR DESCRIPTION
## Summary
Fixes the "Unexpected token '<', '<!DOCTYPE'... is not valid JSON" error that occurs when tracking new repositories.

## Problem
When users attempt to track a new repository, the tracking fails with a JSON parsing error because:
- The `use-repository-tracking.ts` hook was calling the Netlify function directly instead of using the proper API route
- HTML error pages (404s) were being parsed as JSON without validation
- This prevented new repositories from being tracked successfully

## Solution
- ✅ Fixed API endpoint path to use `/api/track-repository` instead of `/.netlify/functions/api-track-repository`
- ✅ Added content-type validation before JSON parsing in all tracking components
- ✅ Improved error messages to clearly indicate when non-JSON responses are received
- ✅ Refactored polling logic to avoid circular dependencies

## Changes
- `src/hooks/use-repository-tracking.ts` - Fixed API path and added response validation
- `src/components/features/repository/repository-tracking-card.tsx` - Added content-type checking
- `src/components/features/repository/unified-sync-button.tsx` - Added content-type checking

## Testing
- [ ] Visit an untracked repository (e.g., `/some-org/some-repo`)
- [ ] Click "Track This Repository" button
- [ ] Verify no JSON parsing errors occur in console
- [ ] Confirm tracking completes successfully and data loads

## Technical Details
The issue was caused by the inconsistent API endpoint usage. Per the documentation and `netlify.toml` configuration:
- Frontend components should always call `/api/track-repository`
- Netlify handles the redirect to `/.netlify/functions/api-track-repository`
- Direct function calls bypass proper error handling and may return HTML 404 pages

This follows the same pattern as other API migrations in the codebase (e.g., Fly.io webhook migration).

🤖 Generated with [Claude Code](https://claude.ai/code)