### PR TITLE
fix: persist social links after fetching from GitHub

### DIFF
--- a/src/components/features/workspace/ContributorProfileModal.tsx
+++ b/src/components/features/workspace/ContributorProfileModal.tsx
@@ -664,8 +664,14 @@ function SocialLinksCard({
       const socialLinks = await fetchAndUpdateSocialLinks(contributor.id, contributor.username);
 
       if (socialLinks.discord_url || socialLinks.linkedin_url) {
+        // Update local state
         setDiscordUrl(socialLinks.discord_url || '');
         setLinkedinUrl(socialLinks.linkedin_url || '');
+
+        // Update the contributor object to persist across modal interactions
+        contributor.discord_url = socialLinks.discord_url;
+        contributor.linkedin_url = socialLinks.linkedin_url;
+
         // Show success toast with specific details
         const { toast } = await import('@/hooks/use-toast');
 
@@ -674,8 +680,8 @@ function SocialLinksCard({
         if (socialLinks.discord_url) foundLinks.push('Discord');
 
         toast({
-          title: '✅ Social links fetched successfully',
-          description: `Found ${foundLinks.join(' and ')} link${foundLinks.length > 1 ? 's' : ''} from @${contributor.username}'s GitHub profile`,
+          title: '✅ Social links fetched and saved',
+          description: `Found ${foundLinks.join(' and ')} link${foundLinks.length > 1 ? 's' : ''} from @${contributor.username}'s GitHub profile and saved to database`,
         });
       } else {
         // Show info message when no links found


### PR DESCRIPTION
## Summary
- Updates contributor object after fetching social links to ensure data persists across modal interactions
- Backend already saves to database, but UI state wasn't being updated with fetched values

## Changes
- Updates contributor object properties after successful fetch
- Updates success toast message to confirm data was saved
- Ensures social links persist when modal is closed and reopened

Fixes #925