### PR TITLE
fix: Add missing original_commit_id column to comments table

### DIFF
--- a/supabase/migrations/20251003000000_add_original_commit_id_to_comments.sql
+++ b/supabase/migrations/20251003000000_add_original_commit_id_to_comments.sql
@@ -1,0 +1,17 @@
+-- Migration: Add original_commit_id column to comments table
+-- Description: Adds missing original_commit_id column to support review comments
+--              that track the original commit when a review comment is outdated
+-- Related Issue: Review comments from GraphQL API include original commit reference
+
+-- Add original_commit_id column to comments table
+ALTER TABLE comments
+ADD COLUMN IF NOT EXISTS original_commit_id TEXT;
+
+-- Add index for better query performance when looking up comments by original commit
+CREATE INDEX IF NOT EXISTS idx_comments_original_commit_id
+ON comments(original_commit_id)
+WHERE original_commit_id IS NOT NULL;
+
+-- Add comment explaining the column
+COMMENT ON COLUMN comments.original_commit_id IS
+'The original commit ID for review comments. Used when a review comment becomes outdated due to new commits.';


### PR DESCRIPTION
## Summary
Fixes Inngest error when storing review comments from GraphQL API.

## Error
```
Error: Failed to store review comments: Could not find the 'original_commit_id' column of 'comments' in the schema cache
```

## Root Cause
The `comments` table was missing the `original_commit_id` column. The GraphQL function `capture-pr-details-graphql.ts:454` attempts to insert this field when processing review comments, but the column doesn't exist in the schema.

## Changes
- **Migration**: Added `20251003000000_add_original_commit_id_to_comments.sql`
- Added `original_commit_id TEXT` column to comments table
- Added index on `original_commit_id` for query performance
- Added column documentation explaining its purpose

## Purpose
The `original_commit_id` field tracks the original commit reference for review comments that become outdated when new commits are pushed. This is needed for GitHub's review comment threading system.

## Test Plan
- ✅ Migration uses `IF NOT EXISTS` for safe re-runs
- ✅ Build passes with no type errors
- Column is nullable (no data migration needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)