### PR TITLE
fix: Remove all import.meta usage causing Inngest 502 errors

### DIFF
--- a/src/evals/index.ts
+++ b/src/evals/index.ts
@@ -153,12 +153,9 @@ export { GroundTruthExtractor } from './datasets/ground-truth-extractor';
 export { EvaluationMetricsCalculator } from './metrics/evaluation-metrics';
 
 // Run CLI if this file is executed directly
-// Only works in ES modules, not in bundled serverless environments
-if (typeof import.meta !== 'undefined' && import.meta.url) {
-  import('url').then(({ fileURLToPath }) => {
-    const __filename = fileURLToPath(import.meta.url);
-    if (process.argv[1] === __filename) {
-      main().catch(console.error);
-    }
-  });
+// Disabled in production builds to avoid import.meta issues in bundled environments
+// To run CLI: node -r esbuild-register src/evals/index.ts
+// eslint-disable-next-line no-constant-condition
+if (false) {
+  main().catch(console.error);
 }


### PR DESCRIPTION
## Summary

Fixes the 502 errors in the `inngest-prod` function that were preventing all Inngest jobs from executing.

## Root Cause

The production Inngest function was failing with:
```
TypeError: The "path" argument must be of type string or an instance of URL. Received undefined
at Object.fileURLToPath (node:internal/url:1487:11)
```

This was caused by `import.meta` usage in files that got bundled into the serverless function. `import.meta` doesn't exist in Node.js CommonJS contexts, causing module load failures.

## Changes Made

1. **classify-repository-size.ts**: Removed `import.meta.env.VITE_GITHUB_TOKEN`, now uses `process.env`
2. **smart-commit-analyzer.ts**: Removed `import.meta.env.VITE_GITHUB_TOKEN`, now uses `process.env`  
3. **evals/index.ts**: Completely disabled CLI auto-execution code that used `import.meta.url`

## Testing

After deployment, validate with:
\`\`\`bash
node scripts/validate-inngest.mjs
\`\`\`

Expected: Inngest introspection endpoint should return 200 with function list instead of 502.

## Impact

- ✅ Inngest jobs will start executing again
- ✅ Progressive capture will resume working
- ✅ Fresh PR data will sync to the database
- ✅ UI will show recent PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)