### PR TITLE
fix(slack): use absolute URLs for OAuth callback redirects

### DIFF
--- a/supabase/functions/.env.example
+++ b/supabase/functions/.env.example
@@ -2,6 +2,9 @@
 GITHUB_TOKEN=your_github_personal_access_token
 GITHUB_WEBHOOK_SECRET=your_webhook_secret_here
 
+# Frontend Application URL (for OAuth redirects)
+FRONTEND_URL=https://contributor.info
+
 # Supabase Configuration (automatically provided in Edge Functions)
 # SUPABASE_URL=https://your-project.supabase.co
 # SUPABASE_SERVICE_ROLE_KEY=your_service_role_key

--- a/supabase/functions/slack-oauth-callback/config.toml
+++ b/supabase/functions/slack-oauth-callback/config.toml
@@ -1,0 +1,3 @@
+# Disable JWT verification for OAuth callback
+# OAuth callbacks come from Slack's servers, not authenticated users
+verify_jwt = false

--- a/supabase/functions/slack-oauth-callback/index.ts
+++ b/supabase/functions/slack-oauth-callback/index.ts
@@ -23,6 +23,7 @@ const SLACK_REDIRECT_URI = Deno.env.get('SLACK_REDIRECT_URI');
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
 const ENCRYPTION_KEY = Deno.env.get('SLACK_WEBHOOK_ENCRYPTION_KEY')!;
+const FRONTEND_URL = Deno.env.get('FRONTEND_URL') || 'https://contributor.info';
 
 interface SlackOAuthResponse {
   ok: boolean;
@@ -130,8 +131,8 @@ serve(async (req) => {
         status: 302,
         headers: {
           Location: workspaceId
-            ? `/workspace/${workspaceId}/settings?slack_install=cancelled`
-            : '/?slack_install=cancelled',
+            ? `${FRONTEND_URL}/workspace/${workspaceId}/settings?slack_install=cancelled`
+            : `${FRONTEND_URL}/?slack_install=cancelled`,
         },
       });
     }
@@ -212,7 +213,7 @@ serve(async (req) => {
       return new Response(null, {
         status: 302,
         headers: {
-          Location: `/workspace/${workspaceId}/settings?slack_install=error&error=network_error`,
+          Location: `${FRONTEND_URL}/workspace/${workspaceId}/settings?slack_install=error&error=network_error`,
         },
       });
     }
@@ -222,7 +223,7 @@ serve(async (req) => {
       return new Response(null, {
         status: 302,
         headers: {
-          Location: `/workspace/${workspaceId}/settings?slack_install=error&error=oauth_failed`,
+          Location: `${FRONTEND_URL}/workspace/${workspaceId}/settings?slack_install=error&error=oauth_failed`,
         },
       });
     }
@@ -235,7 +236,7 @@ serve(async (req) => {
       return new Response(null, {
         status: 302,
         headers: {
-          Location: `/workspace/${workspaceId}/settings?slack_install=error&error=invalid_response`,
+          Location: `${FRONTEND_URL}/workspace/${workspaceId}/settings?slack_install=error&error=invalid_response`,
         },
       });
     }
@@ -246,7 +247,7 @@ serve(async (req) => {
         status: 302,
         headers: {
           Location:
-            `/workspace/${workspaceId}/settings?slack_install=error&error=${tokenData.error}`,
+            `${FRONTEND_URL}/workspace/${workspaceId}/settings?slack_install=error&error=${tokenData.error}`,
         },
       });
     }
@@ -261,7 +262,7 @@ serve(async (req) => {
         status: 302,
         headers: {
           Location:
-            `/workspace/${workspaceId}/settings?slack_install=error&error=encryption_failed`,
+            `${FRONTEND_URL}/workspace/${workspaceId}/settings?slack_install=error&error=encryption_failed`,
         },
       });
     }
@@ -320,7 +321,7 @@ serve(async (req) => {
     return new Response(null, {
       status: 302,
       headers: {
-        Location: `/workspace/${workspaceId}/settings?slack_install=success&team=${
+        Location: `${FRONTEND_URL}/workspace/${workspaceId}/settings?slack_install=success&team=${
           encodeURIComponent(tokenData.team!.name)
         }`,
       },
@@ -351,7 +352,7 @@ serve(async (req) => {
       return new Response(null, {
         status: 302,
         headers: {
-          Location: `/workspace/${workspaceId}/settings?slack_install=error&error=unexpected_error`,
+          Location: `${FRONTEND_URL}/workspace/${workspaceId}/settings?slack_install=error&error=unexpected_error`,
         },
       });
     }


### PR DESCRIPTION
## Problem

Slack OAuth callback was failing with "requested path is invalid" error because the function used relative redirect URLs, causing redirects to Supabase function URL instead of the frontend application.

## Solution

- Added `FRONTEND_URL` environment variable to redirect users to `https://contributor.info`
- Updated all redirect locations to use absolute URLs
- Created `config.toml` to document JWT verification requirement
- Updated `.env.example` with new environment variable

## Testing

Deployed function to Supabase (version 5). After JWT verification is disabled in Dashboard, OAuth flow will:
1. Receive callback from Slack
2. Exchange authorization code for bot token
3. Store encrypted token in database
4. Redirect to workspace settings with success message

## Additional Step Required

JWT verification must be manually disabled in Supabase Dashboard since OAuth callbacks from Slack don't include authorization headers.