### PR TITLE
fix: Add repository_full_name to PR upsert in GraphQL capture

### DIFF
--- a/src/lib/inngest/functions/capture-pr-details-graphql.ts
+++ b/src/lib/inngest/functions/capture-pr-details-graphql.ts
@@ -262,6 +262,7 @@ export const capturePrDetailsGraphQL = inngest.createFunction(
         .upsert(
           {
             repository_id: repositoryId,
+            repository_full_name: `${repository.owner}/${repository.name}`,
             github_id: pullRequest.databaseId,
             number: pullRequest.number,
             title: pullRequest.title,


### PR DESCRIPTION
## Summary
Fixes null constraint violation error in Inngest runs:
```
Error: Failed to store PR: null value in column "repository_full_name" 
of relation "pull_requests" violates not-null constraint
```

## Changes
- Added `repository_full_name` field to PR upsert in `capture-pr-details-graphql.ts`
- Used existing `repository.owner` and `repository.name` to construct the full name
- Verified other capture functions already include this field

## Testing
- ✅ Build passes with no TypeScript errors
- ✅ Verified field structure matches migration requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)