### PR TITLE
fix: Make author_id and repository_id nullable in pull_requests

### DIFF
--- a/supabase/migrations/20251001000001_make_pr_uuid_columns_nullable.sql
+++ b/supabase/migrations/20251001000001_make_pr_uuid_columns_nullable.sql
@@ -1,0 +1,14 @@
+-- Migration: Make author_id and repository_id nullable in pull_requests table
+-- Issue: #877
+-- Purpose: Enable DLT pipeline to sync PRs with github_ids first, UUIDs populated asynchronously
+--          DLT merge operations fail when trying to update all columns including NOT NULL UUIDs
+--          Two-phase approach: DLT writes github_ids, frontend utilities resolve UUIDs later
+
+-- Make UUID foreign key columns nullable
+ALTER TABLE pull_requests
+  ALTER COLUMN author_id DROP NOT NULL,
+  ALTER COLUMN repository_id DROP NOT NULL;
+
+-- Add comments to document the nullable columns and two-phase approach
+COMMENT ON COLUMN pull_requests.author_id IS 'UUID reference to contributors table - nullable to support two-phase sync (github_id first, UUID resolved asynchronously)';
+COMMENT ON COLUMN pull_requests.repository_id IS 'UUID reference to repositories table - nullable to support two-phase sync (github_id first, UUID resolved asynchronously)';


### PR DESCRIPTION
## Summary
Makes `author_id` and `repository_id` columns nullable in the `pull_requests` table to support DLT pipeline's two-phase sync approach.

## Changes
- Made `author_id` and `repository_id` columns nullable
- Updated column comments to document two-phase sync approach
- Foreign key constraints preserved (ON DELETE SET NULL/CASCADE)

## Context
PR #876 added `author_github_id` and `repository_github_id` columns for DLT pipeline sync, but the original UUID foreign keys remained NOT NULL. DLT merge operations update all columns, causing failures when trying to set UUID columns to NULL.

This enables two-phase sync:
1. **Phase 1**: DLT writes PRs with github_ids, UUID columns NULL
2. **Phase 2**: Frontend utilities (PR #845) resolve github_ids → UUIDs asynchronously

## Testing
- ✅ Migration applied successfully via Supabase MCP
- ✅ All 119,387 existing PRs retain UUID values (verified 0 nulls)
- ✅ Foreign key constraints working correctly
- ✅ Build passes without errors

Resolves #877

🤖 Generated with [Claude Code](https://claude.com/claude-code)