### PR TITLE
fix(embeddings): configure esbuild ESM format for inngest-embeddings function

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -72,6 +72,9 @@
 # Embeddings function needs esbuild with longer timeout for ML model loading
 [functions.inngest-embeddings]
   node_bundler = "esbuild"
+  # Use ESM format to support import.meta in the codebase
+  [functions.inngest-embeddings.esbuild]
+    format = "esm"
 
 # Manual backfill functions may take longer
 [functions.backfill-trigger]


### PR DESCRIPTION
## Problem

The `inngest-embeddings` Netlify function returns 502 Bad Gateway, blocking all embedding generation and similarity search.

## Root Cause

Esbuild defaults to CommonJS output format, incompatible with `import.meta` usage in the codebase, causing runtime failures.

## Solution

Configure esbuild to use ESM format in netlify.toml:

```toml
[functions.inngest-embeddings.esbuild]
  format = "esm"
```

## Impact

- ✅ Fixes 502 errors on `/api/inngest-embeddings`
- ✅ Enables embedding generation (cron: every 15 min)
- ✅ Unblocks similarity search functionality
- ✅ Processes 100+ items waiting for embeddings

Fixes #1016

🤖 Generated with [Claude Code](https://claude.com/claude-code)