### PR TITLE
fix: pass embedding arrays directly instead of converting to strings

### DIFF
--- a/supabase/functions/inngest-prod/index.ts
+++ b/supabase/functions/inngest-prod/index.ts
@@ -1142,7 +1142,7 @@ const computeEmbeddings = inngest.createFunction(
               await supabase
                 .from(table)
                 .update({
-                  embedding: `[${embedding.join(',')}]`,
+                  embedding,
                   embedding_generated_at: new Date().toISOString(),
                   content_hash: item.content_hash,
                 })
@@ -1153,7 +1153,7 @@ const computeEmbeddings = inngest.createFunction(
                   repository_id: item.repository_id,
                   item_type: item.type,
                   item_id: item.id,
-                  embedding: `[${embedding.join(',')}]`,
+                  embedding,
                   content_hash: item.content_hash,
                   ttl_hours: 168,
                 },


### PR DESCRIPTION
## Summary

Fixes the silent failure in the "Compute Embeddings for Issues, PRs, and Discussions" Inngest function.

## Problem

The embedding computation function was failing silently with no error messages. The root cause was that embeddings were being converted to strings before insertion into the database:

```typescript
embedding: `[${embedding.join(',')}]`  // Wrong - creates string "[0.1,0.2,0.3]"
```

## Solution

Supabase's PostgreSQL `vector` type expects actual arrays, not stringified versions. The fix removes the string conversion:

```typescript
embedding  // Correct - passes array directly
```

## Changes

- **File**: `supabase/functions/inngest-prod/index.ts:1145,1156`
- Removed string conversion for embedding arrays in both table updates and similarity cache insertions
- Embeddings now properly inserted as vector types instead of failing silently

## Testing

- Build passes ✅
- TypeScript type check passes ✅
- Lint passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)