### PR TITLE
Fix continue-docs-review action to suggest docs when code changes without doc updates

### DIFF
--- a/.continue/doc-templates/README.md
+++ b/.continue/doc-templates/README.md
@@ -134,4 +134,4 @@ These templates should be updated as our documentation standards evolve:
 - Remove sections that aren't useful
 - Add sections that we frequently need
 
-**Last Updated:** 2025-01-07
+**Last Updated:** 2025-10-07

--- a/.continue/doc-templates/README.md
+++ b/.continue/doc-templates/README.md
@@ -1,0 +1,137 @@
+# Documentation Templates
+
+This directory contains templates to help you create consistent, high-quality documentation when adding new features or making changes to the codebase.
+
+## When to Use These Templates
+
+The `continue-docs-review` GitHub Action will suggest which template to use based on your code changes:
+
+- **New feature with UI components?** → Use `feature-template.md`
+- **New hooks or API endpoints?** → Use `api-template.md`
+- **Architecture or system design changes?** → Use `architecture-template.md`
+- **Breaking changes?** → Use `migration-template.md`
+
+## Available Templates
+
+### 1. Feature Template (`feature-template.md`)
+
+Use this when adding new user-facing features or UI components.
+
+**Best for:**
+- New React components
+- New user workflows
+- New UI features
+
+**Copy to:** `docs/features/your-feature-name.md`
+
+### 2. API Template (`api-template.md`)
+
+Use this when creating new hooks, services, or APIs.
+
+**Best for:**
+- React hooks (use*)
+- Service functions
+- Utility libraries
+- API integrations
+
+**Copy to:** `docs/api/your-api-name.md`
+
+### 3. Architecture Template (`architecture-template.md`)
+
+Use this when making significant system design changes or adding new infrastructure.
+
+**Best for:**
+- New services or systems
+- Database schema design
+- Integration patterns
+- Performance optimizations
+- Security implementations
+
+**Copy to:** `docs/architecture/your-system-name.md`
+
+### 4. Migration Template (`migration-template.md`)
+
+Use this when making breaking changes that require users/developers to update their code.
+
+**Best for:**
+- Breaking API changes
+- Removed or renamed exports
+- Database schema migrations
+- Configuration changes
+- Dependency upgrades with breaking changes
+
+**Copy to:** `docs/migration/YYYY-MM-DD-change-description.md`
+
+## How to Use
+
+### 1. Copy the Template
+
+```bash
+# Example: Creating feature documentation
+cp .continue/doc-templates/feature-template.md docs/features/my-new-feature.md
+```
+
+### 2. Fill in the Sections
+
+- Replace `[Placeholders]` with actual content
+- Remove sections that don't apply
+- Add sections if needed
+
+### 3. Review the Documentation
+
+Ask yourself:
+- ✅ Can someone unfamiliar with this code understand it?
+- ✅ Are there code examples they can copy-paste?
+- ✅ Are edge cases and gotchas documented?
+- ✅ Is it scannable (headers, lists, code blocks)?
+
+### 4. Add to Your PR
+
+Include the documentation in the same PR as your code changes.
+
+## Documentation Best Practices
+
+### Write for Your Audience
+
+- **User docs** (`docs/features/`, `public/docs/`): Focus on "how to use"
+- **Developer docs** (`docs/api/`, `docs/architecture/`): Focus on "how it works"
+
+### Keep It Scannable
+
+- Use headers to break up content
+- Use bullet lists for multiple points
+- Use code blocks for examples
+- Use tables for structured data
+
+### Show, Don't Just Tell
+
+```typescript
+// ✅ Good - Shows actual code
+const { data } = useMyHook('param');
+
+// ❌ Bad - Just describes
+// "Call useMyHook with a parameter and it returns data"
+```
+
+### Update Docs When Code Changes
+
+- Docs should be updated in the same PR as code
+- Outdated docs are worse than no docs
+- The CI will remind you if docs are needed
+
+## Need Help?
+
+- See `.continue/rules/` for detailed copywriting and formatting guidelines
+- Check existing docs in `docs/` for examples
+- Ask in PR comments if unsure which template to use
+
+## Template Maintenance
+
+These templates should be updated as our documentation standards evolve:
+
+- Add new templates for common doc patterns
+- Update examples to match current codebase patterns
+- Remove sections that aren't useful
+- Add sections that we frequently need
+
+**Last Updated:** 2025-01-07

