### PR TITLE
feat: Standardize embedding dimensions to 384 across all entities

### DIFF
--- a/src/services/similarity-search.ts
+++ b/src/services/similarity-search.ts
@@ -84,6 +84,10 @@ export async function findSimilarItems(options: SimilaritySearchOptions): Promis
     // Embedding is already in array format from database
     const embeddingArray = itemData.embedding;
 
+    // Map frontend type to database type
+    // Frontend uses 'pr' but database expects 'pull_request'
+    const dbItemType = queryItem.type === 'pr' ? 'pull_request' : queryItem.type;
+
     // Step 4: Use the new cross-entity similarity function
     // This function handles all entity types in a single call with consistent dimensions
     const { data: similarItems, error: similarityError } = await supabase.rpc(
@@ -92,7 +96,7 @@ export async function findSimilarItems(options: SimilaritySearchOptions): Promis
         query_embedding: embeddingArray,
         repo_ids: repoIds,
         match_count: Math.min(limit * 3, 100), // Cap at 100 to prevent excessive database load
-        exclude_item_type: queryItem.type,
+        exclude_item_type: dbItemType,
         exclude_item_id: rawId,
       }
     );

--- a/supabase/migrations/20251018000001_standardize_embedding_dimensions.sql
+++ b/supabase/migrations/20251018000001_standardize_embedding_dimensions.sql
@@ -231,7 +231,7 @@ BEGIN
     JOIN repositories r ON i.repository_id = r.id
     WHERE i.repository_id = ANY(repo_ids)
     AND i.embedding IS NOT NULL
-    AND NOT (exclude_item_type = 'issue' AND exclude_item_id = i.id::TEXT)
+    AND NOT (exclude_item_type IS NOT DISTINCT FROM 'issue' AND exclude_item_id IS NOT DISTINCT FROM i.id::TEXT)
     
     UNION ALL
     
@@ -248,7 +248,7 @@ BEGIN
     JOIN repositories r ON pr.repository_id = r.id
     WHERE pr.repository_id = ANY(repo_ids)
     AND pr.embedding IS NOT NULL
-    AND NOT (exclude_item_type = 'pull_request' AND exclude_item_id = pr.id::TEXT)
+    AND NOT (exclude_item_type IS NOT DISTINCT FROM 'pull_request' AND exclude_item_id IS NOT DISTINCT FROM pr.id::TEXT)
     
     UNION ALL
     
@@ -265,7 +265,7 @@ BEGIN
     JOIN repositories r ON d.repository_id = r.id
     WHERE d.repository_id = ANY(repo_ids)
     AND d.embedding IS NOT NULL
-    AND NOT (exclude_item_type = 'discussion' AND exclude_item_id = d.id)
+    AND NOT (exclude_item_type IS NOT DISTINCT FROM 'discussion' AND exclude_item_id IS NOT DISTINCT FROM d.id)
     
     ORDER BY similarity DESC
     LIMIT match_count;


### PR DESCRIPTION
Resolves ##1112

This PR standardizes embedding dimensions across issues, PRs, and discussions to enable consistent cross-entity similarity search.

## Changes

- **Database Migration**: Standardizes all embeddings to 384 dimensions
- **Schema Fix**: Updates similarity_cache to support both UUID and VARCHAR IDs
- **New Function**: Creates find_similar_items_cross_entity for unified search
- **Service Update**: Simplifies similarity-search.ts to use cross-entity function

## Benefits

- Consistent embedding dimensions across all entity types
- Cross-entity similarity search capability
- Simplified codebase with single similarity function
- Better performance with unified embedding model

## Migration Required

The migration script clears existing embeddings and requires regeneration using the standardized 384-dimension model.

Generated with [Claude Code](https://claude.ai/code)