### PR TITLE
fix: remove DEBUG console statements from production code

### DIFF
--- a/src/lib/insights/issue-metrics.ts
+++ b/src/lib/insights/issue-metrics.ts
@@ -324,15 +324,6 @@ export async function calculateIssueActivityPatterns(
         .gte('created_at', since.toISOString()),
     ]);
 
-    // Debug logging
-    console.log('%s', `[DEBUG] Repository: ${owner}/${repo}`);
-    console.log('%s', `[DEBUG] Issue comments found: ${issueComments?.length || 0}`);
-    console.log('%s', `[DEBUG] PR comments found: ${prComments?.length || 0}`);
-    console.log('%s', `[DEBUG] Issues found: ${issues?.length || 0}`);
-    if (issueComments && issueComments.length > 0) {
-      console.log(`[DEBUG] Sample issue comment:`, issueComments[0]);
-    }
-
     // Calculate most active triager (most comments across both PRs and issues)
     const triagerStats = new Map<string, { username: string; avatar_url: string; count: number }>();
 
@@ -378,13 +369,8 @@ export async function calculateIssueActivityPatterns(
       }
     });
 
-    console.log('%s', `[DEBUG] Triager stats size: ${triagerStats.size}`);
-    console.log(`[DEBUG] Triager stats:`, Array.from(triagerStats.entries()).slice(0, 3));
-
     const mostActiveTriager =
       Array.from(triagerStats.values()).sort((a, b) => b.count - a.count)[0] || null;
-
-    console.log(`[DEBUG] Most active triager:`, mostActiveTriager);
 
     // Calculate most active issue commenters (non-bot users who comment most on issues)
     // Using O(1) Map for efficient counting
@@ -433,17 +419,6 @@ export async function calculateIssueActivityPatterns(
         }
       }
     });
-
-    console.log('%s', `[DEBUG] Issue commenter stats size: ${issueCommenterStats.size}`);
-    console.log('%s', `[DEBUG] Issue authors map size: ${issueAuthors.size}`);
-    if (issueCommenterStats.size === 0) {
-      console.log(
-        `[DEBUG] No commenters found. Total issue comments: ${issueComments?.length || 0}`
-      );
-      console.log(`[DEBUG] First 3 comments (if any):`, issueComments?.slice(0, 3));
-    } else {
-      console.log(`[DEBUG] Top commenters:`, Array.from(issueCommenterStats.values()).slice(0, 3));
-    }
 
     // Get top 3 most active commenters (likely to be first responders)
     const firstResponders = Array.from(issueCommenterStats.values())


### PR DESCRIPTION
## Description
Removes all `[DEBUG]` console.log statements from the codebase as identified in issue #777.

## Changes Made
- Removed 13 debug console.log statements from `src/lib/insights/issue-metrics.ts`
  - Lines 328-334: Repository and data count debug logs
  - Lines 381-383: Triager stats debug logs  
  - Lines 387-388: Most active triager debug log
  - Lines 437-446: Issue commenter stats debug logs

## Why This Change Is Needed
These debug statements were added during development to troubleshoot issue metrics calculations but should not be present in production code as they:
- Add unnecessary output to production logs
- May expose internal implementation details
- Impact performance (although minimal)

## Testing
- [x] Code builds successfully with no TypeScript errors
- [x] Linting passes with no warnings
- [x] Prettier formatting applied
- [x] Verified no other `[DEBUG]` statements exist in source code

## Related Issues
Fixes #777

Generated with [Continue](https://continue.dev)