### PR TITLE
fix: throttle GraphQL requests for linked PRs

### DIFF
--- a/src/lib/__tests__/rate-limiter.test.ts
+++ b/src/lib/__tests__/rate-limiter.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Rate limiter tests
+ * Tests for the GraphQL request throttling functionality
+ * Addresses issue #1260 - Batch/throttle GraphQL requests for linked PRs
+ *
+ * Following bulletproof testing guidelines - synchronous tests only
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { RateLimiter, graphqlRateLimiter } from '../rate-limiter';
+
+describe('RateLimiter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('should use default values when no options provided', () => {
+      const limiter = new RateLimiter();
+      const stats = limiter.getStats();
+      expect(stats.queueLength).toBe(0);
+      expect(stats.activeRequests).toBe(0);
+      expect(stats.isProcessing).toBe(false);
+    });
+
+    it('should accept custom options', () => {
+      const limiter = new RateLimiter({
+        maxConcurrent: 10,
+        minDelay: 50,
+        maxRetries: 5,
+      });
+      const stats = limiter.getStats();
+      expect(stats.queueLength).toBe(0);
+      expect(stats.activeRequests).toBe(0);
+    });
+  });
+
+  describe('getStats', () => {
+    it('should return current queue statistics', () => {
+      const limiter = new RateLimiter({ maxConcurrent: 2, minDelay: 10 });
+      const stats = limiter.getStats();
+      expect(stats).toHaveProperty('queueLength');
+      expect(stats).toHaveProperty('activeRequests');
+      expect(stats).toHaveProperty('isProcessing');
+    });
+
+    it('should show correct initial state', () => {
+      const limiter = new RateLimiter();
+      const stats = limiter.getStats();
+      expect(stats.queueLength).toBe(0);
+      expect(stats.activeRequests).toBe(0);
+      expect(stats.isProcessing).toBe(false);
+    });
+  });
+
+  describe('enqueue', () => {
+    it('should accept a function and return a promise', () => {
+      const limiter = new RateLimiter({ maxConcurrent: 10, minDelay: 0 });
+      const result = limiter.enqueue(() => Promise.resolve('test'));
+      expect(result).toBeInstanceOf(Promise);
+    });
+
+    it('should track queued items in stats', () => {
+      const limiter = new RateLimiter({ maxConcurrent: 1, minDelay: 1000 });
+
+      // Queue several slow tasks (they won't complete immediately)
+      limiter.enqueue(() => new Promise(() => {})).catch(() => {});
+      limiter.enqueue(() => new Promise(() => {})).catch(() => {});
+      limiter.enqueue(() => new Promise(() => {})).catch(() => {});
+
+      const stats = limiter.getStats();
+      // At least some should be queued or processing
+      expect(stats.queueLength + stats.activeRequests).toBeGreaterThan(0);
+    });
+  });
+
+  describe('clear', () => {
+    it('should empty the queue', () => {
+      const limiter = new RateLimiter({ maxConcurrent: 1, minDelay: 1000 });
+
+      // Queue several tasks
+      limiter.enqueue(() => new Promise(() => {})).catch(() => {});
+      limiter.enqueue(() => new Promise(() => {})).catch(() => {});
+      limiter.enqueue(() => new Promise(() => {})).catch(() => {});
+
+      // Clear the queue
+      limiter.clear();
+
+      const stats = limiter.getStats();
+      expect(stats.queueLength).toBe(0);
+    });
+  });
+});
+
+describe('graphqlRateLimiter', () => {
+  it('should be exported and defined', () => {
+    expect(graphqlRateLimiter).toBeDefined();
+  });
+
+  it('should have stats method available', () => {
+    const stats = graphqlRateLimiter.getStats();
+    expect(stats).toBeDefined();
+    expect(stats).toHaveProperty('queueLength');
+    expect(stats).toHaveProperty('activeRequests');
+    expect(stats).toHaveProperty('isProcessing');
+  });
+
+  it('should have enqueue method available', () => {
+    expect(typeof graphqlRateLimiter.enqueue).toBe('function');
+  });
+
+  it('should have clear method available', () => {
+    expect(typeof graphqlRateLimiter.clear).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary
- Replace `Promise.all` with rate-limited queue (max 10 concurrent) for GraphQL requests
- Add `graphqlRateLimiter` and `executeWithRateLimit()` helper for batch operations
- Failed requests return `null` instead of blocking successful ones
- Process repositories sequentially while throttling issues internally

## Changes
| File | Change |
|------|--------|
| `src/lib/rate-limiter.ts` | Added `graphqlRateLimiter` (10 concurrent) and `executeWithRateLimit()` |
| `src/hooks/useWorkspaceIssues.ts` | Refactored to use rate-limited queue |
| `src/lib/__tests__/rate-limiter.test.ts` | Added synchronous unit tests |

## Test plan
- [x] Build passes with no type errors
- [x] Unit tests pass (11 tests)
- [ ] Test with workspace containing 500+ open issues
- [ ] Verify no rate limiting errors in console
- [ ] Test rapid navigation between tabs

Fixes #1260

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented rate-limited concurrent fetching for linked pull requests to prevent API saturation during synchronization.
  * Enhanced repository synchronization with sequential processing and per-repository error handling to prevent cascading failures.
  * Optimized data persistence through batched database updates.

* **Tests**
  * Added comprehensive test suite for rate-limiting functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->