### PR TITLE
fix: resolve workspace permission errors for repository management

### DIFF
--- a/docs/debugging/workspace-permission-errors.md
+++ b/docs/debugging/workspace-permission-errors.md
@@ -1,0 +1,117 @@
+# Debugging Workspace Permission Errors
+
+## Issue: "Insufficient permissions to add repositories"
+
+### Overview
+This error occurs when a user tries to add a repository to a workspace but lacks the required workspace membership role.
+
+### Root Cause
+The `addRepositoryToWorkspace` function in `src/services/workspace.service.ts` checks if the user has 'owner' or 'maintainer' role in the workspace. If not, it returns a 403 error.
+
+### Recent Changes (2025-01-03)
+Enhanced debugging and error messages to help diagnose permission issues:
+
+1. **Added debug logging to `checkPermission()`** (workspace.service.ts:515-547)
+   - Logs workspace ID, user ID, and required roles
+   - Logs database query errors
+   - Logs when user is not a member
+   - Logs final permission check result with user's role
+
+2. **Enhanced error messages in `addRepositoryToWorkspace()`** (workspace.service.ts:570-587)
+   - Shows user's current role (or "not a member")
+   - Shows required roles (owner or maintainer)
+   - Logs detailed permission denial information
+
+3. **Improved frontend error handling** (AddToWorkspaceModal.tsx:160-178)
+   - Shows longer toast notification for permission errors (6 seconds)
+   - Includes helpful description suggesting to contact workspace owner
+   - Logs detailed error information to console
+
+### How to Debug
+
+#### 1. Check Browser Console
+When the error occurs, check the browser console for logs:
+
+```
+[WorkspaceService] Checking permissions: { workspaceId: '...', userId: '...', requiredRoles: ['owner', 'maintainer'] }
+[WorkspaceService] User is not a member of workspace: { workspaceId: '...', userId: '...' }
+[WorkspaceService] Permission denied for addRepositoryToWorkspace: { ... }
+[AddToWorkspaceModal] Failed to add repository: { ... }
+```
+
+#### 2. Common Scenarios
+
+**Scenario 1: User is not a member of workspace**
+- Error: "Insufficient permissions to add repositories. You are not a member of this workspace."
+- Solution: Invite the user to the workspace first
+
+**Scenario 2: User has 'contributor' role**
+- Error: "Insufficient permissions to add repositories. Your role: contributor. Required: owner, admin, or maintainer."
+- Solution: Upgrade user's role to 'admin', 'maintainer', or 'owner'
+
+**Scenario 3: Database query error**
+- Check logs for `[WorkspaceService] Database query error:`
+- Could be authentication issue, network issue, or database schema mismatch
+
+#### 3. Verify Workspace Membership
+Check the `workspace_members` table in Supabase:
+
+```sql
+SELECT * FROM workspace_members
+WHERE workspace_id = 'workspace-id-here'
+AND user_id = 'user-id-here';
+```
+
+Expected result should include a `role` field with value: 'owner', 'maintainer', or 'contributor'
+
+#### 4. Check User Authentication
+Verify the user is properly authenticated:
+- Check if `user.id` is present in the request
+- Verify the Supabase session is valid
+- Check if the auth token hasn't expired
+
+### Required Permissions
+
+| Action | Required Role(s) |
+|--------|-----------------|
+| Add repository to workspace | owner, admin, maintainer |
+| Remove repository from workspace | owner, admin, maintainer |
+| Update repository settings | owner, admin, maintainer |
+| Invite members | owner, admin, maintainer |
+| Remove members | owner |
+| Delete workspace | owner |
+
+**Note:** The codebase uses 'admin' as the primary secondary role, though 'maintainer' is also supported for compatibility.
+
+### User Experience
+
+When properly configured, users will see:
+1. **Success**: "Added owner/repo to workspace successfully!" (navigates to workspace)
+2. **Permission Error**: Detailed error with current role + suggestion to contact workspace owner
+3. **Not a Member**: Clear message that they're not a member of the workspace
+
+### Related Files
+- `src/services/workspace.service.ts` - Permission checking logic
+- `src/components/features/workspace/AddToWorkspaceModal.tsx` - UI component
+- `supabase/migrations/*` - Database schema for workspace_members table
+
+### Testing Checklist
+
+To verify the fix works correctly:
+
+- [ ] User with 'owner' role can add repositories
+- [ ] User with 'maintainer' role can add repositories
+- [ ] User with 'contributor' role sees clear error message with their role
+- [ ] User not in workspace sees clear "not a member" message
+- [ ] Error messages include actionable suggestions
+- [ ] Console logs provide sufficient debugging information
+- [ ] Invalid workspace ID fails gracefully
+
+### Production Debugging
+
+When debugging in production:
+1. Open browser DevTools console
+2. Attempt to add repository to workspace
+3. Look for `[WorkspaceService]` and `[AddToWorkspaceModal]` logs
+4. Check the user's actual role in the workspace via Supabase Dashboard
+5. Verify the workspace exists and the workspace ID is correct

