### PR TITLE
fix(types): use inline papaparse type declarations

### DIFF
--- a/src/types/papaparse.d.ts
+++ b/src/types/papaparse.d.ts
@@ -1,1 +1,75 @@
-/// <reference types="papaparse" />
+/**
+ * Type declarations for papaparse
+ * Inline declarations to ensure consistent builds across all environments
+ */
+
+declare module 'papaparse' {
+  export interface UnparseConfig {
+    quotes?: boolean | boolean[];
+    quoteChar?: string;
+    escapeChar?: string;
+    delimiter?: string;
+    header?: boolean;
+    newline?: string;
+    skipEmptyLines?: boolean | 'greedy';
+    columns?: string[];
+  }
+
+  export function unparse<T>(
+    data: T[] | { fields: string[]; data: T[] },
+    config?: UnparseConfig
+  ): string;
+
+  export interface ParseConfig<T = unknown> {
+    delimiter?: string;
+    newline?: string;
+    quoteChar?: string;
+    escapeChar?: string;
+    header?: boolean;
+    transformHeader?: (header: string, index: number) => string;
+    dynamicTyping?: boolean | { [key: string]: boolean };
+    preview?: number;
+    comments?: boolean | string;
+    step?: (results: ParseResult<T>, parser: Parser) => void;
+    complete?: (results: ParseResult<T>) => void;
+    error?: (error: ParseError) => void;
+    download?: boolean;
+    skipEmptyLines?: boolean | 'greedy';
+    fastMode?: boolean;
+    withCredentials?: boolean;
+    transform?: (value: string, field: string | number) => unknown;
+  }
+
+  export interface ParseResult<T> {
+    data: T[];
+    errors: ParseError[];
+    meta: ParseMeta;
+  }
+
+  export interface ParseError {
+    type: string;
+    code: string;
+    message: string;
+    row?: number;
+  }
+
+  export interface ParseMeta {
+    delimiter: string;
+    linebreak: string;
+    aborted: boolean;
+    truncated: boolean;
+    cursor: number;
+    fields?: string[];
+  }
+
+  export interface Parser {
+    abort: () => void;
+    pause: () => void;
+    resume: () => void;
+  }
+
+  export function parse<T>(
+    input: string | File | NodeJS.ReadableStream,
+    config?: ParseConfig<T>
+  ): ParseResult<T>;
+}


### PR DESCRIPTION
## Summary

- Replaces triple-slash reference directive with full inline type declarations
- Provides complete papaparse types without dependency on `@types/papaparse` resolution

**Why previous fix failed:** The `/// <reference types="papaparse" />` directive relies on TypeScript auto-discovering `@types/papaparse`, which fails on Netlify's build environment due to `moduleResolution: "bundler"` behavior differences.

**This fix:** Inline declarations (like `posthog.d.ts`) work everywhere because they don't depend on external type resolution.

## Test plan

- [x] `npm run build` passes locally
- [ ] Netlify deploy preview succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced TypeScript support with comprehensive type definitions for the papaparse library, providing better IDE autocomplete and type safety for data parsing and conversion operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->