### PR TITLE
fix: Send repositoryId in capture/repository.sync event

### DIFF
--- a/src/lib/supabase-pr-data-smart.ts
+++ b/src/lib/supabase-pr-data-smart.ts
@@ -165,10 +165,10 @@ export async function fetchPRDataSmart(
           await sendInngestEvent({
             name: 'capture/repository.sync',
             data: {
-              owner,
-              repo,
+              repositoryId: repoData.id,
+              days: 7,
               priority: isEmpty ? 'high' : 'medium',
-              source: 'smart-fetch-stale-data',
+              reason: 'smart-fetch-stale-data',
             },
           });
 


### PR DESCRIPTION
## Summary
- Fixed missing repositoryId error in Inngest capture/repository.sync function
- Updated smart fetch to send correct event data structure

## Problem
The capture/repository.sync Inngest function was failing with:
```
NonRetriableError: Missing repositoryId
```

This occurred because the smart fetch function was sending `owner` and `repo` fields instead of the required `repositoryId` field.

## Solution
Updated the event data in `src/lib/supabase-pr-data-smart.ts` to:
- Send `repositoryId` from `repoData.id`
- Include required `days` field
- Change `source` to `reason` field (matching event schema)

## Test Plan
✅ Built project successfully with `npm run build`
✅ Verified event structure matches Inngest function requirements
✅ Manually tested that the fix sends correct repositoryId

🤖 Generated with [Claude Code](https://claude.ai/code)