### PR TITLE
fix: Add missing workspace priority migration from PR #907

### DIFF
--- a/supabase/migrations/20251002000000_add_workspace_priority_columns.sql
+++ b/supabase/migrations/20251002000000_add_workspace_priority_columns.sql
@@ -1,0 +1,55 @@
+-- Migration: Add workspace priority tracking to tracked_repositories
+-- Created: 2025-10-02
+-- Purpose: Support workspace-based repository prioritization system
+-- Related: PR #907 - Workspace repository prioritization (Phase 2)
+
+-- Step 1: Create repository_priority enum if it doesn't exist
+DO $$ BEGIN
+  CREATE TYPE repository_priority AS ENUM ('high', 'medium', 'low');
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+-- Step 2: Add workspace tracking columns
+ALTER TABLE tracked_repositories
+  ADD COLUMN IF NOT EXISTS is_workspace_repo BOOLEAN DEFAULT false,
+  ADD COLUMN IF NOT EXISTS workspace_count INTEGER DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS priority repository_priority DEFAULT 'medium';
+
+-- Step 3: Create indexes for optimized priority queries
+CREATE INDEX IF NOT EXISTS idx_tracked_repos_workspace_priority
+  ON tracked_repositories (is_workspace_repo, priority, tracking_enabled);
+
+CREATE INDEX IF NOT EXISTS idx_tracked_repositories_priority
+  ON tracked_repositories (priority);
+
+CREATE INDEX IF NOT EXISTS idx_tracked_repositories_size_priority
+  ON tracked_repositories (size, priority);
+
+-- Step 4: Backfill workspace repositories with high priority
+-- Repositories in workspaces should have is_workspace_repo=true and priority=high
+UPDATE tracked_repositories tr
+SET
+  is_workspace_repo = true,
+  workspace_count = (
+    SELECT COUNT(DISTINCT wr.workspace_id)
+    FROM workspace_repositories wr
+    WHERE wr.repository_id = tr.repository_id
+  ),
+  priority = 'high'
+WHERE EXISTS (
+  SELECT 1
+  FROM workspace_repositories wr
+  WHERE wr.repository_id = tr.repository_id
+)
+AND (is_workspace_repo IS NULL OR is_workspace_repo = false);
+
+-- Step 5: Add comment for documentation
+COMMENT ON COLUMN tracked_repositories.is_workspace_repo IS
+  'Indicates if repository is in any workspace (updated by WorkspacePrioritySync)';
+
+COMMENT ON COLUMN tracked_repositories.workspace_count IS
+  'Number of workspaces this repository is in (updated by WorkspacePrioritySync)';
+
+COMMENT ON COLUMN tracked_repositories.priority IS
+  'Processing priority: high (workspace repos), medium (tracked-only), low (background tasks)';


### PR DESCRIPTION
## Problem

PR #907 added code querying `priority`, `is_workspace_repo`, and `workspace_count` columns from `tracked_repositories` but didn't include the migration file. This caused all jobs to fail when querying non-existent columns.

## Root Cause

- `HybridQueueManager.queueJob()` queries these columns (lines 65-69)
- Columns were manually applied to production after failures
- Migration file was never committed

## Solution

This PR adds the missing migration file that:

- Creates `repository_priority` enum (high, medium, low)
- Adds `is_workspace_repo`, `workspace_count`, `priority` columns with defaults
- Creates performance indexes for optimized queries
- Backfills existing workspace repos with high priority

## Verification

Migration successfully applied to production. Jobs now process normally since columns exist in database schema.

Fixes job queue stuck in pending state.