### PR TITLE
fix: normalize contributor foreign keys handling across PRs

### DIFF
--- a/app/lib/webhook-contributor-utils.ts
+++ b/app/lib/webhook-contributor-utils.ts
@@ -1,0 +1,67 @@
+// Shared webhook contributor utility (Phase 2)
+// After Phase 2, webhook handlers should import from here instead of inline helpers.
+
+import { supabase } from '../../src/lib/supabase';
+
+interface GithubUserLike {
+  id: number;
+  login: string;
+  name?: string | null;
+  avatar_url?: string | null;
+  html_url?: string | null;
+  email?: string | null;
+  bio?: string | null;
+  company?: string | null;
+  location?: string | null;
+  blog?: string | null;
+  public_repos?: number;
+  followers?: number;
+  following?: number;
+  created_at?: string;
+  type?: string;
+}
+
+export async function ensureContributorForWebhook(
+  githubUser: GithubUserLike | undefined | null
+): Promise<string | null> {
+  if (!githubUser || !githubUser.id || !githubUser.login) return null;
+
+  try {
+    const { data, error } = await supabase
+      .from('contributors')
+      .upsert(
+        {
+          github_id: githubUser.id,
+          username: githubUser.login,
+          display_name: githubUser.name || githubUser.login,
+          email: githubUser.email || null,
+          avatar_url: githubUser.avatar_url || null,
+          profile_url: githubUser.html_url || `https://github.com/${githubUser.login}`,
+          bio: githubUser.bio || null,
+          company: githubUser.company || null,
+          location: githubUser.location || null,
+          blog: githubUser.blog || null,
+          public_repos: githubUser.public_repos || 0,
+          followers: githubUser.followers || 0,
+          following: githubUser.following || 0,
+          github_created_at: githubUser.created_at || new Date().toISOString(),
+          is_bot: githubUser.type === 'Bot' || githubUser.login.includes('[bot]'),
+          is_active: true,
+          first_seen_at: new Date().toISOString(),
+          last_updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'github_id' }
+      )
+      .select('id')
+      .maybeSingle();
+
+    if (error) {
+      console.error('ensureContributorForWebhook error:', error.message);
+      return null;
+    }
+    return data?.id || null;
+  } catch (e: any) {
+    console.error('ensureContributorForWebhook unexpected error:', e?.message || e);
+    return null;
+  }
+}

--- a/scripts/progressive-capture/lib/contributor-utils.js
+++ b/scripts/progressive-capture/lib/contributor-utils.js
@@ -1,0 +1,49 @@
+// Shared contributor utility functions (Phase 2)
+// Ensures we always work with internal contributor UUIDs instead of raw GitHub IDs.
+
+export async function ensureContributor(supabase, githubUser) {
+  if (!githubUser || !githubUser.id || !githubUser.login) return null;
+
+  try {
+    const { data: contributor, error } = await supabase
+      .from('contributors')
+      .upsert(
+        {
+          github_id: githubUser.id,
+          username: githubUser.login,
+          display_name: githubUser.name || githubUser.login,
+          email: githubUser.email || null,
+          avatar_url: githubUser.avatar_url || null,
+          profile_url: githubUser.html_url || `https://github.com/${githubUser.login}`,
+          bio: githubUser.bio || null,
+          company: githubUser.company || null,
+          location: githubUser.location || null,
+          blog: githubUser.blog || null,
+          public_repos: githubUser.public_repos || 0,
+          followers: githubUser.followers || 0,
+          following: githubUser.following || 0,
+          github_created_at: githubUser.created_at || new Date().toISOString(),
+          is_bot: githubUser.type === 'Bot' || (githubUser.login || '').includes('[bot]'),
+          is_active: true,
+          first_seen_at: new Date().toISOString(),
+          last_updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'github_id' }
+      )
+      .select('id')
+      .maybeSingle();
+    if (error) {
+      console.error('ensureContributor upsert error:', error.message);
+      return null;
+    }
+    return contributor?.id || null;
+  } catch (e) {
+    console.error('ensureContributor unexpected error:', e);
+    return null;
+  }
+}
+
+export async function ensureMergedByContributor(supabase, mergedBy) {
+  if (!mergedBy) return null;
+  return ensureContributor(supabase, mergedBy);
+}


### PR DESCRIPTION
This PR completes the contributor foreign key remediation initiative. It eliminates the systemic misuse of raw GitHub numeric IDs in `author_id`-style UUID foreign key columns across webhooks, backfill jobs, sync scripts, and seed generation. All active ingestion pathways now resolve and persist contributor UUIDs via a consistent upsert-on-`github_id` pattern.

## Problem  
Historically, several ingestion paths (webhooks, backfills, historical syncs, and seed scripts) incorrectly wrote raw GitHub user IDs into UUID foreign key columns (`author_id`, `reviewer_id`, `commenter_id`, etc.). This threatened relational integrity, analytics correctness, and future constraints/migrations. Without containment, downstream data quality tooling and similarity systems could become polluted.

## Objectives (Phases 1–3)  
| Phase | Goal | Status |
|-------|------|--------|
| 1 | Stop production corruption in live webhooks & backfill | ✅ Done |
| 2 | Introduce shared, reusable contributor utilities | ✅ Done |
| 3 | Fix manual / historical ingestion & seed scripts | ✅ Done |

## High-Level Outcomes  
- All PR author attribution now consistently uses `contributors.id` (UUID).  
- Webhooks and scripts no longer rely on ad-hoc inline contributor logic.  
- Seed data generation now performs proper UUID mapping (inserts PRs first, then associates reviews/comments).  
- Backfill tasks upgraded to opportunistically repair missing `author_id`.  
- Foundation laid for upcoming data cleanup + validation (Phase 5) and monitoring (Phase 6).  

---

## Detailed Changes by Phase

### Phase 1: Production Ingestion Hardening  
- Webhook handlers updated (`pull-request-direct`, primary PR webhook) to:
  - Upsert contributors by `github_id` before PR persistence.
  - Replace raw `pr.user.id` usage with resolved UUID (`author_id`).
- Backfill PR stats function updated to:
  - Ensure contributor presence.
  - Patch missing `author_id` where resolvable.

### Phase 2: Shared Contributor Utilities  
- Added contributor-utils.js (Node context) and webhook-contributor-utils.ts (typed/TS context).
- Centralized "ensure contributor exists" logic (conflict on `github_id`, return UUID).
- Removed duplicated inline helper code in webhook paths.

### Phase 3: Script & Seed Integrity  
- Updated manual sync scripts:
  - sync-bdougie-repos.js
  - sync-historical-prs.js
  - Normalized contributor resolution, PR entity shape, and numeric ID casting.
- Refactored generate-seed-data.js:
  - Collects GitHub IDs for authors/reviewers/commenters.
  - Inserts PRs first → fetches internal PR UUIDs → maps reviews/comments with valid FKs.
  - Skips orphaned review/comment rows lacking FK resolvability (prevents integrity violations).
- Ensured PR shape matches schema fields (`number`, `base_branch`, `head_branch`, `merged`, metrics, timestamps).
- Added internal mapping steps instead of placeholder raw ID writes.

### Backward Compatibility  
- No breaking schema changes.  
- Existing downstream queries expecting `author_id` as UUID now receive consistent data.  
- Historical analytics that relied (incorrectly) on numeric values may show improved correctness (no negative impact anticipated).

## Related Issue 

Fixes #842