### PR TITLE
fix: identify and label bot accounts in lottery factor card

### DIFF
--- a/src/components/features/health/lottery-factor.tsx
+++ b/src/components/features/health/lottery-factor.tsx
@@ -453,54 +453,61 @@ export function LotteryFactorContent({
               <div className="text-right">% of total</div>
             </div>
 
-            {safeLotteryFactor.contributors.map((contributor, index) => (
-              <div
-                key={contributor.login}
-                className="flex flex-col space-y-2 sm:grid sm:grid-cols-[1fr_100px_80px] sm:gap-4 sm:items-center sm:space-y-0"
-              >
-                <div className="flex items-center gap-2">
-                  <ContributorHoverCard
-                    contributor={contributor}
-                    role={getContributorRole(contributor.login, index)}
-                  >
-                    <OptimizedAvatar
-                      src={contributor.avatar_url}
-                      alt={contributor.login}
-                      size={32}
-                      lazy={false}
-                      fallback={contributor.login[0]?.toUpperCase() || '?'}
-                      className="cursor-pointer hover:ring-2 hover:ring-primary/50 transition-all"
-                    />
-                  </ContributorHoverCard>
-                  <div className="flex-1 min-w-0">
-                    <div className="font-medium" style={{ wordBreak: 'break-word' }}>
-                      {contributor.login}
-                    </div>
-                    <div className="text-sm text-muted-foreground flex items-center justify-between">
-                      <span>{getContributorRole(contributor.login, index)}</span>
-                      <div className="flex items-center gap-2 sm:hidden">
-                        <span className="flex items-center gap-1">
-                          <span className="text-xs">{contributor.pullRequests}</span>
-                          <GitPullRequest className="h-3 w-3" />
-                        </span>
-                        <span className="flex items-center gap-1">
-                          <span className="text-xs">{Math.round(contributor.percentage)}</span>
-                          <Percent className="h-3 w-3" />
-                        </span>
+            {safeLotteryFactor.contributors.map((contributor, index) => {
+              // Determine if this contributor is a bot
+              const isContributorBot = detectBot({
+                githubUser: { login: contributor.login },
+              }).isBot;
+              const contributorRole = isContributorBot
+                ? 'bot'
+                : getContributorRole(contributor.login, index);
+
+              return (
+                <div
+                  key={contributor.login}
+                  className="flex flex-col space-y-2 sm:grid sm:grid-cols-[1fr_100px_80px] sm:gap-4 sm:items-center sm:space-y-0"
+                >
+                  <div className="flex items-center gap-2">
+                    <ContributorHoverCard contributor={contributor} role={contributorRole}>
+                      <OptimizedAvatar
+                        src={contributor.avatar_url}
+                        alt={contributor.login}
+                        size={32}
+                        lazy={false}
+                        fallback={contributor.login[0]?.toUpperCase() || '?'}
+                        className="cursor-pointer hover:ring-2 hover:ring-primary/50 transition-all"
+                      />
+                    </ContributorHoverCard>
+                    <div className="flex-1 min-w-0">
+                      <div className="font-medium" style={{ wordBreak: 'break-word' }}>
+                        {contributor.login}
+                      </div>
+                      <div className="text-sm text-muted-foreground flex items-center justify-between">
+                        <span>{contributorRole}</span>
+                        <div className="flex items-center gap-2 sm:hidden">
+                          <span className="flex items-center gap-1">
+                            <span className="text-xs">{contributor.pullRequests}</span>
+                            <GitPullRequest className="h-3 w-3" />
+                          </span>
+                          <span className="flex items-center gap-1">
+                            <span className="text-xs">{Math.round(contributor.percentage)}</span>
+                            <Percent className="h-3 w-3" />
+                          </span>
+                        </div>
                       </div>
                     </div>
                   </div>
-                </div>
-                <div className="hidden sm:flex sm:justify-between sm:contents">
-                  <div className="sm:text-right font-medium flex items-center gap-1 sm:justify-end">
-                    <span className="text-base">{contributor.pullRequests}</span>
+                  <div className="hidden sm:flex sm:justify-between sm:contents">
+                    <div className="sm:text-right font-medium flex items-center gap-1 sm:justify-end">
+                      <span className="text-base">{contributor.pullRequests}</span>
+                    </div>
+                    <div className="sm:text-right font-medium flex items-center gap-1 sm:justify-end">
+                      <span className="text-base">{Math.round(contributor.percentage)}%</span>
+                    </div>
                   </div>
-                  <div className="sm:text-right font-medium flex items-center gap-1 sm:justify-end">
-                    <span className="text-base">{Math.round(contributor.percentage)}%</span>
-                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
 
             <div className="border-t pt-4">
               <div className="flex flex-col space-y-2 sm:grid sm:grid-cols-[1fr_100px_80px] sm:gap-4 sm:items-center sm:space-y-0">

--- a/src/lib/utils/bot-detection.ts
+++ b/src/lib/utils/bot-detection.ts
@@ -15,6 +15,8 @@ const KNOWN_BOT_PATTERNS = [
   /^dependabot\[?bot\]?$/i, // Dependabot (exact)
   /^renovate\[?bot\]?$/i, // Renovate (exact)
   /^github-actions\[?bot\]?$/i, // GitHub Actions (exact)
+  /^continue\[?bot\]?$/i, // Continue AI coding assistant (exact)
+  /^snyk\[?bot\]?$/i, // Snyk security scanner (exact)
   /-bot$/i, // Ends with -bot
 ] as const;
 

--- a/supabase/functions/_shared/bot-detection.ts
+++ b/supabase/functions/_shared/bot-detection.ts
@@ -11,6 +11,8 @@ const BOT_PATTERNS = [
   /^dependabot\[?bot\]?$/i,
   /^renovate\[?bot\]?$/i,
   /^github-actions\[?bot\]?$/i,
+  /^continue\[?bot\]?$/i,
+  /^snyk\[?bot\]?$/i,
   /-bot$/i,
 ];
 


### PR DESCRIPTION
## Summary

Fixes issue #1165 by properly identifying and labeling bot accounts (Dependabot, Continue, Snyk) in the Lottery Factor card. Bot accounts now display with a "bot" role badge instead of appearing as "unknown" contributors.

## Changes

**Bot Detection Enhancement**
- Added Continue AI and Snyk bot patterns to detection logic
- Patterns match common bot naming conventions: `continue[bot]`, `snyk[bot]`, etc.

**Lottery Factor Updates**
- Applied bot detection to contributor role assignment in main contributor list
- Bots now receive "bot" role badge (consistent with YOLO Coders view)
- Bot toggle correctly filters bot accounts from metrics

**Edge Function Sync**
- Updated Supabase edge function bot patterns to match frontend

## Impact

- ✅ Bot accounts properly identified and labeled
- ✅ Lottery Factor calculations more accurate when filtering bots
- ✅ Improved contributor analysis clarity

## Testing

- Build verification passed (no TypeScript errors)
- All pre-commit hooks passed

Closes #1165