### PR TITLE
perf: fix markdown bundle lazy loading

### DIFF
--- a/src/components/common/layout/index.ts
+++ b/src/components/common/layout/index.ts
@@ -3,4 +3,5 @@ export { default as Home } from './home';
 export { default as NotFound } from './not-found';
 export { MetaTagsProvider, SocialMetaTags } from './meta-tags-provider';
 export { SchemaMarkup } from './schema-markup';
-export { Markdown } from './markdown';
+// NOTE: Markdown is NOT exported here to prevent eager loading of react-markdown bundle (143KB)
+// Import directly from '@/components/common/layout/markdown' when needed

--- a/src/components/features/repository/repository-summary-card.tsx
+++ b/src/components/features/repository/repository-summary-card.tsx
@@ -3,12 +3,13 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { useRepositorySummary } from '@/hooks/use-repository-summary';
-import { Markdown } from '@/components/common/layout';
+import { Markdown } from '@/components/common/layout/markdown';
+import { PullRequest } from '@/lib/types';
 
 interface RepositorySummaryCardProps {
   owner: string;
   repo: string;
-  pullRequests?: any[];
+  pullRequests?: PullRequest[];
   className?: string;
 }
 

--- a/src/components/insights/sections/repository-summary.tsx
+++ b/src/components/insights/sections/repository-summary.tsx
@@ -3,7 +3,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { useRepositorySummary } from '@/hooks/use-repository-summary';
 import { useCachedRepoData } from '@/hooks/use-cached-repo-data';
-import { Markdown } from '@/components/common/layout';
+import { Markdown } from '@/components/common/layout/markdown';
 import { ErrorBoundary } from '@/components/error-boundary';
 import { logError } from '@/lib/error-logging';
 // Removed Sentry import - using simple logging instead

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -179,19 +179,10 @@ export default defineConfig(() => ({
             ) {
               return 'vendor-utils';
             }
-            // Markdown - now lazy loaded, keep in separate chunk
-            if (
-              id.includes('react-markdown') ||
-              id.includes('markdown') ||
-              id.includes('remark') ||
-              id.includes('rehype') ||
-              id.includes('mdast') ||
-              id.includes('unist') ||
-              id.includes('micromark') ||
-              id.includes('hast')
-            ) {
-              return 'vendor-markdown';
-            }
+            // NOTE: Markdown libraries (react-markdown, remark, rehype, etc.) are NOT manually chunked here.
+            // They are lazy loaded via React.lazy() in markdown.tsx, which creates natural code splitting.
+            // Manual chunking caused shared utilities to be bundled into vendor-markdown, creating
+            // dependencies from other chunks and forcing eager loading.
             // Analytics - lazy loaded
             if (id.includes('posthog-js')) {
               return 'vendor-analytics';


### PR DESCRIPTION
## Summary
- Remove Markdown from barrel export to prevent eager loading
- Update imports to use direct path `@/components/common/layout/markdown`
- Remove manual markdown chunking from Vite config that caused shared utilities to be bundled into vendor-markdown, creating static dependencies from other chunks

## Root Cause
The Vite manual chunking config (`id.includes('markdown')`) was too broad and captured shared utility functions that other chunks (recharts, etc.) also needed, forcing static imports from vendor-markdown.

## Impact
**Before:** 143KB `vendor-markdown` loaded on every page
**After:** 3.7KB wrapper loaded; 136KB library deferred until markdown is actually rendered

## Test plan
- [x] Build succeeds with `npm run build`
- [x] Network tab shows markdown library only loads on pages with markdown content
- [x] Homepage no longer loads the 136KB markdown parsing library

Fixes #1279

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal component module exports and import paths for improved code organization.
  * Enhanced type safety through stricter prop type definitions.

* **Chores**
  * Updated build configuration to optimize component loading through improved code-splitting strategies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->