### PR TITLE
fix(types): add explicit papaparse type reference for Netlify builds

### DIFF
--- a/src/types/papaparse.d.ts
+++ b/src/types/papaparse.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="papaparse" />


### PR DESCRIPTION
## Summary

- Adds `src/types/papaparse.d.ts` with explicit type reference directive
- Fixes TS7016 error on Netlify: "Could not find a declaration file for module 'papaparse'"

**Root cause:** PapaParse v5.5.3 doesn't ship built-in types. With `moduleResolution: "bundler"` and explicit `types` array in tsconfig, TypeScript wasn't auto-discovering `@types/papaparse` on Netlify's build environment.

**Fix:** Triple-slash reference directive explicitly includes the types, bypassing module resolution differences between local and Netlify builds.

## Test plan

- [x] `npm run build` passes locally
- [ ] Netlify deploy preview succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript type definitions to improve development experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->