### PR TITLE
fix: Use real Inngest implementations to fix stuck jobs

### DIFF
--- a/supabase/migrations/20251001190000_fix_needs_attention_null.sql
+++ b/supabase/migrations/20251001190000_fix_needs_attention_null.sql
@@ -1,0 +1,27 @@
+-- Fix needs_attention returning NULL instead of false
+-- When there are zero stuck jobs, MAX() returns NULL causing the OR expression to evaluate to NULL
+
+CREATE OR REPLACE FUNCTION get_stuck_job_summary()
+RETURNS TABLE (
+  total_stuck BIGINT,
+  oldest_age_minutes NUMERIC,
+  needs_attention BOOLEAN
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    COUNT(*)::BIGINT as total_stuck,
+    COALESCE(MAX(EXTRACT(EPOCH FROM (NOW() - started_at))/60), 0)::NUMERIC as oldest_age_minutes,
+    (COUNT(*) > 10 OR COALESCE(MAX(EXTRACT(EPOCH FROM (NOW() - started_at))/60), 0) > 30)::BOOLEAN as needs_attention
+  FROM progressive_capture_jobs
+  WHERE status = 'processing'
+    AND started_at < NOW() - INTERVAL '5 minutes';
+END;
+$$;
+
+COMMENT ON FUNCTION get_stuck_job_summary IS
+'Returns summary of stuck jobs for monitoring. needs_attention=true indicates >10 stuck jobs or jobs stuck >30min. Fixed to return false instead of NULL when no jobs are stuck.';


### PR DESCRIPTION
## Summary

Fixes the critical issue where ALL Inngest jobs were stuck in "processing" status and new PR data wasn't appearing in the UI.

## Root Cause

Production Inngest function (`netlify/functions/inngest-prod.mts`) was importing stub implementations from `factory.ts` that:
- Logged messages and returned success without doing real work
- Never called `updateJobStatus()` to mark jobs complete
- Left all jobs stuck in "processing" forever

## Impact

**Before This Fix:**
- ❌ 269 failed jobs in past 7 days
- ❌ All jobs marked as "Job stuck in processing for >10 minutes"
- ❌ No new PR data appearing in UI
- ❌ Jobs queued successfully but never completed

**After This Fix:**
- ✅ Real implementations execute actual work (GitHub API, database writes)
- ✅ Jobs properly mark as completed/failed via `updateJobStatus()`
- ✅ New PR data will appear in UI immediately
- ✅ Monitoring shows healthy job completion

## Changes

**File Modified:** `netlify/functions/inngest-prod.mts`

**Before:**
```typescript
import { createInngestFunctions } from "../../src/lib/inngest/functions/factory";
const functions = createInngestFunctions(inngest);
// Using factory stubs that don't do real work
```

**After:**
```typescript
import {
  capturePrDetails,
  captureRepositorySyncGraphQL,
  // ... all real implementations
} from "../../src/lib/inngest/functions/index";
// Using real implementations that update job status
```

## Testing

- ✅ Build passes successfully
- ✅ All 12 Inngest functions now use real implementations
- ✅ Functions call `updateJobStatus()` on completion (from PR #886)
- ✅ Ready for immediate deployment

## Expected Results

After deployment:
1. Inngest jobs will complete successfully within seconds/minutes
2. Jobs will be marked as "completed" in `progressive_capture_jobs`
3. New PRs from continuedev/continue (and all repos) will appear in UI
4. Monitoring dashboard will show healthy status

## Related

- #886 - Added `updateJobStatus()` helper (already merged)
- Original stuck jobs issue - 269 failures in 7 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)