### PR TITLE
feat: Add workspace metrics functions to Netlify Inngest endpoint

### DIFF
--- a/docs/infrastructure/dual-inngest-architecture.md
+++ b/docs/infrastructure/dual-inngest-architecture.md
@@ -64,7 +64,7 @@ The project uses a **dual-endpoint architecture** for Inngest functions to handl
 6. `handle-batch-embedding-webhook` - Bridge webhook events for batch processing
 7. `handle-similarity-recalculation` - Bridge webhook events for similarity recalculation
 8. `aggregate-workspace-metrics` - Aggregate metrics for a single workspace
-9. `scheduled-workspace-aggregation` - Scheduled metrics refresh (cron: every 5 minutes)
+9. `scheduled-workspace-aggregation` - Scheduled metrics refresh (cron: twice daily at 6 AM and 6 PM)
 10. `handle-workspace-repository-change` - Handle repo add/remove events
 11. `cleanup-workspace-metrics-data` - Data cleanup (cron: daily at 3 AM)
 
@@ -78,7 +78,7 @@ The project uses a **dual-endpoint architecture** for Inngest functions to handl
 - `embedding/batch.process` → `handle-batch-embedding-webhook` → triggers `compute-embeddings`
 - `similarity/repository.recalculate` → `handle-similarity-recalculation` → triggers `compute-embeddings`
 - `workspace.metrics.aggregate` → `aggregate-workspace-metrics`
-- `cron (5m)` → `scheduled-workspace-aggregation`
+- `cron (twice daily)` → `scheduled-workspace-aggregation`
 - `workspace.repository.changed` → `handle-workspace-repository-change`
 - `cron (daily 3am)` → `cleanup-workspace-metrics-data`
 

--- a/docs/infrastructure/dual-inngest-architecture.md
+++ b/docs/infrastructure/dual-inngest-architecture.md
@@ -24,7 +24,7 @@ The project uses a **dual-endpoint architecture** for Inngest functions to handl
                  │  /api/inngest   │              │ /api/inngest-    │
                  │  (Supabase)     │              │  embeddings      │
                  │                 │              │  (Netlify)       │
-                 │  10 Functions   │              │  7 Functions     │
+                 │  10 Functions   │              │  11 Functions    │
                  └─────────────────┘              └──────────────────┘
 ```
 
@@ -63,6 +63,10 @@ The project uses a **dual-endpoint architecture** for Inngest functions to handl
 5. `handle-pr-embedding-webhook` - Bridge webhook events for PR embeddings
 6. `handle-batch-embedding-webhook` - Bridge webhook events for batch processing
 7. `handle-similarity-recalculation` - Bridge webhook events for similarity recalculation
+8. `aggregate-workspace-metrics` - Aggregate metrics for a single workspace
+9. `scheduled-workspace-aggregation` - Scheduled metrics refresh (cron: every 5 minutes)
+10. `handle-workspace-repository-change` - Handle repo add/remove events
+11. `cleanup-workspace-metrics-data` - Data cleanup (cron: daily at 3 AM)
 
 **Event Mappings:**
 - `embeddings.generate` → `generate-embeddings` (legacy)
@@ -73,12 +77,17 @@ The project uses a **dual-endpoint architecture** for Inngest functions to handl
 - `embedding/pr.generate` → `handle-pr-embedding-webhook` → triggers `compute-embeddings`
 - `embedding/batch.process` → `handle-batch-embedding-webhook` → triggers `compute-embeddings`
 - `similarity/repository.recalculate` → `handle-similarity-recalculation` → triggers `compute-embeddings`
+- `workspace.metrics.aggregate` → `aggregate-workspace-metrics`
+- `cron (5m)` → `scheduled-workspace-aggregation`
+- `workspace.repository.changed` → `handle-workspace-repository-change`
+- `cron (daily 3am)` → `cleanup-workspace-metrics-data`
 
 **Why Netlify:**
 - Requires `@xenova/transformers` (Node.js-only ML library for legacy functions)
 - Uses `crypto` module for content hashing
 - Heavy model loading requires Node.js runtime
 - Webhook bridge functions route events to compute-embeddings
+- Workspace metrics use WorkspaceAggregationService (compatible with Node.js runtime)
 
 ## Configuration
 
@@ -244,6 +253,9 @@ Long-term recommendation:
 
 ---
 
-**Last Updated:** 2025-10-02
+**Last Updated:** 2025-10-05
 **Author:** Claude Code
 **Status:** ✅ Implemented and Deployed
+**Recent Changes:**
+- Added 4 workspace metrics functions to Netlify endpoint (Issue #905)
+- Total functions: 10 (Supabase) + 11 (Netlify) = 21 functions


### PR DESCRIPTION
## Problem

Webhooks are sending workspace metrics events (`workspace.metrics.aggregate` and `workspace.repository.changed`) to Inngest Cloud, but no functions are registered to handle them, causing silent failures in production.

## Solution

Add 4 workspace metrics functions to the existing Netlify embeddings endpoint, following the dual Inngest architecture pattern from PR #904.

## Changes

- **Added 4 functions** to `inngest-embeddings` endpoint (7 → 11 total)
  - `aggregate-workspace-metrics` - Handle workspace.metrics.aggregate events
  - `scheduled-workspace-aggregation` - Cron every 5 minutes
  - `handle-workspace-repository-change` - Handle workspace.repository.changed events  
  - `cleanup-workspace-metrics-data` - Daily cleanup at 3 AM
- **Updated documentation** in `dual-inngest-architecture.md`

## Implementation Details

**Overlap Protection:**
- Scheduled cron checks for existing `pending/processing` jobs before triggering new ones
- Individual aggregation function has 1-minute throttle per workspace
- Queue-based system prevents duplicate processing

**Existing Code:**
- Implementation file `aggregate-workspace-metrics.ts` already exists in codebase (committed Aug 30)
- This PR only registers these functions with the Inngest endpoint

## Testing

- ✅ Build passes with no TypeScript errors
- ✅ Function IDs verified and match documentation
- ✅ Implementation file verified in codebase
- 🔄 Deploy preview will verify function registration

## Related

Closes #905