### PR TITLE
fix: Normalize GitHub review states to prevent database constraint violations

### DIFF
--- a/supabase/functions/pr-details-batch/index.ts
+++ b/supabase/functions/pr-details-batch/index.ts
@@ -5,6 +5,23 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { corsHeaders } from '../_shared/cors.ts';
 
+/**
+ * Normalizes GitHub review state to database format
+ * GitHub API returns uppercase from GraphQL (e.g., 'APPROVED', 'CHANGES_REQUESTED')
+ * But may also return other values that need validation
+ */
+function normalizeReviewState(githubState: string): string {
+  const normalized = githubState.toUpperCase();
+  const validStates = ['PENDING', 'APPROVED', 'CHANGES_REQUESTED', 'COMMENTED', 'DISMISSED'];
+
+  if (!validStates.includes(normalized)) {
+    console.warn('Unknown review state: %s, defaulting to COMMENTED', githubState);
+    return 'COMMENTED';
+  }
+
+  return normalized;
+}
+
 // Deno.serve is the new way to create edge functions
 Deno.serve(async (req) => {
   return await handleRequest(req);
@@ -354,7 +371,7 @@ async function handleRequest(req: Request): Promise<Response> {
                     github_id: review.databaseId,
                     pull_request_id: pr.databaseId,
                     author_id: reviewerId,
-                    state: review.state,
+                    state: normalizeReviewState(review.state),
                     body: review.body,
                     submitted_at: review.submittedAt,
                     last_updated_at: new Date().toISOString(),


### PR DESCRIPTION
## Summary

Fixes Inngest error: `new row for relation "reviews" violates check constraint "reviews_state_check"`

GitHub's API returns review states in lowercase (e.g., `approved`, `changes_requested`) but the database constraint expects uppercase values (`APPROVED`, `CHANGES_REQUESTED`, `COMMENTED`, `PENDING`, `DISMISSED`).

## Changes

Added `normalizeReviewState()` function to validate and convert review states in:
- `src/lib/inngest/functions/capture-pr-reviews.ts` - Inngest PR reviews function
- `src/lib/progressive-capture/review-comment-processor.ts` - Client-side processor
- `supabase/functions/pr-details-batch/index.ts` - Batch processing edge function
- `supabase/functions/repository-sync-graphql/index.ts` - GraphQL sync function

The function validates against allowed states and defaults unknown values to `COMMENTED` with a warning log.

## Testing

✅ Build passes with TypeScript type checking

🤖 Generated with [Claude Code](https://claude.com/claude-code)