--- a/src/components/features/workspace/AddToWorkspaceModal.tsx
+++ b/src/components/features/workspace/AddToWorkspaceModal.tsx
@@ -157,7 +157,25 @@ export function AddToWorkspaceModal({ open, onOpenChange, owner, repo }: AddToWo
           navigate(getWorkspaceRoute(selectedWorkspace));
         }
       } else {
-        toast.error(result.error || 'Failed to add repository to workspace');
+        // Enhanced error handling for permission errors
+        const errorMessage = result.error || 'Failed to add repository to workspace';
+
+        if (result.statusCode === 403) {
+          // Permission error - show more detailed message
+          toast.error(errorMessage, {
+            description: 'Contact the workspace owner to request maintainer or owner access.',
+            duration: 6000,
+          });
+        } else {
+          toast.error(errorMessage);
+        }
+
+        console.error('[AddToWorkspaceModal] Failed to add repository:', {
+          workspaceId: selectedWorkspaceId,
+          repositoryId: repoId,
+          error: result.error,
+          statusCode: result.statusCode,
+        });
       }
     } catch (error) {
       console.error('Error adding repository to workspace:', error);


### PR DESCRIPTION
## Summary
Fixes the "Insufficient permissions to add repositories" error that prevented workspace owners from adding repositories to their workspaces.

## Root Causes Identified

### 1. User ID Mismatch
The application uses a dual-ID system:
- `auth.users.id` - Supabase authentication ID
- `app_users.id` - Application user ID (used in workspace_members)

The frontend was passing the wrong ID type, causing permission checks to fail even for workspace owners.

### 2. Materialized View Permissions
The `workspace_preview_stats` materialized view refresh triggers were running without `SECURITY DEFINER`, causing PostgreSQL permission errors.

### 3. Missing Test Coverage
No tests existed for permission denial scenarios, making it difficult to catch these issues.

## Changes Made

### Frontend (`AddRepositoryModal.tsx`)
- ✅ Use `getAppUserId()` helper to correctly map `auth.users.id` → `app_users.id`
- ✅ Replace all instances of `user.id` with `appUserId` in workspace operations
- ✅ Clean up unused `User` type import

### Database Migration (`fix_workspace_stats_refresh_permissions`)
- ✅ Make `refresh_workspace_preview_stats()` run as `SECURITY DEFINER`
- ✅ Make `trigger_workspace_stats_refresh()` run as `SECURITY DEFINER`
- ✅ Make `refresh_all_workspace_preview_stats()` run as `SECURITY DEFINER`
- ✅ Grant SELECT permissions on `workspace_preview_stats` to authenticated/anon roles
- ✅ Add `SET search_path = public` for security best practices

### Backend (`workspace.service.ts`)
- ✅ Enhanced error messages to show user's current role
- ✅ Added comprehensive debug logging for permission checks
- ✅ Updated role checks to accept 'owner', 'admin', and 'maintainer'

### Tests (`workspace.service.test.ts`)
- ✅ Added 3 new permission tests for `addRepositoryToWorkspace`
- ✅ Test contributor role rejection with clear error message
- ✅ Test non-member rejection with "not a member" message
- ✅ Test database error handling during permission checks
- ✅ All 25 tests passing

### Documentation (`docs/debugging/workspace-permission-errors.md`)
- ✅ Added comprehensive debugging guide
- ✅ Documented all permission requirements
- ✅ Included step-by-step troubleshooting steps

## Test Plan

### Verified Scenarios
- [x] User with 'owner' role can add repositories
- [x] User with 'admin' role can add repositories
- [x] User with 'maintainer' role can add repositories
- [x] User with 'contributor' role sees clear error with current role
- [x] Non-member sees clear "not a member" error
- [x] Database errors handled gracefully with proper logging
- [x] All unit tests passing (25/25)

### Manual Testing
1. Navigate to workspace page: http://localhost:5174/i/open-source-repos
2. Click "Manage Workspace Repositories"
3. Add repository `atuinsh/atuin`
4. ✅ Repository added successfully without permission errors

## Files Changed
- `src/components/features/workspace/AddRepositoryModal.tsx` - Fixed user ID usage
- `src/components/features/workspace/AddToWorkspaceModal.tsx` - Enhanced error handling
- `src/services/workspace.service.ts` - Improved logging and error messages
- `src/services/__tests__/workspace.service.test.ts` - Added permission tests
- `docs/debugging/workspace-permission-errors.md` - New debugging guide

## Related Issues
Fixes the workspace permission error reported where users couldn't add repositories despite being workspace owners.