### PR TITLE
fix: use correct 'issues' table in similarity search

### DIFF
--- a/src/services/similarity-search.ts
+++ b/src/services/similarity-search.ts
@@ -62,7 +62,7 @@ export async function findSimilarItems(options: SimilaritySearchOptions): Promis
     if (queryItem.type === 'pr') {
       tableName = 'pull_requests';
     } else if (queryItem.type === 'issue') {
-      tableName = 'github_issues';
+      tableName = 'issues';
     } else {
       tableName = 'discussions';
     }


### PR DESCRIPTION
**Problem:** Similarity search was using `github_issues` table instead of `issues` table, causing silent failures.

**Solution:** Updated `similarity-search.ts` to query the correct `issues` table which has embeddings.

**Analysis:** Both tables serve legitimate but different purposes:
- `github_issues`: DLT pipeline data (external sync)
- `issues`: Core workspace functionality with embeddings

The database function was already fixed in migration `20251009000001` but the client code wasn't updated.

Fixes #1063

Generated with [Claude Code](https://claude.ai/code)