### PR TITLE
fix: register syncDiscussionsCron function in Inngest endpoint

### DIFF
--- a/netlify/functions/netlify/functions/inngest.mts
+++ b/netlify/functions/netlify/functions/inngest.mts
@@ -1,6 +1,6 @@
-import { serve } from "inngest/lambda";
-import type { Context } from "@netlify/functions";
-import { inngest } from "../../src/lib/inngest/client";
+import { serve } from 'inngest/lambda';
+import type { Context } from '@netlify/functions';
+import { inngest } from '../../src/lib/inngest/client';
 import {
   capturePrDetails,
   capturePrReviews,
@@ -11,7 +11,8 @@ import {
   classifyRepositorySize,
   classifySingleRepository,
   discoverNewRepository,
-} from "../../src/lib/inngest/functions/index-without-embeddings";
+  syncDiscussionsCron,
+} from '../../src/lib/inngest/functions/index-without-embeddings';
 
 // Create the Inngest serve handler
 const inngestHandler = serve({
@@ -29,37 +30,43 @@ const inngestHandler = serve({
     classifySingleRepository,
     // Discovery function
     discoverNewRepository,
+    // Discussion sync cron
+    syncDiscussionsCron,
   ],
-  servePath: "/.netlify/functions/inngest",
+  servePath: '/.netlify/functions/inngest',
 });
 
 // Export the Netlify handler
 export default async (req: Request, context: Context) => {
   // Handle GET requests with a status page
-  if (req.method === "GET" && !req.url.includes("?")) {
-    return new Response(JSON.stringify({
-      message: "Inngest endpoint is active",
-      endpoint: "/.netlify/functions/inngest",
-      functions: [
-        "capture-pr-details",
-        "capture-pr-reviews", 
-        "capture-pr-comments",
-        "capture-repository-sync",
-        "capture-pr-details-graphql",
-        "capture-repository-sync-graphql",
-        "classify-repository-size",
-        "classify-single-repository",
-        "discover-new-repository"
-      ],
-      environment: {
-        context: process.env.CONTEXT || "unknown",
-        hasEventKey: !!process.env.INNGEST_EVENT_KEY,
-        hasSigningKey: !!process.env.INNGEST_SIGNING_KEY,
+  if (req.method === 'GET' && !req.url.includes('?')) {
+    return new Response(
+      JSON.stringify({
+        message: 'Inngest endpoint is active',
+        endpoint: '/.netlify/functions/inngest',
+        functions: [
+          'capture-pr-details',
+          'capture-pr-reviews',
+          'capture-pr-comments',
+          'capture-repository-sync',
+          'capture-pr-details-graphql',
+          'capture-repository-sync-graphql',
+          'classify-repository-size',
+          'classify-single-repository',
+          'discover-new-repository',
+          'sync-discussions-cron',
+        ],
+        environment: {
+          context: process.env.CONTEXT || 'unknown',
+          hasEventKey: !!process.env.INNGEST_EVENT_KEY,
+          hasSigningKey: !!process.env.INNGEST_SIGNING_KEY,
+        },
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
       }
-    }), {
-      status: 200,
-      headers: { "Content-Type": "application/json" }
-    });
+    );
   }
 
   // Pass all other requests to Inngest


### PR DESCRIPTION
## Problem
Discussion sync cron job (PR #1039) wasn't running because the `syncDiscussionsCron` function was never registered with the deployed Inngest endpoint.

## Root Cause Analysis
- Function was created in `/src/lib/inngest/functions/sync-discussions-cron.ts`
- Function was properly exported from `index-without-embeddings.ts`
- **BUT** it was never imported or registered in `/netlify/functions/netlify/functions/inngest.mts`
- Last discussion sync: Oct 6, 2025 at 21:15 UTC (3 days ago)
- Database shows 202 discussions, but no new ones since Oct 6

## Solution
Added `syncDiscussionsCron` to the Inngest endpoint in three places:
- Import statement (line 14)
- Functions array registration (line 34)
- Status page function list (line 56)

## Impact
✅ Cron will now run daily at 2 AM UTC as originally intended  
✅ Discussions for `continuedev/continue` and `bdougie/contributor.info` will sync automatically  
✅ Fixes 3-day gap in discussion data  

## Testing
- [x] Build passes
- [x] TypeScript types verified  
- [ ] Ready for deployment to trigger first cron run

🤖 Generated with [Claude Code](https://claude.com/claude-code)