### PR TITLE
fix: workspace preview cards with square repo avatars and cached URLs

### DIFF
--- a/src/components/features/workspace/WorkspacePreviewCard.tsx
+++ b/src/components/features/workspace/WorkspacePreviewCard.tsx
@@ -139,7 +139,7 @@ export function WorkspacePreviewCard({
                   key={repo.id}
                   className="flex items-center gap-3 p-2 rounded-md border bg-muted/30"
                 >
-                  <Avatar className="h-6 w-6">
+                  <Avatar className="h-6 w-6 rounded-md">
                     <AvatarImage src={repo.avatar_url} alt={repo.owner} />
                     <AvatarFallback className="text-xs">
                       {repo.owner.charAt(0).toUpperCase()}
@@ -230,7 +230,7 @@ export function WorkspacePreviewCardSkeleton({ className }: { className?: string
           <div className="space-y-2">
             {Array.from({ length: 3 }).map((_, i) => (
               <div key={i} className="flex items-center gap-3 p-2 rounded-md border bg-muted/30">
-                <div className="h-6 w-6 rounded-full bg-muted animate-pulse" />
+                <div className="h-6 w-6 rounded-md bg-muted animate-pulse" />
                 <div className="flex-1 space-y-2">
                   <div className="flex items-center gap-2">
                     <div className="h-3 w-20 bg-muted animate-pulse rounded" />

--- a/src/hooks/use-user-workspaces.ts
+++ b/src/hooks/use-user-workspaces.ts
@@ -27,6 +27,7 @@ type RepositoryWithWorkspace = {
     github_pushed_at: string | null;
     pull_request_count: number | null;
     open_issues_count: number | null;
+    avatar_url: string | null;
   };
 };
 
@@ -263,7 +264,8 @@ export function useUserWorkspaces(): UseUserWorkspacesReturn {
             language,
             github_pushed_at,
             pull_request_count,
-            open_issues_count
+            open_issues_count,
+            avatar_url
           )
         `
         )
@@ -324,7 +326,10 @@ export function useUserWorkspaces(): UseUserWorkspacesReturn {
               language: item.repositories.language,
               activity_score: activityScore,
               last_activity: item.repositories.github_pushed_at || new Date().toISOString(),
-              avatar_url: getRepoOwnerAvatarUrl(item.repositories.owner),
+              avatar_url: getRepoOwnerAvatarUrl(
+                item.repositories.owner,
+                item.repositories.avatar_url || undefined
+              ),
               html_url: `https://github.com/${item.repositories.full_name}`,
             };
           }) || [];


### PR DESCRIPTION
## Problem

This PR fixes two issues with workspace preview cards on the landing page:

1. **Missing repository avatars** - Repository avatars were showing fallback images instead of actual org/repo avatars
2. **Circular avatars for repos** - Repository avatars were circular instead of square (GitHub standard)

### Root Cause

The `use-user-workspaces` hook was not:
- Selecting `avatar_url` from the repositories table
- Passing the cached avatar URL to `getRepoOwnerAvatarUrl()` function

This caused all repository avatars to use the fallback avatar since no cached URL was provided.

## Solution

### Avatar URL Fetching (use-user-workspaces.ts)

1. Added `avatar_url` to the repositories query selection
2. Updated `RepositoryWithWorkspace` TypeScript type to include `avatar_url` field  
3. Pass cached `avatar_url` to `getRepoOwnerAvatarUrl()` function

### Visual Style (WorkspacePreviewCard.tsx)

1. Changed repository avatars from circular to square (`rounded-md`)
2. Updated skeleton loader to match square style
3. Workspace owner avatar remains circular as intended

## Benefits

✅ Repository avatars now display correctly using Supabase cached URLs
✅ Square avatars match GitHub's org/repo avatar design language
✅ Consistent with PR #994's avatar caching improvements
✅ Better visual hierarchy (circular = user, square = org/repo)

## Testing

- [x] Build passes with TypeScript checks
- [x] Avatars query includes cached avatar_url field
- [x] WorkspacePreviewCard uses square avatars for repositories
- [x] Skeleton loaders match updated avatar style

## Related

- Related to #994 (avatar caching improvements)
- Fixes avatar display in workspace preview cards

## Screenshots

Repository avatars now show as square with proper org/repo images instead of fallback avatars.