### PR TITLE
Fix: Service worker caching HTML for API responses

### DIFF
--- a/src/components/features/repository/repository-tracking-card.tsx
+++ b/src/components/features/repository/repository-tracking-card.tsx
@@ -211,7 +211,7 @@ export function RepositoryTrackingCard({
 
       try {
         // Check if repository now has data
-        const response = await fetch(`/api/repository-status?owner=${owner}&repo=${repo}`);
+        const response = await fetch(`/.netlify/functions/api-repository-status?owner=${owner}&repo=${repo}`);
         const data = await response.json();
 
         if (data.hasData) {

--- a/src/components/features/repository/repository-tracking-card.tsx
+++ b/src/components/features/repository/repository-tracking-card.tsx
@@ -211,7 +211,7 @@ export function RepositoryTrackingCard({
 
       try {
         // Check if repository now has data
-        const response = await fetch(`/.netlify/functions/api-repository-status?owner=${owner}&repo=${repo}`);
+        const response = await fetch(`/api/repository-status?owner=${owner}&repo=${repo}`);
         const data = await response.json();
 
         if (data.hasData) {


### PR DESCRIPTION
## Summary

- Fixed service worker incorrectly caching HTML error pages for API requests
- Added JSON validation before caching API responses
- Prevents `SyntaxError: Unexpected token '<'` when parsing API responses

## Post-Mortem

### Root Cause
The service worker was caching ALL responses for `/api/*` routes, including HTML error pages returned by the SPA fallback. Once cached, these HTML responses were served for subsequent API requests, causing JSON parsing errors.

### Timeline
1. User visits a page that makes an API request to `/api/repository-status`
2. If the Netlify redirect fails or returns HTML (SPA fallback), the service worker caches this HTML response
3. All subsequent requests to the same API endpoint receive the cached HTML
4. Frontend tries to parse HTML as JSON, resulting in `SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON`

### Impact
- API requests returning cached HTML instead of JSON
- Breaking repository tracking functionality
- Persistent errors until cache is cleared

## Solution

### Changes Made
1. **Added content-type validation** for API responses before caching
2. **Automatic cleanup** of invalid cached entries (non-JSON responses)
3. **Incremented cache version** from 3.0.0 to 3.0.1 to force cache refresh
4. **Selective caching** - only cache API responses with `application/json` content-type

## Before Merge Steps

1. **Review the changes** in `public/sw-enhanced.js`
2. **Test locally** with Network tab open:
   ```bash
   npm run dev
   # Open DevTools > Application > Service Workers
   # Click "Update" to reload the service worker
   # Test API calls to verify JSON responses are cached
   ```

3. **Verify cache behavior**:
   - API calls should only be cached if they return JSON
   - HTML responses should not be cached for `/api/*` routes

## After Merge Steps

1. **Monitor deployment** - The new service worker will automatically update
2. **Clear CDN cache** if needed (Netlify should handle this automatically)
3. **Verify in production**:
   - Check that `/api/repository-status` returns JSON
   - Monitor browser console for any parsing errors
   - Confirm repository tracking works correctly

4. **User impact**: 
   - Users will automatically get the new service worker on next visit
   - Corrupted cache entries will be cleaned up automatically
   - No user action required

## Testing Checklist
- [ ] Service worker updates correctly
- [ ] API responses return JSON
- [ ] No HTML is cached for API routes
- [ ] Repository tracking functionality works
- [ ] No console errors about JSON parsing

## Related Issues
Addresses feedback from PR review comment about hardcoded Netlify function paths

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>