### PR TITLE
fix: Make foreign key constraints deferrable for DLT merge compatibility

### DIFF
--- a/supabase/migrations/20251001000002_make_fk_constraints_deferrable.sql
+++ b/supabase/migrations/20251001000002_make_fk_constraints_deferrable.sql
@@ -1,0 +1,66 @@
+-- Migration: Make foreign key constraints DEFERRABLE for DLT compatibility
+-- Issue: #879
+-- Purpose: Enable DLT merge operations (DELETE+INSERT) for contributors and repositories
+--          by allowing constraint checks to be deferred until transaction commit
+--
+-- Problem: DLT merge uses DELETE+INSERT pattern within a transaction
+--          NO ACTION constraints block DELETE when child rows exist
+--          CASCADE would delete child data (undesirable)
+--          SET NULL would orphan child rows (undesirable)
+--
+-- Solution: DEFERRABLE INITIALLY DEFERRED constraints allow:
+--          1. DELETE to proceed
+--          2. INSERT to complete
+--          3. Constraint checked at COMMIT (when both operations are done)
+--
+-- This works because DLT uses the same primary key (UUID) for DELETE and INSERT,
+-- so at transaction COMMIT, all foreign key references are valid.
+
+-- Contributors table - make problematic NO ACTION constraints DEFERRABLE
+ALTER TABLE issues
+  DROP CONSTRAINT issues_author_id_fkey,
+  ADD CONSTRAINT issues_author_id_fkey
+    FOREIGN KEY (author_id)
+    REFERENCES contributors(id)
+    ON DELETE NO ACTION
+    DEFERRABLE INITIALLY DEFERRED;
+
+ALTER TABLE issues
+  DROP CONSTRAINT issues_closed_by_id_fkey,
+  ADD CONSTRAINT issues_closed_by_id_fkey
+    FOREIGN KEY (closed_by_id)
+    REFERENCES contributors(id)
+    ON DELETE NO ACTION
+    DEFERRABLE INITIALLY DEFERRED;
+
+ALTER TABLE commits
+  DROP CONSTRAINT commits_author_id_fkey,
+  ADD CONSTRAINT commits_author_id_fkey
+    FOREIGN KEY (author_id)
+    REFERENCES contributors(id)
+    ON DELETE NO ACTION
+    DEFERRABLE INITIALLY DEFERRED;
+
+-- Repositories table - make problematic NO ACTION constraint DEFERRABLE
+ALTER TABLE progressive_capture_jobs
+  DROP CONSTRAINT progressive_capture_jobs_repository_id_fkey,
+  ADD CONSTRAINT progressive_capture_jobs_repository_id_fkey
+    FOREIGN KEY (repository_id)
+    REFERENCES repositories(id)
+    ON DELETE NO ACTION
+    DEFERRABLE INITIALLY DEFERRED;
+
+-- Self-referencing repository constraint (parent_repository_id)
+ALTER TABLE repositories
+  DROP CONSTRAINT repositories_parent_repository_id_fkey,
+  ADD CONSTRAINT repositories_parent_repository_id_fkey
+    FOREIGN KEY (parent_repository_id)
+    REFERENCES repositories(id)
+    ON DELETE NO ACTION
+    DEFERRABLE INITIALLY DEFERRED;
+
+-- Add comment documenting the DLT compatibility approach
+COMMENT ON CONSTRAINT issues_author_id_fkey ON issues IS
+  'DEFERRABLE to support DLT merge operations - constraint checked at transaction commit';
+COMMENT ON CONSTRAINT progressive_capture_jobs_repository_id_fkey ON progressive_capture_jobs IS
+  'DEFERRABLE to support DLT merge operations - constraint checked at transaction commit';


### PR DESCRIPTION
## Summary
Makes 5 problematic NO ACTION foreign key constraints DEFERRABLE INITIALLY DEFERRED to enable DLT merge operations for contributors and repositories tables.

## Changes
- ✅ `issues.author_id` → `contributors.id` (DEFERRABLE)
- ✅ `issues.closed_by_id` → `contributors.id` (DEFERRABLE)
- ✅ `commits.author_id` → `contributors.id` (DEFERRABLE)
- ✅ `progressive_capture_jobs.repository_id` → `repositories.id` (DEFERRABLE)
- ✅ `repositories.parent_repository_id` → `repositories.id` (DEFERRABLE)

## Problem
DLT merge operations failed with foreign key constraint violations:
```
update or delete on table "contributors" violates foreign key constraint "issues_author_id_fkey"
update or delete on table "repositories" violates foreign key constraint "progressive_capture_jobs_repository_id_fkey"
```

DLT's merge pattern:
1. DELETE existing record (blocked by NO ACTION constraint when child rows exist)
2. INSERT new record with same UUID
3. COMMIT transaction

## Solution: DEFERRABLE Constraints
DEFERRABLE INITIALLY DEFERRED allows constraint checks to be deferred until transaction COMMIT:
1. **DELETE** proceeds (constraint check deferred)
2. **INSERT** completes (within same transaction)
3. **COMMIT** validates constraints (all foreign keys valid)

## Why Not CASCADE or SET NULL?
- ❌ CASCADE: Would delete child data (undesirable)
- ❌ SET NULL: Would orphan child rows (undesirable)
- ✅ DEFERRABLE: Maintains referential integrity while supporting DLT's pattern

## Testing
- ✅ Migration applied successfully via Supabase MCP
- ✅ All 5 constraints verified as deferrable and initially deferred
- ✅ Build passes without errors
- ✅ Data integrity preserved

## Next Steps
Test with DLT pipeline:
```bash
# From gh-datapipe repo
python scripts/test_supabase_sync.py
```

Expected: Contributors and repositories sync successfully without foreign key violations.

Resolves #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)