### PR TITLE
fix: add service_role INSERT policy for issues table

### DIFF
--- a/supabase/migrations/20251027000000_fix_issues_rls_insert_policy.sql
+++ b/supabase/migrations/20251027000000_fix_issues_rls_insert_policy.sql
@@ -1,0 +1,59 @@
+-- Fix RLS policies for issues table
+-- Problem: Missing INSERT policy preventing issue sync from service_role
+-- Security: Only service_role can INSERT/DELETE issues (GitHub sync operations)
+-- Existing UPDATE policies for authenticated users remain unchanged
+
+-- =====================================================
+-- ADD INSERT POLICY (SERVICE ROLE ONLY)
+-- =====================================================
+
+-- Only service_role can insert issues (data comes from GitHub sync)
+-- This prevents unauthorized users from creating fake issue records
+CREATE POLICY "service_role_insert_issues"
+ON issues FOR INSERT
+TO service_role
+WITH CHECK (true);
+
+-- =====================================================
+-- ADD UPDATE POLICY (SERVICE ROLE ONLY)
+-- =====================================================
+
+-- Only service_role can perform full updates on issues (for data sync)
+-- Note: Existing policies allow authenticated users to update specific fields
+-- like 'responded_by' through workspace member permissions
+CREATE POLICY "service_role_update_issues"
+ON issues FOR UPDATE
+TO service_role
+USING (true)
+WITH CHECK (true);
+
+-- =====================================================
+-- ADD DELETE POLICY (SERVICE ROLE ONLY)
+-- =====================================================
+
+-- Only service_role can delete issues (for data cleanup)
+CREATE POLICY "service_role_delete_issues"
+ON issues FOR DELETE
+TO service_role
+USING (true);
+
+-- =====================================================
+-- VERIFICATION
+-- =====================================================
+
+-- Check all policies on issues table
+SELECT
+    policyname,
+    cmd as command,
+    roles::text[] as applies_to,
+    CASE
+        WHEN qual IS NOT NULL THEN 'USING clause defined'
+        ELSE 'No USING clause'
+    END as using_check,
+    CASE
+        WHEN with_check IS NOT NULL THEN 'WITH CHECK clause defined'
+        ELSE 'No WITH CHECK clause'
+    END as with_check_defined
+FROM pg_policies
+WHERE schemaname = 'public' AND tablename = 'issues'
+ORDER BY cmd, policyname;


### PR DESCRIPTION
## Summary
- Fixed RLS error preventing GitHub issue sync
- Added service_role-only INSERT/UPDATE/DELETE policies for issues table
- Maintains security by restricting write access to service_role only

## Problem
Issue syncing failed with 403 errors:
```
Error: Failed to upsert issues: new row violates row-level security policy for table "issues"
```

The issues table only had SELECT and UPDATE policies, missing INSERT policy needed for data sync.

## Solution
Created secure RLS policies:
- INSERT: service_role only (prevents fake issue creation)
- UPDATE: service_role for sync operations
- DELETE: service_role for cleanup
- SELECT: public read preserved for progressive onboarding

## Test Plan
- [x] Migration applied successfully to Supabase
- [x] Verified all policies created correctly
- [ ] Test issue sync in application for continuedev/continue

## Files Changed
- `supabase/migrations/20251027000000_fix_issues_rls_insert_policy.sql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)