--- a/.continue/doc-templates/api-template.md
+++ b/.continue/doc-templates/api-template.md
@@ -1,0 +1,170 @@
+# [API Name] API
+
+## Overview
+
+Brief description of what this API/hook does and its purpose.
+
+## Import
+
+```typescript
+import { useYourHook } from '@/hooks/use-your-hook';
+// or
+import { yourService } from '@/lib/services/your-service';
+```
+
+## Signature
+
+```typescript
+function useYourHook(
+  param1: Type1,
+  options?: Options
+): ReturnType;
+```
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| param1 | `Type1` | Yes | Description of param1 |
+| options | `Options` | No | Configuration options |
+
+### Options
+
+```typescript
+interface Options {
+  option1?: string;  // Description
+  option2?: boolean; // Description
+  onSuccess?: (data: Data) => void; // Callback on success
+  onError?: (error: Error) => void; // Callback on error
+}
+```
+
+### Return Value
+
+```typescript
+interface ReturnType {
+  data: Data | null;
+  loading: boolean;
+  error: Error | null;
+  refetch: () => Promise<void>;
+}
+```
+
+## Usage Examples
+
+### Basic Example
+
+```typescript
+function MyComponent() {
+  const { data, loading, error } = useYourHook('param-value');
+
+  if (loading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error.message}</div>;
+
+  return <div>{data?.value}</div>;
+}
+```
+
+### With Options
+
+```typescript
+function MyComponent() {
+  const { data, refetch } = useYourHook('param-value', {
+    option1: 'value',
+    onSuccess: (data) => {
+      console.log('Success!', data);
+    },
+    onError: (error) => {
+      console.error('Failed:', error);
+    }
+  });
+
+  return (
+    <div>
+      <div>{data?.value}</div>
+      <button onClick={refetch}>Refresh</button>
+    </div>
+  );
+}
+```
+
+### Advanced Pattern
+
+```typescript
+// Example of a more complex usage pattern
+function AdvancedComponent() {
+  const [param, setParam] = useState('initial');
+
+  const { data, loading, refetch } = useYourHook(param, {
+    option1: 'value',
+    option2: true
+  });
+
+  useEffect(() => {
+    if (data) {
+      // Do something with data
+    }
+  }, [data]);
+
+  return (
+    <div>
+      {/* Your component JSX */}
+    </div>
+  );
+}
+```
+
+## API Behavior
+
+### Caching
+
+Explain any caching behavior, if applicable.
+
+### Error Handling
+
+Explain how errors are handled and what errors might be thrown.
+
+### Side Effects
+
+List any side effects this API has (network calls, local storage, etc).
+
+## Best Practices
+
+- ✅ **DO**: Use this hook when...
+- ✅ **DO**: Always handle loading and error states
+- ❌ **DON'T**: Call this in loops or conditionally
+- ❌ **DON'T**: Use this if you need...
+
+## Common Patterns
+
+### Pattern 1: [Scenario]
+
+```typescript
+// Example code for common pattern
+```
+
+### Pattern 2: [Another Scenario]
+
+```typescript
+// Example code for another pattern
+```
+
+## Troubleshooting
+
+### Problem: Hook returns null
+
+**Cause**: Usually means the data hasn't loaded yet or there's no data.
+
+**Solution**: Always check loading state before accessing data.
+
+### Problem: [Another Issue]
+
+**Cause**: Why this happens.
+
+**Solution**: How to fix it.
+
+## Related
+
+- Related hooks/APIs
+- Architecture documentation
+- Related features

