### PR TITLE
fix: needs_attention returns NULL instead of false

### DIFF
--- a/supabase/migrations/20251001190000_fix_needs_attention_null.sql
+++ b/supabase/migrations/20251001190000_fix_needs_attention_null.sql
@@ -1,0 +1,27 @@
+-- Fix needs_attention returning NULL instead of false
+-- When there are zero stuck jobs, MAX() returns NULL causing the OR expression to evaluate to NULL
+
+CREATE OR REPLACE FUNCTION get_stuck_job_summary()
+RETURNS TABLE (
+  total_stuck BIGINT,
+  oldest_age_minutes NUMERIC,
+  needs_attention BOOLEAN
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    COUNT(*)::BIGINT as total_stuck,
+    COALESCE(MAX(EXTRACT(EPOCH FROM (NOW() - started_at))/60), 0)::NUMERIC as oldest_age_minutes,
+    (COUNT(*) > 10 OR COALESCE(MAX(EXTRACT(EPOCH FROM (NOW() - started_at))/60), 0) > 30)::BOOLEAN as needs_attention
+  FROM progressive_capture_jobs
+  WHERE status = 'processing'
+    AND started_at < NOW() - INTERVAL '5 minutes';
+END;
+$$;
+
+COMMENT ON FUNCTION get_stuck_job_summary IS
+'Returns summary of stuck jobs for monitoring. needs_attention=true indicates >10 stuck jobs or jobs stuck >30min. Fixed to return false instead of NULL when no jobs are stuck.';


### PR DESCRIPTION
## Problem

The `get_stuck_job_summary()` function returns NULL for `needs_attention` when there are zero stuck jobs.

**Root Cause:**
```sql
MAX(EXTRACT(EPOCH FROM (NOW() - started_at))/60) > 30
```

When there are no rows, `MAX()` returns `NULL`. In SQL, `false OR NULL` evaluates to `NULL`, not `false`.

**Evidence:**
```sql
SELECT get_stuck_job_summary();
-- Before: (0, 0, )    -- needs_attention is NULL
-- After:  (0, 0, f)    -- needs_attention is false
```

## Solution

Wrap `MAX()` in `COALESCE(..., 0)` to ensure it returns 0 instead of NULL:

```sql
(COUNT(*) > 10 OR COALESCE(MAX(EXTRACT(...)/60), 0) > 30)::BOOLEAN
```

## Impact

- Health check endpoint now correctly reports `false` instead of `NULL`
- Monitoring systems can properly evaluate boolean conditions
- Fixes potential issues with health check parsing

## Testing

Already applied to production database and verified:
```sql
SELECT get_stuck_job_summary();
-- Returns: (0, 0, f) ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)