### PR TITLE
fix: add skeleton loaders to Issues tab to prevent CLS

### DIFF
--- a/src/components/features/activity/active-triager-card.tsx
+++ b/src/components/features/activity/active-triager-card.tsx
@@ -16,7 +16,18 @@ export function ActiveTriagerCard({ triager, loading }: ActiveTriagerCardProps) 
   if (loading) {
     return (
       <Card className="p-3 min-w-0">
-        <Skeleton className="h-16 w-full" />
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-4 w-4 rounded" />
+          <Skeleton className="h-3 w-16" />
+        </div>
+        <div className="flex items-center gap-2 mt-2">
+          <Skeleton className="h-6 w-6 rounded-full" />
+          <Skeleton className="h-4 w-24" />
+        </div>
+        <div className="flex items-center gap-1 mt-1">
+          <Skeleton className="h-3 w-3" />
+          <Skeleton className="h-3 w-16" />
+        </div>
       </Card>
     );
   }

--- a/src/components/features/activity/first-responders-card.tsx
+++ b/src/components/features/activity/first-responders-card.tsx
@@ -17,7 +17,18 @@ export function FirstRespondersCard({ responders, loading }: FirstRespondersCard
   if (loading) {
     return (
       <Card className="p-3 min-w-0">
-        <Skeleton className="h-16 w-full" />
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-4 w-4 rounded" />
+          <Skeleton className="h-3 w-24" />
+        </div>
+        <div className="flex items-center gap-2 mt-2">
+          <Skeleton className="h-6 w-6 rounded-full" />
+          <Skeleton className="h-4 w-24" />
+        </div>
+        <div className="flex items-center gap-1 mt-1">
+          <Skeleton className="h-3 w-3" />
+          <Skeleton className="h-3 w-20" />
+        </div>
       </Card>
     );
   }

--- a/src/components/features/activity/issue-half-life-card.tsx
+++ b/src/components/features/activity/issue-half-life-card.tsx
@@ -13,7 +13,15 @@ export function IssueHalfLifeCard({ halfLife, trend = 'stable', loading }: Issue
   if (loading) {
     return (
       <Card className="p-3 min-w-0">
-        <Skeleton className="h-16 w-full" />
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-4 w-4 rounded" />
+          <Skeleton className="h-3 w-20" />
+        </div>
+        <Skeleton className="h-8 w-12 mt-2" />
+        <div className="flex items-center gap-1 mt-1">
+          <Skeleton className="h-3 w-3" />
+          <Skeleton className="h-3 w-14" />
+        </div>
       </Card>
     );
   }

--- a/src/components/features/activity/issue-volume-calendar-card.tsx
+++ b/src/components/features/activity/issue-volume-calendar-card.tsx
@@ -20,7 +20,38 @@ export function IssueVolumeCalendarCard({ volumeData, loading }: IssueVolumeCale
   if (loading) {
     return (
       <Card className="p-3 min-w-0">
-        <Skeleton className="h-24 w-full" />
+        {/* Header */}
+        <div className="flex items-center gap-2 mb-3">
+          <Skeleton className="h-4 w-4 rounded" />
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-3 w-3" />
+        </div>
+        {/* Calendar grid - 2 rows of 7 days */}
+        <div className="space-y-1 mb-3">
+          <div className="flex gap-1">
+            {[...Array(7)].map((_, i) => (
+              <Skeleton key={i} className="w-4 h-4 rounded-sm" />
+            ))}
+          </div>
+          <div className="flex gap-1">
+            {[...Array(7)].map((_, i) => (
+              <Skeleton key={i + 7} className="w-4 h-4 rounded-sm" />
+            ))}
+          </div>
+        </div>
+        {/* Day labels */}
+        <div className="flex gap-1 mb-3">
+          {[...Array(7)].map((_, i) => (
+            <Skeleton key={i} className="w-4 h-3" />
+          ))}
+        </div>
+        {/* Stats */}
+        <div className="space-y-1">
+          <div className="flex items-center justify-between">
+            <Skeleton className="h-3 w-16" />
+            <Skeleton className="h-3 w-16" />
+          </div>
+        </div>
       </Card>
     );
   }

--- a/src/components/features/activity/repeat-reporters-card.tsx
+++ b/src/components/features/activity/repeat-reporters-card.tsx
@@ -17,7 +17,18 @@ export function RepeatReportersCard({ reporters, loading }: RepeatReportersCardP
   if (loading) {
     return (
       <Card className="p-3 min-w-0">
-        <Skeleton className="h-16 w-full" />
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-4 w-4 rounded" />
+          <Skeleton className="h-3 w-24" />
+        </div>
+        <div className="flex items-center gap-2 mt-2">
+          <Skeleton className="h-6 w-6 rounded-full" />
+          <Skeleton className="h-4 w-24" />
+        </div>
+        <div className="flex items-center gap-1 mt-1">
+          <Skeleton className="h-3 w-3" />
+          <Skeleton className="h-3 w-16" />
+        </div>
       </Card>
     );
   }

--- a/src/components/features/activity/stale-issues-card.tsx
+++ b/src/components/features/activity/stale-issues-card.tsx
@@ -12,7 +12,12 @@ export function StaleIssuesCard({ staleCount, totalCount, loading }: StaleIssues
   if (loading) {
     return (
       <Card className="p-3 min-w-0">
-        <Skeleton className="h-16 w-full" />
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-4 w-4 rounded" />
+          <Skeleton className="h-3 w-16" />
+        </div>
+        <Skeleton className="h-8 w-10 mt-2" />
+        <Skeleton className="h-3 w-20 mt-1" />
       </Card>
     );
   }

--- a/src/components/features/workspace/WorkspaceIssuesTable.tsx
+++ b/src/components/features/workspace/WorkspaceIssuesTable.tsx
@@ -685,13 +685,65 @@ export function WorkspaceIssuesTable({
     return (
       <Card className={cn('w-full', className)}>
         <CardHeader>
-          <CardTitle>Issues</CardTitle>
+          <div className="flex flex-col gap-4">
+            <div className="flex items-center justify-between">
+              <Skeleton className="h-6 w-16 hidden sm:block" />
+              <div className="flex items-center gap-2 w-full sm:w-auto">
+                <Skeleton className="h-10 w-full sm:w-[300px]" />
+              </div>
+            </div>
+            {/* Filter skeleton */}
+            <div className="flex flex-wrap gap-2">
+              <Skeleton className="h-8 w-20" />
+              <Skeleton className="h-8 w-20" />
+              <Skeleton className="h-8 w-24" />
+              <Skeleton className="h-8 w-28" />
+            </div>
+          </div>
         </CardHeader>
         <CardContent>
-          <div className="space-y-3">
-            {[...Array(5)].map((_, i) => (
-              <Skeleton key={i} className="h-16 w-full" />
-            ))}
+          <div className="rounded-md border">
+            <div className="overflow-x-auto">
+              {/* Table header skeleton */}
+              <div className="flex gap-4 px-4 py-3 border-b bg-muted/30">
+                <Skeleton className="h-4 w-16" />
+                <Skeleton className="h-4 w-16" />
+                <Skeleton className="h-4 w-48" />
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-4 w-12" />
+                <Skeleton className="h-4 w-20" />
+                <Skeleton className="h-4 w-16" />
+                <Skeleton className="h-4 w-8" />
+                <Skeleton className="h-4 w-16" />
+                <Skeleton className="h-4 w-16" />
+              </div>
+              {/* Table rows skeleton */}
+              {[...Array(10)].map((_, i) => (
+                <div key={i} className="flex items-center gap-4 px-4 py-4 border-b last:border-0">
+                  <Skeleton className="h-4 w-4 rounded-full" />
+                  <Skeleton className="h-4 w-12" />
+                  <div className="flex-1 space-y-1">
+                    <Skeleton className="h-4 w-3/4" />
+                    <Skeleton className="h-5 w-16 rounded-full" />
+                  </div>
+                  <Skeleton className="h-5 w-5 rounded" />
+                  <Skeleton className="h-6 w-6 rounded-full" />
+                  <Skeleton className="h-6 w-6 rounded-full" />
+                  <Skeleton className="h-4 w-12" />
+                  <Skeleton className="h-4 w-8" />
+                  <Skeleton className="h-4 w-16" />
+                  <Skeleton className="h-4 w-16" />
+                </div>
+              ))}
+            </div>
+          </div>
+          {/* Pagination skeleton */}
+          <div className="flex items-center justify-between mt-4">
+            <Skeleton className="h-4 w-48" />
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-9 w-24" />
+              <Skeleton className="h-9 w-20" />
+            </div>
           </div>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- Adds structured skeleton loaders to all metric cards in the Issues tab
- Implements comprehensive table skeleton matching actual WorkspaceIssuesTable layout
- Adds IssuesMetricsSkeleton component for initial metrics/chart section load
- Implements stable layout tracking using useRef to prevent CLS during data refreshes

## Changes
- **Metric cards**: Updated 6 card components with skeletons matching actual content structure (avatars, badges, calendar grids)
- **Issues table**: Added skeleton with header, search input, filter buttons, 10 placeholder rows, and pagination
- **WorkspaceIssuesTab**: Added top-level skeleton and stable layout state to maintain two-column grid during refreshes

## Test Plan
- [ ] Navigate to Issues tab and verify skeleton displays during initial load
- [ ] Confirm layout doesn't shift when data populates
- [ ] Verify CLS remains under 0.1 threshold
- [ ] Test page refresh maintains stable layout

Closes #1262

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Improvements**
  * Enhanced loading states across activity dashboard cards with detailed skeleton placeholders that better represent final content.
  * Improved Issues table loading UI with structured skeleton layouts for headers, rows, and pagination.
  * Implemented layout stability improvements in Workspace Issues view to reduce visual shifts during data loading.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->