--- a/.continue/doc-templates/architecture-template.md
+++ b/.continue/doc-templates/architecture-template.md
@@ -1,0 +1,263 @@
+# [System/Feature] Architecture
+
+## Overview
+
+High-level description of what this architecture document covers and why this system exists.
+
+## System Context
+
+### Problem Statement
+
+What problem does this solve? What pain points did we have before?
+
+### Goals
+
+- Primary goal 1
+- Primary goal 2
+- Non-goal: What this explicitly does NOT do
+
+### Constraints
+
+- Technical constraints (e.g., "must work with existing auth system")
+- Business constraints (e.g., "needs to scale to 1M+ users")
+- Time constraints
+
+## Architecture Diagram
+
+```
+[User] --> [Frontend Component]
+           |
+           v
+     [Service Layer] --> [External API]
+           |
+           v
+     [Database] --> [Cache]
+```
+
+*(Use ASCII diagrams, Mermaid, or link to external diagram)*
+
+## Components
+
+### Component 1: [Name]
+
+**Purpose**: What this component does
+
+**Location**: `src/lib/services/component-name.ts`
+
+**Responsibilities**:
+- Responsibility 1
+- Responsibility 2
+
+**Dependencies**:
+- Depends on Component X
+- Uses Service Y
+
+**Key Design Decisions**:
+- Decision: Why we chose approach A over B
+- Trade-off: What we gained and what we gave up
+
+### Component 2: [Name]
+
+**Purpose**: What this component does
+
+**Location**: `src/hooks/use-component.ts`
+
+**Responsibilities**:
+- Responsibility 1
+- Responsibility 2
+
+**Dependencies**:
+- Depends on Component X
+
+## Data Flow
+
+### Request Flow
+
+1. User action triggers component
+2. Component calls service layer
+3. Service validates input
+4. Service makes API call
+5. Response is cached
+6. Component updates UI
+
+```typescript
+// Example of typical data flow
+user.click()
+  -> component.handleClick()
+  -> service.fetchData()
+  -> api.request()
+  -> cache.set()
+  -> component.setState()
+```
+
+### Data Model
+
+```typescript
+interface PrimaryDataModel {
+  id: string;
+  field1: Type;
+  field2: Type;
+  // Key fields and their purpose
+}
+```
+
+## Technical Decisions
+
+### Decision 1: [Choice Made]
+
+**Context**: What situation led to this decision
+
+**Options Considered**:
+- Option A: Pros and cons
+- Option B: Pros and cons
+- Option C: Pros and cons
+
+**Decision**: We chose Option A
+
+**Rationale**:
+- Reason 1: Why this was the best choice
+- Reason 2: What this enables for us
+- Trade-off: What we're giving up
+
+**Consequences**:
+- Positive: What we gain
+- Negative: What constraints this imposes
+- Future: What this means for future development
+
+### Decision 2: [Another Choice]
+
+*(Same structure as Decision 1)*
+
+## Integration Points
+
+### External Services
+
+- **Service 1**: How we integrate with it, authentication method
+- **Service 2**: Data we send/receive, error handling
+
+### Internal Services
+
+- **Service A**: How this system talks to Service A
+- **Service B**: Shared data models
+
+## Error Handling
+
+### Error Scenarios
+
+1. **Scenario**: Network failure
+   - **Handling**: Retry with exponential backoff
+   - **User Impact**: Loading spinner, then error message
+
+2. **Scenario**: Invalid data
+   - **Handling**: Validation at service layer
+   - **User Impact**: Form validation errors
+
+### Fallback Strategy
+
+What happens when things fail? Graceful degradation approach.
+
+## Performance Considerations
+
+### Optimization Strategies
+
+- **Caching**: What we cache and for how long
+- **Lazy Loading**: What loads on demand
+- **Batch Operations**: Where we batch requests
+
+### Bottlenecks
+
+- Known bottleneck 1 and mitigation
+- Known bottleneck 2 and future plan
+
+## Security
+
+### Authentication
+
+How this system authenticates users/requests.
+
+### Authorization
+
+What permissions are required and how they're checked.
+
+### Data Protection
+
+- Sensitive data handling
+- Encryption approach
+- PII considerations
+
+## Scalability
+
+### Current Limits
+
+- Can handle X requests per second
+- Database can store Y records efficiently
+
+### Scaling Strategy
+
+- Horizontal: How to add more instances
+- Vertical: Resource limits and upgrades
+- Data: Partitioning/sharding approach if needed
+
+## Testing Strategy
+
+### Unit Tests
+
+What should be unit tested and where tests live.
+
+### Integration Tests
+
+What integration points need testing.
+
+### E2E Tests
+
+Critical user flows that need E2E coverage.
+
+## Deployment
+
+### Infrastructure
+
+- Where this runs (server, serverless, edge)
+- Required resources (memory, CPU)
+
+### Configuration
+
+Key environment variables and their purpose:
+
+```bash
+VARIABLE_NAME=value  # What this controls
+```
+
+### Monitoring
+
+- Metrics to track
+- Alerts to set up
+- Logging approach
+
+## Future Considerations
+
+### Known Limitations
+
+1. **Limitation**: Description of current limit
+   - **Impact**: How this affects users
+   - **Plan**: How we plan to address it
+
+### Planned Improvements
+
+- Improvement 1: What and when
+- Improvement 2: What and when
+
+### Migration Path
+
+If this replaces an old system, how do we migrate?
+
+## References
+
+- [Related Architecture Doc](../link-to-doc.md)
+- [External API Documentation](https://external-api.com/docs)
+- [Original RFC/PRD](../prds/original-prd.md)
+
+## Changelog
+
+- **2024-01-15**: Initial architecture design
+- **2024-02-01**: Added caching layer
+- **2024-03-10**: Updated for new auth system

--- a/.continue/doc-templates/feature-template.md
+++ b/.continue/doc-templates/feature-template.md
@@ -1,0 +1,98 @@
+# [Feature Name]
+
+## Overview
+
+Brief description of what this feature does and why it exists (1-2 sentences).
+
+## Use Cases
+
+- **Use case 1**: Who uses this and when
+- **Use case 2**: Another scenario where this is useful
+
+## How to Use
+
+### Prerequisites
+
+- List any requirements
+- Required permissions or configuration
+- Dependencies needed
+
+### Basic Usage
+
+```tsx
+// Simple example showing the most common usage
+import { YourComponent } from '@/components/YourComponent';
+
+function Example() {
+  return <YourComponent />;
+}
+```
+
+### Advanced Usage
+
+```tsx
+// More complex example with all options
+import { YourComponent } from '@/components/YourComponent';
+
+function AdvancedExample() {
+  return (
+    <YourComponent
+      prop1="value"
+      prop2={customValue}
+      onEvent={handleEvent}
+    />
+  );
+}
+```
+
+## API Reference
+
+### Props / Parameters
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| prop1 | `string` | Yes | - | What this prop does |
+| prop2 | `number` | No | `0` | What this prop does |
+| onEvent | `() => void` | No | - | Callback fired when... |
+
+### Return Value
+
+Describe what the component/function returns or renders.
+
+## Examples
+
+### Example 1: [Scenario]
+
+Description of this example scenario.
+
+```tsx
+// Code example
+```
+
+Expected result: What the user should see or expect.
+
+### Example 2: [Another Scenario]
+
+Description of another scenario.
+
+```tsx
+// Code example
+```
+
+Expected result: What the user should see or expect.
+
+## Common Issues
+
+### Issue: [Problem Description]
+
+**Solution**: How to fix it.
+
+### Issue: [Another Problem]
+
+**Solution**: How to fix it.
+
+## Related
+
+- Link to related features
+- Link to API documentation
+- Link to architecture docs

--- a/.continue/doc-templates/migration-template.md
+++ b/.continue/doc-templates/migration-template.md
@@ -93,11 +93,17 @@ const result = newMethod({ param });
 
 Update your configuration files:
 
+**Before:**
 ```json
-// config.json
 {
-  "oldKey": "value"  // ❌ Remove this
-  "newKey": "value"  // ✅ Add this
+  "oldKey": "value"
+}
+```
+
+**After:**
+```json
+{
+  "newKey": "value"
 }
 ```
 

--- a/.continue/doc-templates/migration-template.md
+++ b/.continue/doc-templates/migration-template.md
@@ -1,0 +1,259 @@
+# Migration Guide: [Change Name]
+
+## Overview
+
+Brief summary of what changed and why this migration is needed.
+
+**Version**: From vX.X.X to vY.Y.Y
+**Date**: YYYY-MM-DD
+**Severity**: 🔴 Critical / 🟡 Moderate / 🟢 Minor
+
+## Who Is Affected?
+
+- [ ] All users
+- [ ] Users of [specific feature]
+- [ ] Developers using [specific API]
+- [ ] Self-hosted installations only
+
+## What Changed?
+
+### Before
+
+```typescript
+// Old way of doing things
+import { oldFunction } from 'old-module';
+
+oldFunction('param');
+```
+
+### After
+
+```typescript
+// New way of doing things
+import { newFunction } from 'new-module';
+
+newFunction({ param: 'value' });
+```
+
+### Breaking Changes
+
+1. **Change 1**: `oldFunction()` is removed
+   - **Why**: Reason for removal
+   - **Impact**: What breaks if you don't update
+
+2. **Change 2**: `OldComponent` props changed
+   - **Old props**: `{ prop1: string }`
+   - **New props**: `{ config: { prop1: string } }`
+   - **Why**: Reason for change
+   - **Impact**: Components won't compile
+
+3. **Change 3**: Database schema updated
+   - **What changed**: Column X renamed to Y
+   - **Impact**: Queries using old column will fail
+
+## Migration Steps
+
+### Step 1: Update Dependencies
+
+```bash
+npm install package@latest
+# or
+yarn upgrade package
+```
+
+### Step 2: Update Code
+
+#### Pattern 1: [Common Update]
+
+**Before:**
+```typescript
+// Old code
+const result = oldMethod(param);
+```
+
+**After:**
+```typescript
+// New code
+const result = newMethod({ param });
+```
+
+#### Pattern 2: [Another Common Update]
+
+**Before:**
+```typescript
+// Old code
+```
+
+**After:**
+```typescript
+// New code
+```
+
+### Step 3: Update Configuration
+
+Update your configuration files:
+
+```json
+// config.json
+{
+  "oldKey": "value"  // ❌ Remove this
+  "newKey": "value"  // ✅ Add this
+}
+```
+
+### Step 4: Update Database (if applicable)
+
+Run migration:
+
+```bash
+npm run migrate
+# or
+npx supabase db push
+```
+
+The migration will:
+- Rename column X to Y
+- Add index on column Z
+- Preserve all existing data
+
+### Step 5: Update Environment Variables
+
+```bash
+# .env
+OLD_VAR=value     # ❌ Remove
+NEW_VAR=value     # ✅ Add - serves same purpose as OLD_VAR
+```
+
+### Step 6: Test Your Changes
+
+```bash
+# Run tests to verify migration
+npm test
+
+# Test in development
+npm run dev
+```
+
+## Automated Migration (if available)
+
+We provide a codemod to automate most changes:
+
+```bash
+npx codemod-name migrate
+```
+
+This will automatically:
+- Update import statements
+- Rename function calls
+- Update prop signatures (where possible)
+
+**Manual review required for**: Complex cases that can't be automated
+
+## Common Migration Issues
+
+### Issue 1: [Common Problem]
+
+**Symptom**: Error message or behavior
+
+**Cause**: Why this happens
+
+**Solution**:
+```typescript
+// Fix code
+```
+
+### Issue 2: [Another Problem]
+
+**Symptom**: Error message or behavior
+
+**Solution**: Steps to fix
+
+## Rollback Plan
+
+If you need to rollback:
+
+### Step 1: Revert Code
+
+```bash
+git revert <commit-hash>
+npm install package@<old-version>
+```
+
+### Step 2: Revert Database (if applicable)
+
+```bash
+npm run migrate:rollback
+```
+
+### Step 3: Restore Configuration
+
+Restore old configuration files from backup.
+
+## Verification Checklist
+
+After migration, verify:
+
+- [ ] Application builds without errors
+- [ ] Tests pass
+- [ ] Dev environment runs successfully
+- [ ] [Feature X] still works
+- [ ] [Feature Y] still works
+- [ ] No console errors
+- [ ] Database queries work
+- [ ] External integrations work
+
+## Timeline
+
+| Date | Action |
+|------|--------|
+| YYYY-MM-DD | Migration guide published |
+| YYYY-MM-DD | Old APIs deprecated (still work) |
+| YYYY-MM-DD | Old APIs removed (breaking) |
+
+## Getting Help
+
+If you encounter issues:
+
+1. Check [Troubleshooting](#common-migration-issues) section above
+2. Search existing [GitHub Issues](link)
+3. Ask in [Discord/Slack](link)
+4. Open a new issue with:
+   - Error message
+   - Your code before and after migration
+   - Steps to reproduce
+
+## Examples
+
+### Full Example: [Real-world Scenario]
+
+Complete before and after example showing migration in context:
+
+**Before:**
+```typescript
+// Full component/file before migration
+```
+
+**After:**
+```typescript
+// Full component/file after migration
+```
+
+## FAQ
+
+### Q: Do I need to update everything at once?
+
+A: No, you can update gradually. See [gradual migration strategy](#).
+
+### Q: Will this affect production?
+
+A: Yes/No. Details about production impact.
+
+### Q: Can I still use the old API temporarily?
+
+A: Yes/No. Details about backward compatibility period.
+
+## Related
+
+- [Changelog](../CHANGELOG.md)
+- [Original RFC](../rfcs/RFC-XXX.md)
+- [Architecture Documentation](../architecture/related-doc.md)

--- a/.github/workflows/continue-docs-review.yml
+++ b/.github/workflows/continue-docs-review.yml
@@ -1,13 +1,28 @@
 name: Continue Documentation Review
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened, ready_for_review, synchronize]
     paths:
+      # Documentation files
       - 'docs/**'
       - 'public/docs/**'
       - '**.md'
       - 'CONTRIBUTING.md'
       - 'README.md'
+      # Code files that may need documentation
+      - 'src/**'
+      - 'components/**'
+      - 'lib/**'
+      - 'hooks/**'
+      - 'app/**'
+      - 'supabase/migrations/**'
+      # Exclude test files and build artifacts
+      - '!**/*.test.{ts,tsx,js,jsx}'
+      - '!**/*.spec.{ts,tsx,js,jsx}'
+      - '!**/__tests__/**'
+      - '!**/*.stories.{ts,tsx,js,jsx}'
+      - '!**/dist/**'
+      - '!**/build/**'
   issue_comment:
     types: [created]
   workflow_dispatch: # Allow manual testing


### PR DESCRIPTION
## Problem

The `continue-docs-review` action only triggered when docs were already modified, missing cases where developers forgot to add documentation with their code changes.

## Solution

### 1. Expanded Workflow Triggers
- Now triggers on all code changes (src/, components/, lib/, hooks/, migrations/)
- Excludes test files and build artifacts
- Added 'synchronize' event for PR updates

### 2. Enhanced Detection Logic
Detects missing docs with priority levels:
- 🔴 **Breaking changes** (removals, renames) - CRITICAL
- 📊 **Database migrations** - schema changes
- ✨ **New features** - components, hooks (50+ lines)
- 🔧 **New services** - APIs, endpoints (100+ lines)
- ⚙️ **Configuration** - env variables, config changes
- 🏗️ **Core library** - significant lib/ changes (150+ lines)

### 3. Smart Suggestions
- Specific file paths based on change type
- Counts affected files ("3 new components need docs")
- Prioritizes critical documentation needs

### 4. Documentation Templates
Created 4 comprehensive templates:
- feature-template.md, api-template.md, architecture-template.md, migration-template.md
- Includes examples and best practices

## Impact

**Before**: Only reviewed existing docs
**After**: Proactively detects missing documentation and provides specific guidance

## Testing

- ✅ TypeScript compiles
- ✅ Linting passes
- Action will trigger on next PR with code changes

Fixes #1000