### PR TITLE
refactor: migrate forwardRef to React 19 ref-as-prop pattern

### DIFF
--- a/src/components/features/analytics/ChartErrorBoundary.tsx
+++ b/src/components/features/analytics/ChartErrorBoundary.tsx
@@ -112,15 +112,20 @@ export class ChartErrorBoundary extends Component<
 }
 
 /**
- * Hook to wrap any component with error boundary
+ * HOC to wrap any component with error boundary
+ * Note: With React 19 ref-as-prop, refs pass through automatically
  */
 export function withChartErrorBoundary<P extends object>(
   Component: React.ComponentType<P>,
   boundaryProps?: Omit<ChartErrorBoundaryProps, 'children'>
 ) {
-  return React.forwardRef<unknown, P>((props, ref) => (
-    <ChartErrorBoundary {...boundaryProps}>
-      <Component {...(props as P)} ref={ref} />
-    </ChartErrorBoundary>
-  ));
+  function WrappedComponent(props: P) {
+    return (
+      <ChartErrorBoundary {...boundaryProps}>
+        <Component {...props} />
+      </ChartErrorBoundary>
+    );
+  }
+  WrappedComponent.displayName = `WithChartErrorBoundary(${Component.displayName || Component.name || 'Component'})`;
+  return WrappedComponent;
 }

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { ComponentPropsWithoutRef, ElementRef, HTMLAttributes, Ref } from 'react';
 import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
 
 import { cn } from '@/lib/utils';
@@ -10,95 +10,115 @@ const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
 
 const AlertDialogPortal = AlertDialogPrimitive.Portal;
 
-const AlertDialogOverlay = React.forwardRef<
-  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Overlay
-    className={cn(
-      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-      className
-    )}
-    {...props}
-    ref={ref}
-  />
-));
-AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
+export interface AlertDialogOverlayProps
+  extends ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay> {
+  ref?: Ref<ElementRef<typeof AlertDialogPrimitive.Overlay>>;
+}
 
-const AlertDialogContent = React.forwardRef<
-  React.ElementRef<typeof AlertDialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
->(({ className, ...props }, ref) => (
-  <AlertDialogPortal>
-    <AlertDialogOverlay />
-    <AlertDialogPrimitive.Content
-      ref={ref}
+function AlertDialogOverlay({ className, ref, ...props }: AlertDialogOverlayProps) {
+  return (
+    <AlertDialogPrimitive.Overlay
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
         className
       )}
       {...props}
+      ref={ref}
     />
-  </AlertDialogPortal>
-));
-AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
+  );
+}
 
-const AlertDialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn('flex flex-col space-y-2 text-center sm:text-left', className)} {...props} />
-);
-AlertDialogHeader.displayName = 'AlertDialogHeader';
+export interface AlertDialogContentProps
+  extends ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content> {
+  ref?: Ref<ElementRef<typeof AlertDialogPrimitive.Content>>;
+}
 
-const AlertDialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
-    {...props}
-  />
-);
-AlertDialogFooter.displayName = 'AlertDialogFooter';
+function AlertDialogContent({ className, ref, ...props }: AlertDialogContentProps) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  );
+}
 
-const AlertDialogTitle = React.forwardRef<
-  React.ElementRef<typeof AlertDialogPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
->(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Title
-    ref={ref}
-    className={cn('text-lg font-semibold', className)}
-    {...props}
-  />
-));
-AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
+function AlertDialogHeader({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={cn('flex flex-col space-y-2 text-center sm:text-left', className)} {...props} />
+  );
+}
 
-const AlertDialogDescription = React.forwardRef<
-  React.ElementRef<typeof AlertDialogPrimitive.Description>,
-  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
->(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Description
-    ref={ref}
-    className={cn('text-sm text-muted-foreground', className)}
-    {...props}
-  />
-));
-AlertDialogDescription.displayName = AlertDialogPrimitive.Description.displayName;
+function AlertDialogFooter({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
+      {...props}
+    />
+  );
+}
 
-const AlertDialogAction = React.forwardRef<
-  React.ElementRef<typeof AlertDialogPrimitive.Action>,
-  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
->(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Action ref={ref} className={cn(buttonVariants(), className)} {...props} />
-));
-AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
+export interface AlertDialogTitleProps
+  extends ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title> {
+  ref?: Ref<ElementRef<typeof AlertDialogPrimitive.Title>>;
+}
 
-const AlertDialogCancel = React.forwardRef<
-  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
-  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
->(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Cancel
-    ref={ref}
-    className={cn(buttonVariants({ variant: 'outline' }), 'mt-2 sm:mt-0', className)}
-    {...props}
-  />
-));
-AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
+function AlertDialogTitle({ className, ref, ...props }: AlertDialogTitleProps) {
+  return (
+    <AlertDialogPrimitive.Title
+      ref={ref}
+      className={cn('text-lg font-semibold', className)}
+      {...props}
+    />
+  );
+}
+
+export interface AlertDialogDescriptionProps
+  extends ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description> {
+  ref?: Ref<ElementRef<typeof AlertDialogPrimitive.Description>>;
+}
+
+function AlertDialogDescription({ className, ref, ...props }: AlertDialogDescriptionProps) {
+  return (
+    <AlertDialogPrimitive.Description
+      ref={ref}
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+export interface AlertDialogActionProps
+  extends ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action> {
+  ref?: Ref<ElementRef<typeof AlertDialogPrimitive.Action>>;
+}
+
+function AlertDialogAction({ className, ref, ...props }: AlertDialogActionProps) {
+  return (
+    <AlertDialogPrimitive.Action ref={ref} className={cn(buttonVariants(), className)} {...props} />
+  );
+}
+
+export interface AlertDialogCancelProps
+  extends ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel> {
+  ref?: Ref<ElementRef<typeof AlertDialogPrimitive.Cancel>>;
+}
+
+function AlertDialogCancel({ className, ref, ...props }: AlertDialogCancelProps) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      ref={ref}
+      className={cn(buttonVariants({ variant: 'outline' }), 'mt-2 sm:mt-0', className)}
+      {...props}
+    />
+  );
+}
 
 export {
   AlertDialog,

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { HTMLAttributes, Ref } from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '@/lib/utils';
@@ -19,31 +19,38 @@ const alertVariants = cva(
   }
 );
 
-const Alert = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
->(({ className, variant, ...props }, ref) => (
-  <div ref={ref} role="alert" className={cn(alertVariants({ variant }), className)} {...props} />
-));
-Alert.displayName = 'Alert';
+export interface AlertProps
+  extends HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof alertVariants> {
+  ref?: Ref<HTMLDivElement>;
+}
 
-const AlertTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
-  ({ className, ...props }, ref) => (
+function Alert({ className, variant, ref, ...props }: AlertProps) {
+  return (
+    <div ref={ref} role="alert" className={cn(alertVariants({ variant }), className)} {...props} />
+  );
+}
+
+export interface AlertTitleProps extends HTMLAttributes<HTMLHeadingElement> {
+  ref?: Ref<HTMLParagraphElement>;
+}
+
+function AlertTitle({ className, ref, ...props }: AlertTitleProps) {
+  return (
     <h5
       ref={ref}
       className={cn('mb-1 font-medium leading-none tracking-tight', className)}
       {...props}
     />
-  )
-);
-AlertTitle.displayName = 'AlertTitle';
+  );
+}
 
-const AlertDescription = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLParagraphElement>
->(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn('text-sm [&_p]:leading-relaxed', className)} {...props} />
-));
-AlertDescription.displayName = 'AlertDescription';
+export interface AlertDescriptionProps extends HTMLAttributes<HTMLParagraphElement> {
+  ref?: Ref<HTMLParagraphElement>;
+}
+
+function AlertDescription({ className, ref, ...props }: AlertDescriptionProps) {
+  return <div ref={ref} className={cn('text-sm [&_p]:leading-relaxed', className)} {...props} />;
+}
 
 export { Alert, AlertTitle, AlertDescription };

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,52 +1,65 @@
-import { forwardRef, type ComponentPropsWithoutRef, type ElementRef } from 'react';
+import type { ComponentPropsWithoutRef, ElementRef, Ref } from 'react';
 import * as AvatarPrimitive from '@radix-ui/react-avatar';
 
 import { cn } from '@/lib/utils';
 
-const Avatar = forwardRef<
-  ElementRef<typeof AvatarPrimitive.Root>,
-  ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <AvatarPrimitive.Root
-    ref={ref}
-    className={cn('relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full', className)}
-    {...props}
-  />
-));
-Avatar.displayName = AvatarPrimitive.Root.displayName;
+export interface AvatarProps extends ComponentPropsWithoutRef<typeof AvatarPrimitive.Root> {
+  ref?: Ref<ElementRef<typeof AvatarPrimitive.Root>>;
+}
 
-const AvatarImage = forwardRef<
-  ElementRef<typeof AvatarPrimitive.Image>,
-  ComponentPropsWithoutRef<typeof AvatarPrimitive.Image> & {
-    loading?: 'lazy' | 'eager';
-    width?: number;
-    height?: number;
-  }
->(({ className, loading = 'lazy', width, height, ...props }, ref) => (
-  <AvatarPrimitive.Image
-    ref={ref}
-    className={cn('aspect-square h-full w-full', className)}
-    loading={loading}
-    width={width}
-    height={height}
-    {...props}
-  />
-));
-AvatarImage.displayName = AvatarPrimitive.Image.displayName;
+function Avatar({ className, ref, ...props }: AvatarProps) {
+  return (
+    <AvatarPrimitive.Root
+      ref={ref}
+      className={cn('relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full', className)}
+      {...props}
+    />
+  );
+}
 
-const AvatarFallback = forwardRef<
-  ElementRef<typeof AvatarPrimitive.Fallback>,
-  ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
->(({ className, ...props }, ref) => (
-  <AvatarPrimitive.Fallback
-    ref={ref}
-    className={cn(
-      'flex h-full w-full items-center justify-center rounded-full bg-muted',
-      className
-    )}
-    {...props}
-  />
-));
-AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName;
+export interface AvatarImageProps extends ComponentPropsWithoutRef<typeof AvatarPrimitive.Image> {
+  loading?: 'lazy' | 'eager';
+  width?: number;
+  height?: number;
+  ref?: Ref<ElementRef<typeof AvatarPrimitive.Image>>;
+}
+
+function AvatarImage({
+  className,
+  loading = 'lazy',
+  width,
+  height,
+  ref,
+  ...props
+}: AvatarImageProps) {
+  return (
+    <AvatarPrimitive.Image
+      ref={ref}
+      className={cn('aspect-square h-full w-full', className)}
+      loading={loading}
+      width={width}
+      height={height}
+      {...props}
+    />
+  );
+}
+
+export interface AvatarFallbackProps
+  extends ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback> {
+  ref?: Ref<ElementRef<typeof AvatarPrimitive.Fallback>>;
+}
+
+function AvatarFallback({ className, ref, ...props }: AvatarFallbackProps) {
+  return (
+    <AvatarPrimitive.Fallback
+      ref={ref}
+      className={cn(
+        'flex h-full w-full items-center justify-center rounded-full bg-muted',
+        className
+      )}
+      {...props}
+    />
+  );
+}
 
 export { Avatar, AvatarImage, AvatarFallback };

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { HTMLAttributes, Ref } from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '@/lib/utils';
@@ -23,15 +23,14 @@ const badgeVariants = cva(
 );
 
 export interface BadgeProps
-  extends React.HTMLAttributes<HTMLDivElement>,
-    VariantProps<typeof badgeVariants> {}
+  extends HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {
+  ref?: Ref<HTMLDivElement>;
+}
 
-const Badge = React.forwardRef<HTMLDivElement, BadgeProps>(
-  ({ className, variant, ...props }, ref) => {
-    return <div ref={ref} className={cn(badgeVariants({ variant }), className)} {...props} />;
-  }
-);
-Badge.displayName = 'Badge';
+function Badge({ className, variant, ref, ...props }: BadgeProps) {
+  return <div ref={ref} className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
 
 // eslint-disable-next-line react-refresh/only-export-components
 export { Badge, badgeVariants };

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -1,19 +1,31 @@
-import * as React from 'react';
+import type {
+  AnchorHTMLAttributes,
+  ComponentProps,
+  ComponentPropsWithoutRef,
+  LiHTMLAttributes,
+  ReactNode,
+  Ref,
+} from 'react';
 import { ChevronRight, MoreHorizontal } from '@/components/ui/icon';
 import { Slot } from '@radix-ui/react-slot';
 
 import { cn } from '@/lib/utils';
 
-const Breadcrumb = React.forwardRef<
-  HTMLElement,
-  React.ComponentPropsWithoutRef<'nav'> & {
-    separator?: React.ReactNode;
-  }
->(({ ...props }, ref) => <nav ref={ref} aria-label="breadcrumb" {...props} />);
-Breadcrumb.displayName = 'Breadcrumb';
+export interface BreadcrumbProps extends ComponentPropsWithoutRef<'nav'> {
+  ref?: Ref<HTMLElement>;
+  separator?: ReactNode;
+}
 
-const BreadcrumbList = React.forwardRef<HTMLOListElement, React.ComponentPropsWithoutRef<'ol'>>(
-  ({ className, ...props }, ref) => (
+function Breadcrumb({ ref, ...props }: BreadcrumbProps) {
+  return <nav ref={ref} aria-label="breadcrumb" {...props} />;
+}
+
+export interface BreadcrumbListProps extends ComponentPropsWithoutRef<'ol'> {
+  ref?: Ref<HTMLOListElement>;
+}
+
+function BreadcrumbList({ className, ref, ...props }: BreadcrumbListProps) {
+  return (
     <ol
       ref={ref}
       className={cn(
@@ -22,23 +34,23 @@ const BreadcrumbList = React.forwardRef<HTMLOListElement, React.ComponentPropsWi
       )}
       {...props}
     />
-  )
-);
-BreadcrumbList.displayName = 'BreadcrumbList';
+  );
+}
 
-const BreadcrumbItem = React.forwardRef<HTMLLIElement, React.ComponentPropsWithoutRef<'li'>>(
-  ({ className, ...props }, ref) => (
-    <li ref={ref} className={cn('inline-flex items-center gap-1', className)} {...props} />
-  )
-);
-BreadcrumbItem.displayName = 'BreadcrumbItem';
+export interface BreadcrumbItemProps extends LiHTMLAttributes<HTMLLIElement> {
+  ref?: Ref<HTMLLIElement>;
+}
 
-const BreadcrumbLink = React.forwardRef<
-  HTMLAnchorElement,
-  React.ComponentPropsWithoutRef<'a'> & {
-    asChild?: boolean;
-  }
->(({ asChild, className, ...props }, ref) => {
+function BreadcrumbItem({ className, ref, ...props }: BreadcrumbItemProps) {
+  return <li ref={ref} className={cn('inline-flex items-center gap-1', className)} {...props} />;
+}
+
+export interface BreadcrumbLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  ref?: Ref<HTMLAnchorElement>;
+  asChild?: boolean;
+}
+
+function BreadcrumbLink({ asChild, className, ref, ...props }: BreadcrumbLinkProps) {
   const Comp = asChild ? Slot : 'a';
 
   return (
@@ -48,11 +60,14 @@ const BreadcrumbLink = React.forwardRef<
       {...props}
     />
   );
-});
-BreadcrumbLink.displayName = 'BreadcrumbLink';
+}
 
-const BreadcrumbPage = React.forwardRef<HTMLSpanElement, React.ComponentPropsWithoutRef<'span'>>(
-  ({ className, ...props }, ref) => (
+export interface BreadcrumbPageProps extends ComponentPropsWithoutRef<'span'> {
+  ref?: Ref<HTMLSpanElement>;
+}
+
+function BreadcrumbPage({ className, ref, ...props }: BreadcrumbPageProps) {
+  return (
     <span
       ref={ref}
       role="link"
@@ -61,34 +76,35 @@ const BreadcrumbPage = React.forwardRef<HTMLSpanElement, React.ComponentPropsWit
       className={cn('font-normal text-muted-foreground', className)}
       {...props}
     />
-  )
-);
-BreadcrumbPage.displayName = 'BreadcrumbPage';
+  );
+}
 
-const BreadcrumbSeparator = ({ children, className, ...props }: React.ComponentProps<'li'>) => (
-  <li
-    role="presentation"
-    aria-hidden="true"
-    className={cn('[&>svg]:size-3 opacity-50', className)}
-    {...props}
-  >
-    {children ?? <ChevronRight />}
-  </li>
-);
-BreadcrumbSeparator.displayName = 'BreadcrumbSeparator';
+function BreadcrumbSeparator({ children, className, ...props }: ComponentProps<'li'>) {
+  return (
+    <li
+      role="presentation"
+      aria-hidden="true"
+      className={cn('[&>svg]:size-3 opacity-50', className)}
+      {...props}
+    >
+      {children ?? <ChevronRight />}
+    </li>
+  );
+}
 
-const BreadcrumbEllipsis = ({ className, ...props }: React.ComponentProps<'span'>) => (
-  <span
-    role="presentation"
-    aria-hidden="true"
-    className={cn('flex h-9 w-9 items-center justify-center', className)}
-    {...props}
-  >
-    <MoreHorizontal className="h-4 w-4" />
-    <span className="sr-only">More</span>
-  </span>
-);
-BreadcrumbEllipsis.displayName = 'BreadcrumbElipssis';
+function BreadcrumbEllipsis({ className, ...props }: ComponentProps<'span'>) {
+  return (
+    <span
+      role="presentation"
+      aria-hidden="true"
+      className={cn('flex h-9 w-9 items-center justify-center', className)}
+      {...props}
+    >
+      <MoreHorizontal className="h-4 w-4" />
+      <span className="sr-only">More</span>
+    </span>
+  );
+}
 
 export {
   Breadcrumb,

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, type ButtonHTMLAttributes } from 'react';
+import type { ButtonHTMLAttributes, Ref } from 'react';
 import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
 
@@ -35,16 +35,13 @@ export interface ButtonProps
   extends ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
+  ref?: Ref<HTMLButtonElement>;
 }
 
-const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : 'button';
-    return (
-      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
-    );
-  }
-);
-Button.displayName = 'Button';
+function Button({ className, variant, size, asChild = false, ref, ...props }: ButtonProps) {
+  const Comp = asChild ? Slot : 'button';
+  return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />;
+}
 
+// eslint-disable-next-line react-refresh/only-export-components -- buttonVariants is intentionally co-located
 export { Button, buttonVariants };

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,56 +1,65 @@
-import * as React from 'react';
+import type { HTMLAttributes, Ref } from 'react';
 
 import { cn } from '@/lib/utils';
 
-const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
+export interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  ref?: Ref<HTMLDivElement>;
+}
+
+function Card({ className, ref, ...props }: CardProps) {
+  return (
     <div
       ref={ref}
       className={cn('rounded-xl border bg-card text-card-foreground shadow', className)}
       {...props}
     />
-  )
-);
-Card.displayName = 'Card';
+  );
+}
 
-const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
-  )
-);
-CardHeader.displayName = 'CardHeader';
+export interface CardHeaderProps extends HTMLAttributes<HTMLDivElement> {
+  ref?: Ref<HTMLDivElement>;
+}
 
-const CardTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
-  ({ className, ...props }, ref) => (
+function CardHeader({ className, ref, ...props }: CardHeaderProps) {
+  return <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />;
+}
+
+export interface CardTitleProps extends HTMLAttributes<HTMLHeadingElement> {
+  ref?: Ref<HTMLHeadingElement>;
+}
+
+function CardTitle({ className, ref, ...props }: CardTitleProps) {
+  return (
     <h3
       ref={ref}
       className={cn('font-semibold leading-none tracking-tight', className)}
       {...props}
     />
-  )
-);
-CardTitle.displayName = 'CardTitle';
+  );
+}
 
-const CardDescription = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLParagraphElement>
->(({ className, ...props }, ref) => (
-  <p ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
-));
-CardDescription.displayName = 'CardDescription';
+export interface CardDescriptionProps extends HTMLAttributes<HTMLParagraphElement> {
+  ref?: Ref<HTMLParagraphElement>;
+}
 
-const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
-  )
-);
-CardContent.displayName = 'CardContent';
+function CardDescription({ className, ref, ...props }: CardDescriptionProps) {
+  return <p ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />;
+}
 
-const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('flex items-center p-6 pt-0', className)} {...props} />
-  )
-);
-CardFooter.displayName = 'CardFooter';
+export interface CardContentProps extends HTMLAttributes<HTMLDivElement> {
+  ref?: Ref<HTMLDivElement>;
+}
+
+function CardContent({ className, ref, ...props }: CardContentProps) {
+  return <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />;
+}
+
+export interface CardFooterProps extends HTMLAttributes<HTMLDivElement> {
+  ref?: Ref<HTMLDivElement>;
+}
+
+function CardFooter({ className, ref, ...props }: CardFooterProps) {
+  return <div ref={ref} className={cn('flex items-center p-6 pt-0', className)} {...props} />;
+}
 
 export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -1,4 +1,14 @@
-import * as React from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ComponentProps,
+  type HTMLAttributes,
+  type KeyboardEvent,
+  type Ref,
+} from 'react';
 import { ArrowLeft, ArrowRight } from '@/components/ui/icon';
 import useEmblaCarousel, { type UseEmblaCarouselType } from 'embla-carousel-react';
 
@@ -27,10 +37,10 @@ type CarouselContextProps = {
   canScrollNext: boolean;
 } & CarouselProps;
 
-const CarouselContext = React.createContext<CarouselContextProps | null>(null);
+const CarouselContext = createContext<CarouselContextProps | null>(null);
 
 function useCarousel() {
-  const context = React.useContext(CarouselContext);
+  const context = useContext(CarouselContext);
 
   if (!context) {
     throw new Error('useCarousel must be used within a <Carousel />');
@@ -39,10 +49,20 @@ function useCarousel() {
   return context;
 }
 
-const Carousel = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & CarouselProps
->(({ orientation = 'horizontal', opts, setApi, plugins, className, children, ...props }, ref) => {
+export interface CarouselComponentProps extends HTMLAttributes<HTMLDivElement>, CarouselProps {
+  ref?: Ref<HTMLDivElement>;
+}
+
+function Carousel({
+  orientation = 'horizontal',
+  opts,
+  setApi,
+  plugins,
+  className,
+  children,
+  ref,
+  ...props
+}: CarouselComponentProps) {
   const [carouselRef, api] = useEmblaCarousel(
     {
       ...opts,
@@ -50,10 +70,10 @@ const Carousel = React.forwardRef<
     },
     plugins
   );
-  const [canScrollPrev, setCanScrollPrev] = React.useState(false);
-  const [canScrollNext, setCanScrollNext] = React.useState(false);
+  const [canScrollPrev, setCanScrollPrev] = useState(false);
+  const [canScrollNext, setCanScrollNext] = useState(false);
 
-  const onSelect = React.useCallback((api: CarouselApi) => {
+  const onSelect = useCallback((api: CarouselApi) => {
     if (!api) {
       return;
     }
@@ -62,16 +82,16 @@ const Carousel = React.forwardRef<
     setCanScrollNext(api.canScrollNext());
   }, []);
 
-  const scrollPrev = React.useCallback(() => {
+  const scrollPrev = useCallback(() => {
     api?.scrollPrev();
   }, [api]);
 
-  const scrollNext = React.useCallback(() => {
+  const scrollNext = useCallback(() => {
     api?.scrollNext();
   }, [api]);
 
-  const handleKeyDown = React.useCallback(
-    (event: React.KeyboardEvent<HTMLDivElement>) => {
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
       if (event.key === 'ArrowLeft') {
         event.preventDefault();
         scrollPrev();
@@ -83,7 +103,7 @@ const Carousel = React.forwardRef<
     [scrollPrev, scrollNext]
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!api || !setApi) {
       return;
     }
@@ -91,7 +111,7 @@ const Carousel = React.forwardRef<
     setApi(api);
   }, [api, setApi]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!api) {
       return;
     }
@@ -130,106 +150,117 @@ const Carousel = React.forwardRef<
       </div>
     </CarouselContext.Provider>
   );
-});
-Carousel.displayName = 'Carousel';
+}
 
-const CarouselContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => {
-    const { carouselRef, orientation } = useCarousel();
+export interface CarouselContentProps extends HTMLAttributes<HTMLDivElement> {
+  ref?: Ref<HTMLDivElement>;
+}
 
-    return (
-      <div ref={carouselRef} className="overflow-hidden">
-        <div
-          ref={ref}
-          className={cn(
-            'flex',
-            orientation === 'horizontal' ? '-ml-4' : '-mt-4 flex-col',
-            className
-          )}
-          {...props}
-        />
-      </div>
-    );
-  }
-);
-CarouselContent.displayName = 'CarouselContent';
+function CarouselContent({ className, ref, ...props }: CarouselContentProps) {
+  const { carouselRef, orientation } = useCarousel();
 
-const CarouselItem = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => {
-    const { orientation } = useCarousel();
-
-    return (
+  return (
+    <div ref={carouselRef} className="overflow-hidden">
       <div
         ref={ref}
-        role="group"
-        aria-roledescription="slide"
-        className={cn(
-          'min-w-0 shrink-0 grow-0 basis-full',
-          orientation === 'horizontal' ? 'pl-4' : 'pt-4',
-          className
-        )}
+        className={cn('flex', orientation === 'horizontal' ? '-ml-4' : '-mt-4 flex-col', className)}
         {...props}
       />
-    );
-  }
-);
-CarouselItem.displayName = 'CarouselItem';
+    </div>
+  );
+}
 
-const CarouselPrevious = React.forwardRef<HTMLButtonElement, React.ComponentProps<typeof Button>>(
-  ({ className, variant = 'outline', size = 'icon', ...props }, ref) => {
-    const { orientation, scrollPrev, canScrollPrev } = useCarousel();
+export interface CarouselItemProps extends HTMLAttributes<HTMLDivElement> {
+  ref?: Ref<HTMLDivElement>;
+}
 
-    return (
-      <Button
-        ref={ref}
-        variant={variant}
-        size={size}
-        className={cn(
-          'absolute  h-8 w-8 rounded-full',
-          orientation === 'horizontal'
-            ? '-left-12 top-1/2 -translate-y-1/2'
-            : '-top-12 left-1/2 -translate-x-1/2 rotate-90',
-          className
-        )}
-        disabled={!canScrollPrev}
-        onClick={scrollPrev}
-        {...props}
-      >
-        <ArrowLeft className="h-4 w-4" />
-        <span className="sr-only">Previous slide</span>
-      </Button>
-    );
-  }
-);
-CarouselPrevious.displayName = 'CarouselPrevious';
+function CarouselItem({ className, ref, ...props }: CarouselItemProps) {
+  const { orientation } = useCarousel();
 
-const CarouselNext = React.forwardRef<HTMLButtonElement, React.ComponentProps<typeof Button>>(
-  ({ className, variant = 'outline', size = 'icon', ...props }, ref) => {
-    const { orientation, scrollNext, canScrollNext } = useCarousel();
+  return (
+    <div
+      ref={ref}
+      role="group"
+      aria-roledescription="slide"
+      className={cn(
+        'min-w-0 shrink-0 grow-0 basis-full',
+        orientation === 'horizontal' ? 'pl-4' : 'pt-4',
+        className
+      )}
+      {...props}
+    />
+  );
+}
 
-    return (
-      <Button
-        ref={ref}
-        variant={variant}
-        size={size}
-        className={cn(
-          'absolute h-8 w-8 rounded-full',
-          orientation === 'horizontal'
-            ? '-right-12 top-1/2 -translate-y-1/2'
-            : '-bottom-12 left-1/2 -translate-x-1/2 rotate-90',
-          className
-        )}
-        disabled={!canScrollNext}
-        onClick={scrollNext}
-        {...props}
-      >
-        <ArrowRight className="h-4 w-4" />
-        <span className="sr-only">Next slide</span>
-      </Button>
-    );
-  }
-);
-CarouselNext.displayName = 'CarouselNext';
+export interface CarouselPreviousProps extends ComponentProps<typeof Button> {
+  ref?: Ref<HTMLButtonElement>;
+}
+
+function CarouselPrevious({
+  className,
+  variant = 'outline',
+  size = 'icon',
+  ref,
+  ...props
+}: CarouselPreviousProps) {
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel();
+
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={cn(
+        'absolute  h-8 w-8 rounded-full',
+        orientation === 'horizontal'
+          ? '-left-12 top-1/2 -translate-y-1/2'
+          : '-top-12 left-1/2 -translate-x-1/2 rotate-90',
+        className
+      )}
+      disabled={!canScrollPrev}
+      onClick={scrollPrev}
+      {...props}
+    >
+      <ArrowLeft className="h-4 w-4" />
+      <span className="sr-only">Previous slide</span>
+    </Button>
+  );
+}
+
+export interface CarouselNextProps extends ComponentProps<typeof Button> {
+  ref?: Ref<HTMLButtonElement>;
+}
+
+function CarouselNext({
+  className,
+  variant = 'outline',
+  size = 'icon',
+  ref,
+  ...props
+}: CarouselNextProps) {
+  const { orientation, scrollNext, canScrollNext } = useCarousel();
+
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={cn(
+        'absolute h-8 w-8 rounded-full',
+        orientation === 'horizontal'
+          ? '-right-12 top-1/2 -translate-y-1/2'
+          : '-bottom-12 left-1/2 -translate-x-1/2 rotate-90',
+        className
+      )}
+      disabled={!canScrollNext}
+      onClick={scrollNext}
+      {...props}
+    >
+      <ArrowRight className="h-4 w-4" />
+      <span className="sr-only">Next slide</span>
+    </Button>
+  );
+}
 
 export {
   type CarouselApi,

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -1,4 +1,14 @@
-import * as React from 'react';
+import {
+  createContext,
+  useContext,
+  useId,
+  useMemo,
+  type ComponentProps,
+  type ComponentType,
+  type CSSProperties,
+  type ReactNode,
+  type Ref,
+} from 'react';
 import {
   ResponsiveContainer as RechartsResponsiveContainer,
   Tooltip as RechartsTooltip,
@@ -13,8 +23,8 @@ const THEMES = { light: '', dark: '.dark' } as const;
 
 export type ChartConfig = {
   [k in string]: {
-    label?: React.ReactNode;
-    icon?: React.ComponentType;
+    label?: ReactNode;
+    icon?: ComponentType;
   } & (
     | { color?: string; theme?: never }
     | { color?: never; theme: Record<keyof typeof THEMES, string> }
@@ -25,10 +35,10 @@ type ChartContextProps = {
   config: ChartConfig;
 };
 
-const ChartContext = React.createContext<ChartContextProps | null>(null);
+const ChartContext = createContext<ChartContextProps | null>(null);
 
 function useChart() {
-  const context = React.useContext(ChartContext);
+  const context = useContext(ChartContext);
 
   if (!context) {
     throw new Error('useChart must be used within a <ChartContainer />');
@@ -37,14 +47,14 @@ function useChart() {
   return context;
 }
 
-const ChartContainer = React.forwardRef<
-  HTMLDivElement,
-  React.ComponentProps<'div'> & {
-    config: ChartConfig;
-    children: React.ComponentProps<typeof RechartsResponsiveContainer>['children'];
-  }
->(({ id, className, children, config, ...props }, ref) => {
-  const uniqueId = React.useId();
+export interface ChartContainerProps extends ComponentProps<'div'> {
+  ref?: Ref<HTMLDivElement>;
+  config: ChartConfig;
+  children: ComponentProps<typeof RechartsResponsiveContainer>['children'];
+}
+
+function ChartContainer({ id, className, children, config, ref, ...props }: ChartContainerProps) {
+  const uniqueId = useId();
   const chartId = `chart-${id || uniqueId.replace(/:/g, '')}`;
 
   return (
@@ -63,11 +73,10 @@ const ChartContainer = React.forwardRef<
       </div>
     </ChartContext.Provider>
   );
-});
-ChartContainer.displayName = 'Chart';
+}
 
 const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
-  const colorConfig = Object.entries(config).filter(([_, config]) => config.theme || config.color);
+  const colorConfig = Object.entries(config).filter(([, cfg]) => cfg.theme || cfg.color);
 
   if (!colorConfig.length) {
     return null;
@@ -97,160 +106,164 @@ ${colorConfig
 
 const ChartTooltip = RechartsTooltip;
 
-const ChartTooltipContent = React.forwardRef<
-  HTMLDivElement,
-  React.ComponentProps<typeof RechartsTooltip> &
-    React.ComponentProps<'div'> & {
-      hideLabel?: boolean;
-      hideIndicator?: boolean;
-      indicator?: 'line' | 'dot' | 'dashed';
-      nameKey?: string;
-      labelKey?: string;
-    }
->(
-  (
-    {
-      active,
-      payload,
-      className,
-      indicator = 'dot',
-      hideLabel = false,
-      hideIndicator = false,
-      label,
-      labelFormatter,
-      labelClassName,
-      formatter,
-      color,
-      nameKey,
-      labelKey,
-    },
-    ref
-  ) => {
-    const { config } = useChart();
+export interface ChartTooltipContentProps
+  extends ComponentProps<typeof RechartsTooltip>,
+    Omit<ComponentProps<'div'>, 'content'> {
+  ref?: Ref<HTMLDivElement>;
+  hideLabel?: boolean;
+  hideIndicator?: boolean;
+  indicator?: 'line' | 'dot' | 'dashed';
+  nameKey?: string;
+  labelKey?: string;
+}
 
-    const tooltipLabel = React.useMemo(() => {
-      if (hideLabel || !payload?.length) {
-        return null;
-      }
+function ChartTooltipContent({
+  active,
+  payload,
+  className,
+  indicator = 'dot',
+  hideLabel = false,
+  hideIndicator = false,
+  label,
+  labelFormatter,
+  labelClassName,
+  formatter,
+  color,
+  nameKey,
+  labelKey,
+  ref,
+}: ChartTooltipContentProps) {
+  const { config } = useChart();
 
-      const [item] = payload;
-      const key = `${labelKey || item.dataKey || item.name || 'value'}`;
-      const itemConfig = getPayloadConfigFromPayload(config, item, key);
-      const value =
-        !labelKey && typeof label === 'string'
-          ? config[label as keyof typeof config]?.label || label
-          : itemConfig?.label;
-
-      if (labelFormatter) {
-        return (
-          <div className={cn('font-medium', labelClassName)}>{labelFormatter(value, payload)}</div>
-        );
-      }
-
-      if (!value) {
-        return null;
-      }
-
-      return <div className={cn('font-medium', labelClassName)}>{value}</div>;
-    }, [label, labelFormatter, payload, hideLabel, labelClassName, config, labelKey]);
-
-    if (!active || !payload?.length) {
+  const tooltipLabel = useMemo(() => {
+    if (hideLabel || !payload?.length) {
       return null;
     }
 
-    const nestLabel = payload.length === 1 && indicator !== 'dot';
+    const [item] = payload;
+    const key = `${labelKey || item.dataKey || item.name || 'value'}`;
+    const itemConfig = getPayloadConfigFromPayload(config, item, key);
+    const value =
+      !labelKey && typeof label === 'string'
+        ? config[label as keyof typeof config]?.label || label
+        : itemConfig?.label;
 
-    return (
-      <div
-        ref={ref}
-        className={cn(
-          'grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl',
-          className
-        )}
-      >
-        {!nestLabel ? tooltipLabel : null}
-        <div className="grid gap-1.5">
-          {payload.map((item, index) => {
-            const key = `${nameKey || item.name || item.dataKey || 'value'}`;
-            const itemConfig = getPayloadConfigFromPayload(config, item, key);
-            const indicatorColor = color || item.payload.fill || item.color;
+    if (labelFormatter) {
+      return (
+        <div className={cn('font-medium', labelClassName)}>{labelFormatter(value, payload)}</div>
+      );
+    }
 
-            return (
-              <div
-                key={item.dataKey}
-                className={cn(
-                  'flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground',
-                  indicator === 'dot' && 'items-center'
-                )}
-              >
-                {formatter && item?.value !== undefined && item.name ? (
-                  formatter(item.value, item.name, item, index, item.payload)
-                ) : (
-                  <>
-                    {itemConfig?.icon ? (
-                      <itemConfig.icon />
-                    ) : (
-                      !hideIndicator && (
-                        <div
-                          className={cn(
-                            'shrink-0 rounded-[2px] border-[--color-border] bg-[--color-bg]',
-                            {
-                              'h-2.5 w-2.5': indicator === 'dot',
-                              'w-1': indicator === 'line',
-                              'w-0 border-[1.5px] border-dashed bg-transparent':
-                                indicator === 'dashed',
-                              'my-0.5': nestLabel && indicator === 'dashed',
-                            }
-                          )}
-                          style={
-                            {
-                              '--color-bg': indicatorColor,
-                              '--color-border': indicatorColor,
-                            } as React.CSSProperties
-                          }
-                        />
-                      )
-                    )}
-                    <div
-                      className={cn(
-                        'flex flex-1 justify-between leading-none',
-                        nestLabel ? 'items-end' : 'items-center'
-                      )}
-                    >
-                      <div className="grid gap-1.5">
-                        {nestLabel ? tooltipLabel : null}
-                        <span className="text-muted-foreground">
-                          {itemConfig?.label || item.name}
-                        </span>
-                      </div>
-                      {item.value && (
-                        <span className="font-mono font-medium tabular-nums text-foreground">
-                          {item.value.toLocaleString()}
-                        </span>
-                      )}
-                    </div>
-                  </>
-                )}
-              </div>
-            );
-          })}
-        </div>
-      </div>
-    );
+    if (!value) {
+      return null;
+    }
+
+    return <div className={cn('font-medium', labelClassName)}>{value}</div>;
+  }, [label, labelFormatter, payload, hideLabel, labelClassName, config, labelKey]);
+
+  if (!active || !payload?.length) {
+    return null;
   }
-);
-ChartTooltipContent.displayName = 'ChartTooltip';
+
+  const nestLabel = payload.length === 1 && indicator !== 'dot';
+
+  return (
+    <div
+      ref={ref}
+      className={cn(
+        'grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl',
+        className
+      )}
+    >
+      {!nestLabel ? tooltipLabel : null}
+      <div className="grid gap-1.5">
+        {payload.map((item, index) => {
+          const key = `${nameKey || item.name || item.dataKey || 'value'}`;
+          const itemConfig = getPayloadConfigFromPayload(config, item, key);
+          const indicatorColor = color || item.payload.fill || item.color;
+
+          return (
+            <div
+              key={item.dataKey}
+              className={cn(
+                'flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground',
+                indicator === 'dot' && 'items-center'
+              )}
+            >
+              {formatter && item?.value !== undefined && item.name ? (
+                formatter(item.value, item.name, item, index, item.payload)
+              ) : (
+                <>
+                  {itemConfig?.icon ? (
+                    <itemConfig.icon />
+                  ) : (
+                    !hideIndicator && (
+                      <div
+                        className={cn(
+                          'shrink-0 rounded-[2px] border-[--color-border] bg-[--color-bg]',
+                          {
+                            'h-2.5 w-2.5': indicator === 'dot',
+                            'w-1': indicator === 'line',
+                            'w-0 border-[1.5px] border-dashed bg-transparent':
+                              indicator === 'dashed',
+                            'my-0.5': nestLabel && indicator === 'dashed',
+                          }
+                        )}
+                        style={
+                          {
+                            '--color-bg': indicatorColor,
+                            '--color-border': indicatorColor,
+                          } as CSSProperties
+                        }
+                      />
+                    )
+                  )}
+                  <div
+                    className={cn(
+                      'flex flex-1 justify-between leading-none',
+                      nestLabel ? 'items-end' : 'items-center'
+                    )}
+                  >
+                    <div className="grid gap-1.5">
+                      {nestLabel ? tooltipLabel : null}
+                      <span className="text-muted-foreground">
+                        {itemConfig?.label || item.name}
+                      </span>
+                    </div>
+                    {item.value && (
+                      <span className="font-mono font-medium tabular-nums text-foreground">
+                        {item.value.toLocaleString()}
+                      </span>
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
 
 const ChartLegend = RechartsLegend;
 
-const ChartLegendContent = React.forwardRef<
-  HTMLDivElement,
-  React.ComponentProps<'div'> &
-    Pick<LegendProps, 'payload' | 'verticalAlign'> & {
-      hideIcon?: boolean;
-      nameKey?: string;
-    }
->(({ className, hideIcon = false, payload, verticalAlign = 'bottom', nameKey }, ref) => {
+export interface ChartLegendContentProps
+  extends ComponentProps<'div'>,
+    Pick<LegendProps, 'payload' | 'verticalAlign'> {
+  ref?: Ref<HTMLDivElement>;
+  hideIcon?: boolean;
+  nameKey?: string;
+}
+
+function ChartLegendContent({
+  className,
+  hideIcon = false,
+  payload,
+  verticalAlign = 'bottom',
+  nameKey,
+  ref,
+}: ChartLegendContentProps) {
   const { config } = useChart();
 
   if (!payload?.length) {
@@ -293,8 +306,7 @@ const ChartLegendContent = React.forwardRef<
       })}
     </div>
   );
-});
-ChartLegendContent.displayName = 'ChartLegend';
+}
 
 // Helper to extract item config from a payload.
 function getPayloadConfigFromPayload(config: ChartConfig, payload: unknown, key: string) {

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,26 +1,28 @@
-import * as React from 'react';
+import type { ComponentPropsWithoutRef, ElementRef, Ref } from 'react';
 import { Check } from '@/components/ui/icon';
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
 
 import { cn } from '@/lib/utils';
 
-const Checkbox = React.forwardRef<
-  React.ElementRef<typeof CheckboxPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <CheckboxPrimitive.Root
-    ref={ref}
-    className={cn(
-      'peer h-4 w-4 shrink-0 rounded-sm border border-input ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=checked]:border-transparent',
-      className
-    )}
-    {...props}
-  >
-    <CheckboxPrimitive.Indicator className={cn('flex items-center justify-center text-current')}>
-      <Check className="h-3.5 w-3.5" />
-    </CheckboxPrimitive.Indicator>
-  </CheckboxPrimitive.Root>
-));
-Checkbox.displayName = CheckboxPrimitive.Root.displayName;
+export interface CheckboxProps extends ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root> {
+  ref?: Ref<ElementRef<typeof CheckboxPrimitive.Root>>;
+}
+
+function Checkbox({ className, ref, ...props }: CheckboxProps) {
+  return (
+    <CheckboxPrimitive.Root
+      ref={ref}
+      className={cn(
+        'peer h-4 w-4 shrink-0 rounded-sm border border-input ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=checked]:border-transparent',
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator className={cn('flex items-center justify-center text-current')}>
+        <Check className="h-3.5 w-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}
 
 export { Checkbox };

--- a/src/components/ui/circular-progress.tsx
+++ b/src/components/ui/circular-progress.tsx
@@ -1,109 +1,113 @@
-import * as React from 'react';
+import type { HTMLAttributes, Ref, ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 
-export interface CircularProgressProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface CircularProgressProps extends HTMLAttributes<HTMLDivElement> {
   value: number;
   size?: number;
   className?: string;
-  children?: React.ReactNode;
+  children?: ReactNode;
+  ref?: Ref<HTMLDivElement>;
 }
 
-const CircularProgress = React.forwardRef<HTMLDivElement, CircularProgressProps>(
-  ({ value, size = 98, className, children, ...props }, ref) => {
-    const normalizedValue = Math.min(Math.max(value, 0), 100);
-    const halfSize = size / 2;
+function CircularProgress({
+  value,
+  size = 98,
+  className,
+  children,
+  ref,
+  ...props
+}: CircularProgressProps) {
+  const normalizedValue = Math.min(Math.max(value, 0), 100);
+  const halfSize = size / 2;
 
-    // Create the background semicircle path (gray background)
-    const backgroundPath = `M${size} ${halfSize}C${size} ${halfSize * 0.735} ${size * 0.8375} ${halfSize * 0.265} ${size * 0.6648} ${halfSize * 0.2927}C${size * 0.4919} ${halfSize * 0.1055} ${size * 0.2204} ${halfSize * 0.0} ${halfSize} 0C${halfSize * 0.7796} ${halfSize * -0.0} ${halfSize * 0.5082} ${halfSize * 0.1055} ${halfSize * 0.2927} ${halfSize * 0.2927}C${halfSize * 0.1055} ${halfSize * 0.4919} ${halfSize * 0.0} ${halfSize * 0.7796} 0 ${halfSize}H${halfSize * 0.16}C${halfSize * 0.16} ${halfSize * 0.7769} ${halfSize * 0.2435} ${halfSize * 0.5529} ${halfSize * 0.4078} ${halfSize * 0.4078}C${halfSize * 0.5529} ${halfSize * 0.2435} ${halfSize * 0.7769} ${halfSize * 0.16} ${halfSize} ${halfSize * 0.16}C${halfSize * 1.2231} ${halfSize * 0.16} ${halfSize * 1.4471} ${halfSize * 0.2435} ${halfSize * 1.5922} ${halfSize * 0.4078}C${halfSize * 1.7565} ${halfSize * 0.5529} ${halfSize * 1.84} ${halfSize * 0.7769} ${halfSize * 1.84} ${halfSize}H${size}Z`;
+  // Create the background semicircle path (gray background)
+  const backgroundPath = `M${size} ${halfSize}C${size} ${halfSize * 0.735} ${size * 0.8375} ${halfSize * 0.265} ${size * 0.6648} ${halfSize * 0.2927}C${size * 0.4919} ${halfSize * 0.1055} ${size * 0.2204} ${halfSize * 0.0} ${halfSize} 0C${halfSize * 0.7796} ${halfSize * -0.0} ${halfSize * 0.5082} ${halfSize * 0.1055} ${halfSize * 0.2927} ${halfSize * 0.2927}C${halfSize * 0.1055} ${halfSize * 0.4919} ${halfSize * 0.0} ${halfSize * 0.7796} 0 ${halfSize}H${halfSize * 0.16}C${halfSize * 0.16} ${halfSize * 0.7769} ${halfSize * 0.2435} ${halfSize * 0.5529} ${halfSize * 0.4078} ${halfSize * 0.4078}C${halfSize * 0.5529} ${halfSize * 0.2435} ${halfSize * 0.7769} ${halfSize * 0.16} ${halfSize} ${halfSize * 0.16}C${halfSize * 1.2231} ${halfSize * 0.16} ${halfSize * 1.4471} ${halfSize * 0.2435} ${halfSize * 1.5922} ${halfSize * 0.4078}C${halfSize * 1.7565} ${halfSize * 0.5529} ${halfSize * 1.84} ${halfSize * 0.7769} ${halfSize * 1.84} ${halfSize}H${size}Z`;
 
-    // Calculate progress path based on percentage (left to right)
-    const getProgressPath = (percentage: number) => {
-      if (percentage <= 0) return '';
-      if (percentage >= 100) {
-        // Full semicircle - complete path from left to right
-        return `M0 ${halfSize}C0 ${halfSize * 0.735} ${halfSize * 0.1055} ${halfSize * 0.541} ${halfSize * 0.2927} ${halfSize * 0.2927}C${halfSize * 0.5411} ${halfSize * 0.1055} ${halfSize * 0.7796} 0 ${halfSize} 0C${halfSize * 1.2204} 0 ${halfSize * 1.4589} ${halfSize * 0.1055} ${halfSize * 1.6482} ${halfSize * 0.2927}C${halfSize * 1.8375} ${halfSize * 0.5411} ${size} ${halfSize * 0.735} ${size} ${halfSize}H${size * 0.92}C${size * 0.92} ${halfSize * 0.7769} ${halfSize * 1.7565} ${halfSize * 0.5529} ${halfSize * 1.5922} ${halfSize * 0.4078}C${halfSize * 1.4471} ${halfSize * 0.2435} ${halfSize * 1.2231} ${halfSize * 0.16} ${halfSize} ${halfSize * 0.16}C${halfSize * 0.7769} ${halfSize * 0.16} ${halfSize * 0.5529} ${halfSize * 0.2435} ${halfSize * 0.4078} ${halfSize * 0.4078}C${halfSize * 0.2435} ${halfSize * 0.5529} ${halfSize * 0.16} ${halfSize * 0.7769} ${halfSize * 0.16} ${halfSize}H0Z`;
-      }
+  // Calculate progress path based on percentage (left to right)
+  const getProgressPath = (percentage: number) => {
+    if (percentage <= 0) return '';
+    if (percentage >= 100) {
+      // Full semicircle - complete path from left to right
+      return `M0 ${halfSize}C0 ${halfSize * 0.735} ${halfSize * 0.1055} ${halfSize * 0.541} ${halfSize * 0.2927} ${halfSize * 0.2927}C${halfSize * 0.5411} ${halfSize * 0.1055} ${halfSize * 0.7796} 0 ${halfSize} 0C${halfSize * 1.2204} 0 ${halfSize * 1.4589} ${halfSize * 0.1055} ${halfSize * 1.6482} ${halfSize * 0.2927}C${halfSize * 1.8375} ${halfSize * 0.5411} ${size} ${halfSize * 0.735} ${size} ${halfSize}H${size * 0.92}C${size * 0.92} ${halfSize * 0.7769} ${halfSize * 1.7565} ${halfSize * 0.5529} ${halfSize * 1.5922} ${halfSize * 0.4078}C${halfSize * 1.4471} ${halfSize * 0.2435} ${halfSize * 1.2231} ${halfSize * 0.16} ${halfSize} ${halfSize * 0.16}C${halfSize * 0.7769} ${halfSize * 0.16} ${halfSize * 0.5529} ${halfSize * 0.2435} ${halfSize * 0.4078} ${halfSize * 0.4078}C${halfSize * 0.2435} ${halfSize * 0.5529} ${halfSize * 0.16} ${halfSize * 0.7769} ${halfSize * 0.16} ${halfSize}H0Z`;
+    }
 
-      // Calculate the angle for the percentage - start from left (π) and move to right (0)
-      const angleRadians = Math.PI - (percentage / 100) * Math.PI;
+    // Calculate the angle for the percentage - start from left (π) and move to right (0)
+    const angleRadians = Math.PI - (percentage / 100) * Math.PI;
 
-      // Outer arc points
-      const outerStartX = 0;
-      const outerStartY = halfSize;
-      const outerEndX = halfSize + halfSize * Math.cos(angleRadians);
-      const outerEndY = halfSize - halfSize * Math.sin(angleRadians);
+    // Outer arc points
+    const outerStartX = 0;
+    const outerStartY = halfSize;
+    const outerEndX = halfSize + halfSize * Math.cos(angleRadians);
+    const outerEndY = halfSize - halfSize * Math.sin(angleRadians);
 
-      // Inner arc points (for donut effect)
-      const innerRadius = halfSize * 0.84; // 84% of outer radius to match the card
-      const innerStartX = halfSize - innerRadius;
-      const innerStartY = halfSize;
-      const innerEndX = halfSize + innerRadius * Math.cos(angleRadians);
-      const innerEndY = halfSize - innerRadius * Math.sin(angleRadians);
+    // Inner arc points (for donut effect)
+    const innerRadius = halfSize * 0.84; // 84% of outer radius to match the card
+    const innerStartX = halfSize - innerRadius;
+    const innerStartY = halfSize;
+    const innerEndX = halfSize + innerRadius * Math.cos(angleRadians);
+    const innerEndY = halfSize - innerRadius * Math.sin(angleRadians);
 
-      // Determine if we need the large arc flag
-      const largeArcFlag = percentage > 50 ? 1 : 0;
+    // Determine if we need the large arc flag
+    const largeArcFlag = percentage > 50 ? 1 : 0;
 
-      // Build the path with correct sweep direction
-      let path = `M${outerStartX} ${outerStartY}`; // Move to outer start (left edge)
-      path += ` A${halfSize} ${halfSize} 0 ${largeArcFlag} 1 ${outerEndX} ${outerEndY}`; // Outer arc clockwise
-      path += ` L${innerEndX} ${innerEndY}`; // Line to inner arc end
-      path += ` A${innerRadius} ${innerRadius} 0 ${largeArcFlag} 0 ${innerStartX} ${innerStartY}`; // Inner arc counter-clockwise
-      path += ` Z`; // Close path
+    // Build the path with correct sweep direction
+    let path = `M${outerStartX} ${outerStartY}`; // Move to outer start (left edge)
+    path += ` A${halfSize} ${halfSize} 0 ${largeArcFlag} 1 ${outerEndX} ${outerEndY}`; // Outer arc clockwise
+    path += ` L${innerEndX} ${innerEndY}`; // Line to inner arc end
+    path += ` A${innerRadius} ${innerRadius} 0 ${largeArcFlag} 0 ${innerStartX} ${innerStartY}`; // Inner arc counter-clockwise
+    path += ` Z`; // Close path
 
-      return path;
-    };
+    return path;
+  };
 
-    const progressPath = getProgressPath(normalizedValue);
+  const progressPath = getProgressPath(normalizedValue);
 
-    // Color based on confidence level
-    const getProgressColor = (value: number) => {
-      if (value <= 30) return '#FB3748'; // Red
-      if (value <= 50) return '#FFA500'; // Orange
-      if (value <= 70) return '#0EA5E9'; // Blue
-      return '#00C851'; // Green
-    };
+  // Color based on confidence level
+  const getProgressColor = (value: number) => {
+    if (value <= 30) return '#FB3748'; // Red
+    if (value <= 50) return '#FFA500'; // Orange
+    if (value <= 70) return '#0EA5E9'; // Blue
+    return '#00C851'; // Green
+  };
 
-    return (
-      <div ref={ref} className={cn('relative w-[98px] h-[52px]', className)} {...props}>
-        <div className="relative h-[98px] mb-[46px]">
-          <div className="absolute w-[98px] h-[98px] top-0 left-0">
-            <div className="relative h-[49px]">
-              {/* Background semicircle */}
+  return (
+    <div ref={ref} className={cn('relative w-[98px] h-[52px]', className)} {...props}>
+      <div className="relative h-[98px] mb-[46px]">
+        <div className="absolute w-[98px] h-[98px] top-0 left-0">
+          <div className="relative h-[49px]">
+            {/* Background semicircle */}
+            <svg
+              width={size}
+              height={halfSize}
+              viewBox={`0 0 ${size} ${halfSize}`}
+              className="absolute top-0 left-0"
+            >
+              <path d={backgroundPath} fill="#E1E4EA" />
+            </svg>
+
+            {/* Progress overlay */}
+            {progressPath && (
               <svg
                 width={size}
                 height={halfSize}
                 viewBox={`0 0 ${size} ${halfSize}`}
                 className="absolute top-0 left-0"
               >
-                <path d={backgroundPath} fill="#E1E4EA" />
+                <path d={progressPath} fill={getProgressColor(normalizedValue)} />
               </svg>
-
-              {/* Progress overlay */}
-              {progressPath && (
-                <svg
-                  width={size}
-                  height={halfSize}
-                  viewBox={`0 0 ${size} ${halfSize}`}
-                  className="absolute top-0 left-0"
-                >
-                  <path d={progressPath} fill={getProgressColor(normalizedValue)} />
-                </svg>
-              )}
-            </div>
+            )}
           </div>
-
-          {/* Center content (percentage text) */}
-          {children && (
-            <div className="absolute w-14 top-7 left-[21px] font-['Inter',Helvetica] font-normal text-[#0d111b] text-[28px] text-center tracking-[-0.17px] leading-5">
-              {children}
-            </div>
-          )}
         </div>
-      </div>
-    );
-  }
-);
 
-CircularProgress.displayName = 'CircularProgress';
+        {/* Center content (percentage text) */}
+        {children && (
+          <div className="absolute w-14 top-7 left-[21px] font-['Inter',Helvetica] font-normal text-[#0d111b] text-[28px] text-center tracking-[-0.17px] leading-5">
+            {children}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
 
 export { CircularProgress };

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { ComponentPropsWithoutRef, ElementRef, HTMLAttributes, Ref } from 'react';
 import { Search } from '@/components/ui/icon';
 import { type DialogProps } from '@radix-ui/react-dialog';
 import { Command as CommandPrimitive } from 'cmdk';
@@ -6,24 +6,26 @@ import { Command as CommandPrimitive } from 'cmdk';
 import { cn } from '@/lib/utils';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 
-const Command = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive>
->(({ className, ...props }, ref) => (
-  <CommandPrimitive
-    ref={ref}
-    className={cn(
-      'flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground',
-      className
-    )}
-    {...props}
-  />
-));
-Command.displayName = CommandPrimitive.displayName;
+export interface CommandProps extends ComponentPropsWithoutRef<typeof CommandPrimitive> {
+  ref?: Ref<ElementRef<typeof CommandPrimitive>>;
+}
 
-interface CommandDialogProps extends DialogProps {}
+function Command({ className, ref, ...props }: CommandProps) {
+  return (
+    <CommandPrimitive
+      ref={ref}
+      className={cn(
+        'flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground',
+        className
+      )}
+      {...props}
+    />
+  );
+}
 
-const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
+type CommandDialogProps = DialogProps;
+
+function CommandDialog({ children, ...props }: CommandDialogProps) {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0">
@@ -33,102 +35,107 @@ const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
       </DialogContent>
     </Dialog>
   );
-};
+}
 
-const CommandInput = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Input>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
->(({ className, ...props }, ref) => (
-  <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
-    <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
-    <CommandPrimitive.Input
+export interface CommandInputProps extends ComponentPropsWithoutRef<typeof CommandPrimitive.Input> {
+  ref?: Ref<ElementRef<typeof CommandPrimitive.Input>>;
+}
+
+function CommandInput({ className, ref, ...props }: CommandInputProps) {
+  return (
+    <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
+      <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        ref={ref}
+        className={cn(
+          'flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
+          className
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+export interface CommandListProps extends ComponentPropsWithoutRef<typeof CommandPrimitive.List> {
+  ref?: Ref<ElementRef<typeof CommandPrimitive.List>>;
+}
+
+function CommandList({ className, ref, ...props }: CommandListProps) {
+  return (
+    <CommandPrimitive.List
+      ref={ref}
+      className={cn('max-h-[300px] overflow-y-auto overflow-x-hidden', className)}
+      {...props}
+    />
+  );
+}
+
+export interface CommandEmptyProps extends ComponentPropsWithoutRef<typeof CommandPrimitive.Empty> {
+  ref?: Ref<ElementRef<typeof CommandPrimitive.Empty>>;
+}
+
+function CommandEmpty({ ref, ...props }: CommandEmptyProps) {
+  return <CommandPrimitive.Empty ref={ref} className="py-6 text-center text-sm" {...props} />;
+}
+
+export interface CommandGroupProps extends ComponentPropsWithoutRef<typeof CommandPrimitive.Group> {
+  ref?: Ref<ElementRef<typeof CommandPrimitive.Group>>;
+}
+
+function CommandGroup({ className, ref, ...props }: CommandGroupProps) {
+  return (
+    <CommandPrimitive.Group
       ref={ref}
       className={cn(
-        'flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
+        'overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground',
         className
       )}
       {...props}
     />
-  </div>
-));
+  );
+}
 
-CommandInput.displayName = CommandPrimitive.Input.displayName;
+export interface CommandSeparatorProps
+  extends ComponentPropsWithoutRef<typeof CommandPrimitive.Separator> {
+  ref?: Ref<ElementRef<typeof CommandPrimitive.Separator>>;
+}
 
-const CommandList = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
->(({ className, ...props }, ref) => (
-  <CommandPrimitive.List
-    ref={ref}
-    className={cn('max-h-[300px] overflow-y-auto overflow-x-hidden', className)}
-    {...props}
-  />
-));
+function CommandSeparator({ className, ref, ...props }: CommandSeparatorProps) {
+  return (
+    <CommandPrimitive.Separator
+      ref={ref}
+      className={cn('-mx-1 h-px bg-border', className)}
+      {...props}
+    />
+  );
+}
 
-CommandList.displayName = CommandPrimitive.List.displayName;
+export interface CommandItemProps extends ComponentPropsWithoutRef<typeof CommandPrimitive.Item> {
+  ref?: Ref<ElementRef<typeof CommandPrimitive.Item>>;
+}
 
-const CommandEmpty = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Empty>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
->((props, ref) => (
-  <CommandPrimitive.Empty ref={ref} className="py-6 text-center text-sm" {...props} />
-));
+function CommandItem({ className, ref, ...props }: CommandItemProps) {
+  return (
+    <CommandPrimitive.Item
+      ref={ref}
+      className={cn(
+        'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50',
+        className
+      )}
+      {...props}
+    />
+  );
+}
 
-CommandEmpty.displayName = CommandPrimitive.Empty.displayName;
-
-const CommandGroup = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Group>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
->(({ className, ...props }, ref) => (
-  <CommandPrimitive.Group
-    ref={ref}
-    className={cn(
-      'overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground',
-      className
-    )}
-    {...props}
-  />
-));
-
-CommandGroup.displayName = CommandPrimitive.Group.displayName;
-
-const CommandSeparator = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Separator>
->(({ className, ...props }, ref) => (
-  <CommandPrimitive.Separator
-    ref={ref}
-    className={cn('-mx-1 h-px bg-border', className)}
-    {...props}
-  />
-));
-CommandSeparator.displayName = CommandPrimitive.Separator.displayName;
-
-const CommandItem = React.forwardRef<
-  React.ElementRef<typeof CommandPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
->(({ className, ...props }, ref) => (
-  <CommandPrimitive.Item
-    ref={ref}
-    className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50',
-      className
-    )}
-    {...props}
-  />
-));
-
-CommandItem.displayName = CommandPrimitive.Item.displayName;
-
-const CommandShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => {
+function CommandShortcut({ className, ...props }: HTMLAttributes<HTMLSpanElement>) {
   return (
     <span
       className={cn('ml-auto text-xs tracking-widest text-muted-foreground', className)}
       {...props}
     />
   );
-};
-CommandShortcut.displayName = 'CommandShortcut';
+}
 
 export {
   Command,

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { ComponentPropsWithoutRef, ElementRef, HTMLAttributes, Ref } from 'react';
 import { X } from '@/components/ui/icon';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 
@@ -12,81 +12,97 @@ const DialogPortal = DialogPrimitive.Portal;
 
 const DialogClose = DialogPrimitive.Close;
 
-const DialogOverlay = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Overlay
-    ref={ref}
-    className={cn(
-      'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-      className
-    )}
-    {...props}
-  />
-));
-DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+export interface DialogOverlayProps
+  extends ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay> {
+  ref?: Ref<ElementRef<typeof DialogPrimitive.Overlay>>;
+}
 
-const DialogContent = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay />
-    <DialogPrimitive.Content
+function DialogOverlay({ className, ref, ...props }: DialogOverlayProps) {
+  return (
+    <DialogPrimitive.Overlay
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
         className
       )}
       {...props}
-    >
-      {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
-    </DialogPrimitive.Content>
-  </DialogPortal>
-));
-DialogContent.displayName = DialogPrimitive.Content.displayName;
+    />
+  );
+}
 
-const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
-);
-DialogHeader.displayName = 'DialogHeader';
+export interface DialogContentProps
+  extends ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
+  ref?: Ref<ElementRef<typeof DialogPrimitive.Content>>;
+}
 
-const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
-    {...props}
-  />
-);
-DialogFooter.displayName = 'DialogFooter';
+function DialogContent({ className, children, ref, ...props }: DialogContentProps) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
 
-const DialogTitle = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Title
-    ref={ref}
-    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
-    {...props}
-  />
-));
-DialogTitle.displayName = DialogPrimitive.Title.displayName;
+function DialogHeader({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)}
+      {...props}
+    />
+  );
+}
 
-const DialogDescription = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Description>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Description
-    ref={ref}
-    className={cn('text-sm text-muted-foreground', className)}
-    {...props}
-  />
-));
-DialogDescription.displayName = DialogPrimitive.Description.displayName;
+function DialogFooter({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
+      {...props}
+    />
+  );
+}
+
+export interface DialogTitleProps extends ComponentPropsWithoutRef<typeof DialogPrimitive.Title> {
+  ref?: Ref<ElementRef<typeof DialogPrimitive.Title>>;
+}
+
+function DialogTitle({ className, ref, ...props }: DialogTitleProps) {
+  return (
+    <DialogPrimitive.Title
+      ref={ref}
+      className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+      {...props}
+    />
+  );
+}
+
+export interface DialogDescriptionProps
+  extends ComponentPropsWithoutRef<typeof DialogPrimitive.Description> {
+  ref?: Ref<ElementRef<typeof DialogPrimitive.Description>>;
+}
+
+function DialogDescription({ className, ref, ...props }: DialogDescriptionProps) {
+  return (
+    <DialogPrimitive.Description
+      ref={ref}
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
 
 export {
   Dialog,

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -1,15 +1,20 @@
-import * as React from 'react';
+import type {
+  ComponentProps,
+  ComponentPropsWithoutRef,
+  ElementRef,
+  HTMLAttributes,
+  Ref,
+} from 'react';
 import { Drawer as DrawerPrimitive } from 'vaul';
 
 import { cn } from '@/lib/utils';
 
-const Drawer = ({
+function Drawer({
   shouldScaleBackground = true,
   ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Root>) => (
-  <DrawerPrimitive.Root shouldScaleBackground={shouldScaleBackground} {...props} />
-);
-Drawer.displayName = 'Drawer';
+}: ComponentProps<typeof DrawerPrimitive.Root>) {
+  return <DrawerPrimitive.Root shouldScaleBackground={shouldScaleBackground} {...props} />;
+}
 
 const DrawerTrigger = DrawerPrimitive.Trigger;
 
@@ -17,72 +22,81 @@ const DrawerPortal = DrawerPrimitive.Portal;
 
 const DrawerClose = DrawerPrimitive.Close;
 
-const DrawerOverlay = React.forwardRef<
-  React.ElementRef<typeof DrawerPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
->(({ className, ...props }, ref) => (
-  <DrawerPrimitive.Overlay
-    ref={ref}
-    className={cn('fixed inset-0 z-50 bg-black/80', className)}
-    {...props}
-  />
-));
-DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName;
+export interface DrawerOverlayProps
+  extends ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay> {
+  ref?: Ref<ElementRef<typeof DrawerPrimitive.Overlay>>;
+}
 
-const DrawerContent = React.forwardRef<
-  React.ElementRef<typeof DrawerPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-  <DrawerPortal>
-    <DrawerOverlay />
-    <DrawerPrimitive.Content
+function DrawerOverlay({ className, ref, ...props }: DrawerOverlayProps) {
+  return (
+    <DrawerPrimitive.Overlay
       ref={ref}
-      className={cn(
-        'fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background',
-        className
-      )}
+      className={cn('fixed inset-0 z-50 bg-black/80', className)}
       {...props}
-    >
-      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
-      {children}
-    </DrawerPrimitive.Content>
-  </DrawerPortal>
-));
-DrawerContent.displayName = 'DrawerContent';
+    />
+  );
+}
 
-const DrawerHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn('grid gap-1.5 p-4 text-center sm:text-left', className)} {...props} />
-);
-DrawerHeader.displayName = 'DrawerHeader';
+export interface DrawerContentProps
+  extends ComponentPropsWithoutRef<typeof DrawerPrimitive.Content> {
+  ref?: Ref<ElementRef<typeof DrawerPrimitive.Content>>;
+}
 
-const DrawerFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn('mt-auto flex flex-col gap-2 p-4', className)} {...props} />
-);
-DrawerFooter.displayName = 'DrawerFooter';
+function DrawerContent({ className, children, ref, ...props }: DrawerContentProps) {
+  return (
+    <DrawerPortal>
+      <DrawerOverlay />
+      <DrawerPrimitive.Content
+        ref={ref}
+        className={cn(
+          'fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background',
+          className
+        )}
+        {...props}
+      >
+        <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
+        {children}
+      </DrawerPrimitive.Content>
+    </DrawerPortal>
+  );
+}
 
-const DrawerTitle = React.forwardRef<
-  React.ElementRef<typeof DrawerPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
->(({ className, ...props }, ref) => (
-  <DrawerPrimitive.Title
-    ref={ref}
-    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
-    {...props}
-  />
-));
-DrawerTitle.displayName = DrawerPrimitive.Title.displayName;
+function DrawerHeader({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('grid gap-1.5 p-4 text-center sm:text-left', className)} {...props} />;
+}
 
-const DrawerDescription = React.forwardRef<
-  React.ElementRef<typeof DrawerPrimitive.Description>,
-  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
->(({ className, ...props }, ref) => (
-  <DrawerPrimitive.Description
-    ref={ref}
-    className={cn('text-sm text-muted-foreground', className)}
-    {...props}
-  />
-));
-DrawerDescription.displayName = DrawerPrimitive.Description.displayName;
+function DrawerFooter({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('mt-auto flex flex-col gap-2 p-4', className)} {...props} />;
+}
+
+export interface DrawerTitleProps extends ComponentPropsWithoutRef<typeof DrawerPrimitive.Title> {
+  ref?: Ref<ElementRef<typeof DrawerPrimitive.Title>>;
+}
+
+function DrawerTitle({ className, ref, ...props }: DrawerTitleProps) {
+  return (
+    <DrawerPrimitive.Title
+      ref={ref}
+      className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+      {...props}
+    />
+  );
+}
+
+export interface DrawerDescriptionProps
+  extends ComponentPropsWithoutRef<typeof DrawerPrimitive.Description> {
+  ref?: Ref<ElementRef<typeof DrawerPrimitive.Description>>;
+}
+
+function DrawerDescription({ className, ref, ...props }: DrawerDescriptionProps) {
+  return (
+    <DrawerPrimitive.Description
+      ref={ref}
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
 
 export {
   Drawer,

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { ComponentPropsWithoutRef, ElementRef, HTMLAttributes, Ref } from 'react';
 import { Check, ChevronRight, Circle } from '@/components/ui/icon';
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 
@@ -16,156 +16,193 @@ const DropdownMenuSub = DropdownMenuPrimitive.Sub;
 
 const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
 
-const DropdownMenuSubTrigger = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
-    inset?: boolean;
-  }
->(({ className, inset, children, ...props }, ref) => (
-  <DropdownMenuPrimitive.SubTrigger
-    ref={ref}
-    className={cn(
-      'flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent',
-      inset && 'pl-8',
-      className
-    )}
-    {...props}
-  >
-    {children}
-    <ChevronRight className="ml-auto h-4 w-4" />
-  </DropdownMenuPrimitive.SubTrigger>
-));
-DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName;
+export interface DropdownMenuSubTriggerProps
+  extends ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> {
+  ref?: Ref<ElementRef<typeof DropdownMenuPrimitive.SubTrigger>>;
+  inset?: boolean;
+}
 
-const DropdownMenuSubContent = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
->(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.SubContent
-    ref={ref}
-    className={cn(
-      'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-      className
-    )}
-    {...props}
-  />
-));
-DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName;
-
-const DropdownMenuContent = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
-  <DropdownMenuPrimitive.Portal>
-    <DropdownMenuPrimitive.Content
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ref,
+  ...props
+}: DropdownMenuSubTriggerProps) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
       ref={ref}
-      sideOffset={sideOffset}
       className={cn(
-        'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md',
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent',
+        inset && 'pl-8',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRight className="ml-auto h-4 w-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  );
+}
+
+export interface DropdownMenuSubContentProps
+  extends ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent> {
+  ref?: Ref<ElementRef<typeof DropdownMenuPrimitive.SubContent>>;
+}
+
+function DropdownMenuSubContent({ className, ref, ...props }: DropdownMenuSubContentProps) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      ref={ref}
+      className={cn(
+        'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         className
       )}
       {...props}
     />
-  </DropdownMenuPrimitive.Portal>
-));
-DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+  );
+}
 
-const DropdownMenuItem = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
-    inset?: boolean;
-  }
->(({ className, inset, ...props }, ref) => (
-  <DropdownMenuPrimitive.Item
-    ref={ref}
-    className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
-      inset && 'pl-8',
-      className
-    )}
-    {...props}
-  />
-));
-DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+export interface DropdownMenuContentProps
+  extends ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> {
+  ref?: Ref<ElementRef<typeof DropdownMenuPrimitive.Content>>;
+}
 
-const DropdownMenuCheckboxItem = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
->(({ className, children, checked, ...props }, ref) => (
-  <DropdownMenuPrimitive.CheckboxItem
-    ref={ref}
-    className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
-      className
-    )}
-    checked={checked}
-    {...props}
-  >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <DropdownMenuPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
-      </DropdownMenuPrimitive.ItemIndicator>
-    </span>
-    {children}
-  </DropdownMenuPrimitive.CheckboxItem>
-));
-DropdownMenuCheckboxItem.displayName = DropdownMenuPrimitive.CheckboxItem.displayName;
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ref,
+  ...props
+}: DropdownMenuContentProps) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        ref={ref}
+        sideOffset={sideOffset}
+        className={cn(
+          'z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md',
+          'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+}
 
-const DropdownMenuRadioItem = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
->(({ className, children, ...props }, ref) => (
-  <DropdownMenuPrimitive.RadioItem
-    ref={ref}
-    className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
-      className
-    )}
-    {...props}
-  >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <DropdownMenuPrimitive.ItemIndicator>
-        <Circle className="h-2 w-2 fill-current" />
-      </DropdownMenuPrimitive.ItemIndicator>
-    </span>
-    {children}
-  </DropdownMenuPrimitive.RadioItem>
-));
-DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
+export interface DropdownMenuItemProps
+  extends ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> {
+  ref?: Ref<ElementRef<typeof DropdownMenuPrimitive.Item>>;
+  inset?: boolean;
+}
 
-const DropdownMenuLabel = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
-    inset?: boolean;
-  }
->(({ className, inset, ...props }, ref) => (
-  <DropdownMenuPrimitive.Label
-    ref={ref}
-    className={cn('px-2 py-1.5 text-sm font-semibold', inset && 'pl-8', className)}
-    {...props}
-  />
-));
-DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
+function DropdownMenuItem({ className, inset, ref, ...props }: DropdownMenuItemProps) {
+  return (
+    <DropdownMenuPrimitive.Item
+      ref={ref}
+      className={cn(
+        'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        inset && 'pl-8',
+        className
+      )}
+      {...props}
+    />
+  );
+}
 
-const DropdownMenuSeparator = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
->(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.Separator
-    ref={ref}
-    className={cn('-mx-1 my-1 h-px bg-muted', className)}
-    {...props}
-  />
-));
-DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
+export interface DropdownMenuCheckboxItemProps
+  extends ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem> {
+  ref?: Ref<ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>>;
+}
 
-const DropdownMenuShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => {
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ref,
+  ...props
+}: DropdownMenuCheckboxItemProps) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      ref={ref}
+      className={cn(
+        'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <Check className="h-4 w-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  );
+}
+
+export interface DropdownMenuRadioItemProps
+  extends ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem> {
+  ref?: Ref<ElementRef<typeof DropdownMenuPrimitive.RadioItem>>;
+}
+
+function DropdownMenuRadioItem({ className, children, ref, ...props }: DropdownMenuRadioItemProps) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      ref={ref}
+      className={cn(
+        'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        className
+      )}
+      {...props}
+    >
+      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <Circle className="h-2 w-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  );
+}
+
+export interface DropdownMenuLabelProps
+  extends ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> {
+  ref?: Ref<ElementRef<typeof DropdownMenuPrimitive.Label>>;
+  inset?: boolean;
+}
+
+function DropdownMenuLabel({ className, inset, ref, ...props }: DropdownMenuLabelProps) {
+  return (
+    <DropdownMenuPrimitive.Label
+      ref={ref}
+      className={cn('px-2 py-1.5 text-sm font-semibold', inset && 'pl-8', className)}
+      {...props}
+    />
+  );
+}
+
+export interface DropdownMenuSeparatorProps
+  extends ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator> {
+  ref?: Ref<ElementRef<typeof DropdownMenuPrimitive.Separator>>;
+}
+
+function DropdownMenuSeparator({ className, ref, ...props }: DropdownMenuSeparatorProps) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      ref={ref}
+      className={cn('-mx-1 my-1 h-px bg-muted', className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuShortcut({ className, ...props }: HTMLAttributes<HTMLSpanElement>) {
   return (
     <span className={cn('ml-auto text-xs tracking-widest opacity-60', className)} {...props} />
   );
-};
-DropdownMenuShortcut.displayName = 'DropdownMenuShortcut';
+}
 
 export {
   DropdownMenu,

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import { createContext, useContext, useId } from 'react';
+import type { ComponentPropsWithoutRef, ElementRef, HTMLAttributes, Ref } from 'react';
 import * as LabelPrimitive from '@radix-ui/react-label';
 import { Slot } from '@radix-ui/react-slot';
 import {
@@ -23,7 +24,7 @@ type FormFieldContextValue<
   name: TName;
 };
 
-const FormFieldContext = React.createContext<FormFieldContextValue>({} as FormFieldContextValue);
+const FormFieldContext = createContext<FormFieldContextValue>({} as FormFieldContextValue);
 
 const FormField = <
   TFieldValues extends FieldValues = FieldValues,
@@ -39,8 +40,8 @@ const FormField = <
 };
 
 const useFormField = () => {
-  const fieldContext = React.useContext(FormFieldContext);
-  const itemContext = React.useContext(FormItemContext);
+  const fieldContext = useContext(FormFieldContext);
+  const itemContext = useContext(FormItemContext);
   const { getFieldState, formState } = useFormContext();
 
   const fieldState = getFieldState(fieldContext.name, formState);
@@ -65,25 +66,27 @@ type FormItemContextValue = {
   id: string;
 };
 
-const FormItemContext = React.createContext<FormItemContextValue>({} as FormItemContextValue);
+const FormItemContext = createContext<FormItemContextValue>({} as FormItemContextValue);
 
-const FormItem = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => {
-    const id = React.useId();
+export interface FormItemProps extends HTMLAttributes<HTMLDivElement> {
+  ref?: Ref<HTMLDivElement>;
+}
 
-    return (
-      <FormItemContext.Provider value={{ id }}>
-        <div ref={ref} className={cn('space-y-2', className)} {...props} />
-      </FormItemContext.Provider>
-    );
-  }
-);
-FormItem.displayName = 'FormItem';
+function FormItem({ className, ref, ...props }: FormItemProps) {
+  const id = useId();
 
-const FormLabel = React.forwardRef<
-  React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
->(({ className, ...props }, ref) => {
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div ref={ref} className={cn('space-y-2', className)} {...props} />
+    </FormItemContext.Provider>
+  );
+}
+
+export interface FormLabelProps extends ComponentPropsWithoutRef<typeof LabelPrimitive.Root> {
+  ref?: Ref<ElementRef<typeof LabelPrimitive.Root>>;
+}
+
+function FormLabel({ className, ref, ...props }: FormLabelProps) {
   const { error, formItemId } = useFormField();
 
   return (
@@ -94,13 +97,13 @@ const FormLabel = React.forwardRef<
       {...props}
     />
   );
-});
-FormLabel.displayName = 'FormLabel';
+}
 
-const FormControl = React.forwardRef<
-  React.ElementRef<typeof Slot>,
-  React.ComponentPropsWithoutRef<typeof Slot>
->(({ ...props }, ref) => {
+export interface FormControlProps extends ComponentPropsWithoutRef<typeof Slot> {
+  ref?: Ref<ElementRef<typeof Slot>>;
+}
+
+function FormControl({ ref, ...props }: FormControlProps) {
   const { error, formItemId, formDescriptionId, formMessageId } = useFormField();
 
   return (
@@ -112,13 +115,13 @@ const FormControl = React.forwardRef<
       {...props}
     />
   );
-});
-FormControl.displayName = 'FormControl';
+}
 
-const FormDescription = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLParagraphElement>
->(({ className, ...props }, ref) => {
+export interface FormDescriptionProps extends HTMLAttributes<HTMLParagraphElement> {
+  ref?: Ref<HTMLParagraphElement>;
+}
+
+function FormDescription({ className, ref, ...props }: FormDescriptionProps) {
   const { formDescriptionId } = useFormField();
 
   return (
@@ -129,13 +132,13 @@ const FormDescription = React.forwardRef<
       {...props}
     />
   );
-});
-FormDescription.displayName = 'FormDescription';
+}
 
-const FormMessage = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLParagraphElement>
->(({ className, children, ...props }, ref) => {
+export interface FormMessageProps extends HTMLAttributes<HTMLParagraphElement> {
+  ref?: Ref<HTMLParagraphElement>;
+}
+
+function FormMessage({ className, children, ref, ...props }: FormMessageProps) {
   const { error, formMessageId } = useFormField();
   const body = getFormErrorContent(error, children);
 
@@ -153,11 +156,10 @@ const FormMessage = React.forwardRef<
       {body}
     </p>
   );
-});
-FormMessage.displayName = 'FormMessage';
+}
 
 export {
-  useFormField,
+  useFormField, // eslint-disable-line react-refresh/only-export-components -- hook is intentionally co-located
   Form,
   FormItem,
   FormLabel,

--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { ComponentPropsWithoutRef, ElementRef, Ref } from 'react';
 import * as HoverCardPrimitive from '@radix-ui/react-hover-card';
 
 import { cn } from '@/lib/utils';
@@ -7,21 +7,30 @@ const HoverCard = HoverCardPrimitive.Root;
 
 const HoverCardTrigger = HoverCardPrimitive.Trigger;
 
-const HoverCardContent = React.forwardRef<
-  React.ElementRef<typeof HoverCardPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
->(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
-  <HoverCardPrimitive.Content
-    ref={ref}
-    align={align}
-    sideOffset={sideOffset}
-    className={cn(
-      'z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-      className
-    )}
-    {...props}
-  />
-));
-HoverCardContent.displayName = HoverCardPrimitive.Content.displayName;
+export interface HoverCardContentProps
+  extends ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content> {
+  ref?: Ref<ElementRef<typeof HoverCardPrimitive.Content>>;
+}
+
+function HoverCardContent({
+  className,
+  align = 'center',
+  sideOffset = 4,
+  ref,
+  ...props
+}: HoverCardContentProps) {
+  return (
+    <HoverCardPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        className
+      )}
+      {...props}
+    />
+  );
+}
 
 export { HoverCard, HoverCardTrigger, HoverCardContent };

--- a/src/components/ui/icon.tsx
+++ b/src/components/ui/icon.tsx
@@ -1,43 +1,42 @@
-import React from 'react';
+import type { SVGProps, Ref } from 'react';
 import { cn } from '@/lib/utils';
 import type { IconName } from '@/types/icons';
 
-export interface IconProps extends React.SVGProps<SVGSVGElement> {
+export interface IconProps extends SVGProps<SVGSVGElement> {
   name: IconName;
   size?: number | string;
+  ref?: Ref<SVGSVGElement>;
 }
 
 /**
  * Icon component that uses SVG sprites instead of importing individual icons
  * This reduces bundle size from ~100KB (lucide-react) to ~20KB (sprite)
  */
-export const Icon = React.forwardRef<SVGSVGElement, IconProps>(
-  ({ name, className, size = 24, width, height, ...props }, ref) => {
-    const iconSize = width || height || size;
+function Icon({ name, className, size = 24, width, height, ref, ...props }: IconProps) {
+  const iconSize = width || height || size;
 
-    return (
-      <svg
-        ref={ref}
-        width={iconSize}
-        height={iconSize}
-        className={cn('inline-block', className)}
-        aria-hidden="true"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlnsXlink="http://www.w3.org/1999/xlink"
-        {...props}
-      >
-        <use href={`#icon-${name}`} xlinkHref={`#icon-${name}`} />
-      </svg>
-    );
-  }
-);
+  return (
+    <svg
+      ref={ref}
+      width={iconSize}
+      height={iconSize}
+      className={cn('inline-block', className)}
+      aria-hidden="true"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      xmlns="http://www.w3.org/2000/svg"
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      {...props}
+    >
+      <use href={`#icon-${name}`} xlinkHref={`#icon-${name}`} />
+    </svg>
+  );
+}
 
-Icon.displayName = 'Icon';
+export { Icon };
 
 // Convenience exports for common icons matching lucide-react API
 export const ChevronDown = (props: Omit<IconProps, 'name'>) => (

--- a/src/components/ui/input-otp.tsx
+++ b/src/components/ui/input-otp.tsx
@@ -1,38 +1,42 @@
-import * as React from 'react';
+import { useContext, type ComponentPropsWithoutRef, type ElementRef, type Ref } from 'react';
 import { Minus } from '@/components/ui/icon';
 import { OTPInput, OTPInputContext } from 'input-otp';
 
 import { cn } from '@/lib/utils';
 
-const InputOTP = React.forwardRef<
-  React.ElementRef<typeof OTPInput>,
-  React.ComponentPropsWithoutRef<typeof OTPInput>
->(({ className, containerClassName, ...props }, ref) => (
-  <OTPInput
-    ref={ref}
-    containerClassName={cn(
-      'flex items-center gap-2 has-[:disabled]:opacity-50',
-      containerClassName
-    )}
-    className={cn('disabled:cursor-not-allowed', className)}
-    {...props}
-  />
-));
-InputOTP.displayName = 'InputOTP';
+export type InputOTPProps = ComponentPropsWithoutRef<typeof OTPInput> & {
+  ref?: Ref<ElementRef<typeof OTPInput>>;
+};
 
-const InputOTPGroup = React.forwardRef<
-  React.ElementRef<'div'>,
-  React.ComponentPropsWithoutRef<'div'>
->(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn('flex items-center', className)} {...props} />
-));
-InputOTPGroup.displayName = 'InputOTPGroup';
+function InputOTP({ className, containerClassName, ref, ...props }: InputOTPProps) {
+  return (
+    <OTPInput
+      ref={ref}
+      containerClassName={cn(
+        'flex items-center gap-2 has-[:disabled]:opacity-50',
+        containerClassName
+      )}
+      className={cn('disabled:cursor-not-allowed', className)}
+      {...props}
+    />
+  );
+}
 
-const InputOTPSlot = React.forwardRef<
-  React.ElementRef<'div'>,
-  React.ComponentPropsWithoutRef<'div'> & { index: number }
->(({ index, className, ...props }, ref) => {
-  const inputOTPContext = React.useContext(OTPInputContext);
+export interface InputOTPGroupProps extends ComponentPropsWithoutRef<'div'> {
+  ref?: Ref<HTMLDivElement>;
+}
+
+function InputOTPGroup({ className, ref, ...props }: InputOTPGroupProps) {
+  return <div ref={ref} className={cn('flex items-center', className)} {...props} />;
+}
+
+export interface InputOTPSlotProps extends ComponentPropsWithoutRef<'div'> {
+  ref?: Ref<HTMLDivElement>;
+  index: number;
+}
+
+function InputOTPSlot({ index, className, ref, ...props }: InputOTPSlotProps) {
+  const inputOTPContext = useContext(OTPInputContext);
   const { char, hasFakeCaret, isActive } = inputOTPContext.slots[index];
 
   return (
@@ -53,17 +57,18 @@ const InputOTPSlot = React.forwardRef<
       )}
     </div>
   );
-});
-InputOTPSlot.displayName = 'InputOTPSlot';
+}
 
-const InputOTPSeparator = React.forwardRef<
-  React.ElementRef<'div'>,
-  React.ComponentPropsWithoutRef<'div'>
->(({ ...props }, ref) => (
-  <div ref={ref} role="separator" {...props}>
-    <Minus />
-  </div>
-));
-InputOTPSeparator.displayName = 'InputOTPSeparator';
+export interface InputOTPSeparatorProps extends ComponentPropsWithoutRef<'div'> {
+  ref?: Ref<HTMLDivElement>;
+}
+
+function InputOTPSeparator({ ref, ...props }: InputOTPSeparatorProps) {
+  return (
+    <div ref={ref} role="separator" {...props}>
+      <Minus />
+    </div>
+  );
+}
 
 export { InputOTP, InputOTPGroup, InputOTPSlot, InputOTPSeparator };

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,24 +1,23 @@
-import * as React from 'react';
+import type { InputHTMLAttributes, Ref } from 'react';
 
 import { cn } from '@/lib/utils';
 
-export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  ref?: Ref<HTMLInputElement>;
+}
 
-const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref) => {
-    return (
-      <input
-        type={type}
-        className={cn(
-          'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
-          className
-        )}
-        ref={ref}
-        {...props}
-      />
-    );
-  }
-);
-Input.displayName = 'Input';
+function Input({ className, type, ref, ...props }: InputProps) {
+  return (
+    <input
+      type={type}
+      className={cn(
+        'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+}
 
 export { Input };

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { ComponentPropsWithoutRef, ElementRef, Ref } from 'react';
 import * as LabelPrimitive from '@radix-ui/react-label';
 import { cva, type VariantProps } from 'class-variance-authority';
 
@@ -8,12 +8,14 @@ const labelVariants = cva(
   'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70'
 );
 
-const Label = React.forwardRef<
-  React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & VariantProps<typeof labelVariants>
->(({ className, ...props }, ref) => (
-  <LabelPrimitive.Root ref={ref} className={cn(labelVariants(), className)} {...props} />
-));
-Label.displayName = LabelPrimitive.Root.displayName;
+export interface LabelProps
+  extends ComponentPropsWithoutRef<typeof LabelPrimitive.Root>,
+    VariantProps<typeof labelVariants> {
+  ref?: Ref<ElementRef<typeof LabelPrimitive.Root>>;
+}
+
+function Label({ className, ref, ...props }: LabelProps) {
+  return <LabelPrimitive.Root ref={ref} className={cn(labelVariants(), className)} {...props} />;
+}
 
 export { Label };

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,91 +1,97 @@
-import * as React from 'react';
+import type { ComponentProps, Ref } from 'react';
 import { ChevronLeft, ChevronRight, MoreHorizontal } from '@/components/ui/icon';
 
 import { cn } from '@/lib/utils';
 import { ButtonProps, buttonVariants } from '@/components/ui/button';
 
-const Pagination = ({ className, ...props }: React.ComponentProps<'nav'>) => (
-  <nav
-    role="navigation"
-    aria-label="pagination"
-    className={cn('mx-auto flex w-full justify-center', className)}
-    {...props}
-  />
-);
-Pagination.displayName = 'Pagination';
+function Pagination({ className, ...props }: ComponentProps<'nav'>) {
+  return (
+    <nav
+      role="navigation"
+      aria-label="pagination"
+      className={cn('mx-auto flex w-full justify-center', className)}
+      {...props}
+    />
+  );
+}
 
-const PaginationContent = React.forwardRef<HTMLUListElement, React.ComponentProps<'ul'>>(
-  ({ className, ...props }, ref) => (
-    <ul ref={ref} className={cn('flex flex-row items-center gap-1', className)} {...props} />
-  )
-);
-PaginationContent.displayName = 'PaginationContent';
+export interface PaginationContentProps extends ComponentProps<'ul'> {
+  ref?: Ref<HTMLUListElement>;
+}
 
-const PaginationItem = React.forwardRef<HTMLLIElement, React.ComponentProps<'li'>>(
-  ({ className, ...props }, ref) => <li ref={ref} className={cn('', className)} {...props} />
-);
-PaginationItem.displayName = 'PaginationItem';
+function PaginationContent({ className, ref, ...props }: PaginationContentProps) {
+  return <ul ref={ref} className={cn('flex flex-row items-center gap-1', className)} {...props} />;
+}
+
+export interface PaginationItemProps extends ComponentProps<'li'> {
+  ref?: Ref<HTMLLIElement>;
+}
+
+function PaginationItem({ className, ref, ...props }: PaginationItemProps) {
+  return <li ref={ref} className={cn('', className)} {...props} />;
+}
 
 type PaginationLinkProps = {
   isActive?: boolean;
 } & Pick<ButtonProps, 'size'> &
-  React.ComponentProps<'a'>;
+  ComponentProps<'a'>;
 
-const PaginationLink = ({ className, isActive, size = 'icon', ...props }: PaginationLinkProps) => (
-  <a
-    aria-current={isActive ? 'page' : undefined}
-    className={cn(
-      buttonVariants({
-        variant: isActive ? 'outline' : 'ghost',
-        size,
-      }),
-      className
-    )}
-    {...props}
-  />
-);
-PaginationLink.displayName = 'PaginationLink';
+function PaginationLink({ className, isActive, size = 'icon', ...props }: PaginationLinkProps) {
+  return (
+    <a
+      aria-current={isActive ? 'page' : undefined}
+      className={cn(
+        buttonVariants({
+          variant: isActive ? 'outline' : 'ghost',
+          size,
+        }),
+        className
+      )}
+      {...props}
+    />
+  );
+}
 
-const PaginationPrevious = ({
-  className,
-  ...props
-}: React.ComponentProps<typeof PaginationLink>) => (
-  <PaginationLink
-    aria-label="Go to previous page"
-    size="default"
-    className={cn('gap-1 pl-2.5', className)}
-    {...props}
-  >
-    <ChevronLeft className="h-4 w-4" />
-    <span>Previous</span>
-  </PaginationLink>
-);
-PaginationPrevious.displayName = 'PaginationPrevious';
+function PaginationPrevious({ className, ...props }: ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to previous page"
+      size="default"
+      className={cn('gap-1 pl-2.5', className)}
+      {...props}
+    >
+      <ChevronLeft className="h-4 w-4" />
+      <span>Previous</span>
+    </PaginationLink>
+  );
+}
 
-const PaginationNext = ({ className, ...props }: React.ComponentProps<typeof PaginationLink>) => (
-  <PaginationLink
-    aria-label="Go to next page"
-    size="default"
-    className={cn('gap-1 pr-2.5', className)}
-    {...props}
-  >
-    <span>Next</span>
-    <ChevronRight className="h-4 w-4" />
-  </PaginationLink>
-);
-PaginationNext.displayName = 'PaginationNext';
+function PaginationNext({ className, ...props }: ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to next page"
+      size="default"
+      className={cn('gap-1 pr-2.5', className)}
+      {...props}
+    >
+      <span>Next</span>
+      <ChevronRight className="h-4 w-4" />
+    </PaginationLink>
+  );
+}
 
-const PaginationEllipsis = ({ className, ...props }: React.ComponentProps<'span'>) => (
-  <span
-    aria-hidden
-    className={cn('flex h-9 w-9 items-center justify-center', className)}
-    {...props}
-  >
-    <MoreHorizontal className="h-4 w-4" />
-    <span className="sr-only">More pages</span>
-  </span>
-);
-PaginationEllipsis.displayName = 'PaginationEllipsis';
+function PaginationEllipsis({ className, ...props }: ComponentProps<'span'>) {
+  return (
+    <span
+      aria-hidden
+      className={cn('flex h-9 w-9 items-center justify-center', className)}
+      {...props}
+    >
+      <MoreHorizontal className="h-4 w-4" />
+      <span className="sr-only">More pages</span>
+    </span>
+  );
+}
 
 export {
   Pagination,

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { ComponentPropsWithoutRef, ElementRef, Ref } from 'react';
 import * as PopoverPrimitive from '@radix-ui/react-popover';
 
 import { cn } from '@/lib/utils';
@@ -9,23 +9,32 @@ const PopoverTrigger = PopoverPrimitive.Trigger;
 
 const PopoverAnchor = PopoverPrimitive.Anchor;
 
-const PopoverContent = React.forwardRef<
-  React.ElementRef<typeof PopoverPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
-  <PopoverPrimitive.Portal>
-    <PopoverPrimitive.Content
-      ref={ref}
-      align={align}
-      sideOffset={sideOffset}
-      className={cn(
-        'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-        className
-      )}
-      {...props}
-    />
-  </PopoverPrimitive.Portal>
-));
-PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+export interface PopoverContentProps
+  extends ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> {
+  ref?: Ref<ElementRef<typeof PopoverPrimitive.Content>>;
+}
+
+function PopoverContent({
+  className,
+  align = 'center',
+  sideOffset = 4,
+  ref,
+  ...props
+}: PopoverContentProps) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        ref={ref}
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  );
+}
 
 export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,26 +1,28 @@
-import * as React from 'react';
+import type { ComponentPropsWithoutRef, ElementRef, Ref } from 'react';
 import * as ProgressPrimitive from '@radix-ui/react-progress';
 
 import { cn } from '@/lib/utils';
 
-const Progress = React.forwardRef<
-  React.ElementRef<typeof ProgressPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
->(({ className, value, ...props }, ref) => (
-  <ProgressPrimitive.Root
-    ref={ref}
-    className={cn(
-      'relative h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-800',
-      className
-    )}
-    {...props}
-  >
-    <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-gray-900 dark:bg-gray-100 transition-all"
-      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
-    />
-  </ProgressPrimitive.Root>
-));
-Progress.displayName = ProgressPrimitive.Root.displayName;
+export interface ProgressProps extends ComponentPropsWithoutRef<typeof ProgressPrimitive.Root> {
+  ref?: Ref<ElementRef<typeof ProgressPrimitive.Root>>;
+}
+
+function Progress({ className, value, ref, ...props }: ProgressProps) {
+  return (
+    <ProgressPrimitive.Root
+      ref={ref}
+      className={cn(
+        'relative h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-gray-800',
+        className
+      )}
+      {...props}
+    >
+      <ProgressPrimitive.Indicator
+        className="h-full w-full flex-1 bg-gray-900 dark:bg-gray-100 transition-all"
+        style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      />
+    </ProgressPrimitive.Root>
+  );
+}
 
 export { Progress };

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -1,21 +1,23 @@
-import * as React from 'react';
+import type { ComponentPropsWithoutRef, ElementRef, Ref } from 'react';
 import { Check } from '@/components/ui/icon';
 import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';
 
 import { cn } from '@/lib/utils';
 
-const RadioGroup = React.forwardRef<
-  React.ElementRef<typeof RadioGroupPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
->(({ className, ...props }, ref) => {
-  return <RadioGroupPrimitive.Root className={cn('grid gap-2', className)} {...props} ref={ref} />;
-});
-RadioGroup.displayName = RadioGroupPrimitive.Root.displayName;
+export interface RadioGroupProps extends ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root> {
+  ref?: Ref<ElementRef<typeof RadioGroupPrimitive.Root>>;
+}
 
-const RadioGroupItem = React.forwardRef<
-  React.ElementRef<typeof RadioGroupPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
->(({ className, ...props }, ref) => {
+function RadioGroup({ className, ref, ...props }: RadioGroupProps) {
+  return <RadioGroupPrimitive.Root className={cn('grid gap-2', className)} {...props} ref={ref} />;
+}
+
+export interface RadioGroupItemProps
+  extends ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item> {
+  ref?: Ref<ElementRef<typeof RadioGroupPrimitive.Item>>;
+}
+
+function RadioGroupItem({ className, ref, ...props }: RadioGroupItemProps) {
   return (
     <RadioGroupPrimitive.Item
       ref={ref}
@@ -30,7 +32,6 @@ const RadioGroupItem = React.forwardRef<
       </RadioGroupPrimitive.Indicator>
     </RadioGroupPrimitive.Item>
   );
-});
-RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName;
+}
 
 export { RadioGroup, RadioGroupItem };

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,44 +1,49 @@
-import * as React from 'react';
+import type { ComponentPropsWithoutRef, ElementRef, Ref } from 'react';
 import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
 
 import { cn } from '@/lib/utils';
 
-const ScrollArea = React.forwardRef<
-  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
->(({ className, children, ...props }, ref) => (
-  <ScrollAreaPrimitive.Root
-    ref={ref}
-    className={cn('relative overflow-hidden', className)}
-    {...props}
-  >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
-      {children}
-    </ScrollAreaPrimitive.Viewport>
-    <ScrollBar />
-    <ScrollAreaPrimitive.Corner />
-  </ScrollAreaPrimitive.Root>
-));
-ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
+export interface ScrollAreaProps extends ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> {
+  ref?: Ref<ElementRef<typeof ScrollAreaPrimitive.Root>>;
+}
 
-const ScrollBar = React.forwardRef<
-  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
-  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
->(({ className, orientation = 'vertical', ...props }, ref) => (
-  <ScrollAreaPrimitive.ScrollAreaScrollbar
-    ref={ref}
-    orientation={orientation}
-    className={cn(
-      'flex touch-none select-none transition-colors',
-      orientation === 'vertical' && 'h-full w-2.5 border-l border-l-transparent p-[1px]',
-      orientation === 'horizontal' && 'h-2.5 flex-col border-t border-t-transparent p-[1px]',
-      className
-    )}
-    {...props}
-  >
-    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
-  </ScrollAreaPrimitive.ScrollAreaScrollbar>
-));
-ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName;
+function ScrollArea({ className, children, ref, ...props }: ScrollAreaProps) {
+  return (
+    <ScrollAreaPrimitive.Root
+      ref={ref}
+      className={cn('relative overflow-hidden', className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  );
+}
+
+export interface ScrollBarProps
+  extends ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar> {
+  ref?: Ref<ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>>;
+}
+
+function ScrollBar({ className, orientation = 'vertical', ref, ...props }: ScrollBarProps) {
+  return (
+    <ScrollAreaPrimitive.ScrollAreaScrollbar
+      ref={ref}
+      orientation={orientation}
+      className={cn(
+        'flex touch-none select-none transition-colors',
+        orientation === 'vertical' && 'h-full w-2.5 border-l border-l-transparent p-[1px]',
+        orientation === 'horizontal' && 'h-2.5 flex-col border-t border-t-transparent p-[1px]',
+        className
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+    </ScrollAreaPrimitive.ScrollAreaScrollbar>
+  );
+}
 
 export { ScrollArea, ScrollBar };

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { ComponentPropsWithoutRef, ElementRef, Ref } from 'react';
 import { Check, ChevronDown, ChevronUp, ChevronsUpDown } from '@/components/ui/icon';
 import * as SelectPrimitive from '@radix-ui/react-select';
 
@@ -10,131 +10,156 @@ const SelectGroup = SelectPrimitive.Group;
 
 const SelectValue = SelectPrimitive.Value;
 
-const SelectTrigger = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
-  <SelectPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      'flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
-      className
-    )}
-    {...props}
-  >
-    {children}
-    <SelectPrimitive.Icon asChild>
-      <ChevronsUpDown className="h-4 w-4 opacity-50" />
-    </SelectPrimitive.Icon>
-  </SelectPrimitive.Trigger>
-));
-SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+export interface SelectTriggerProps
+  extends ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> {
+  ref?: Ref<ElementRef<typeof SelectPrimitive.Trigger>>;
+}
 
-const SelectScrollUpButton = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
->(({ className, ...props }, ref) => (
-  <SelectPrimitive.ScrollUpButton
-    ref={ref}
-    className={cn('flex cursor-default items-center justify-center py-1', className)}
-    {...props}
-  >
-    <ChevronUp />
-  </SelectPrimitive.ScrollUpButton>
-));
-SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
-
-const SelectScrollDownButton = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
->(({ className, ...props }, ref) => (
-  <SelectPrimitive.ScrollDownButton
-    ref={ref}
-    className={cn('flex cursor-default items-center justify-center py-1', className)}
-    {...props}
-  >
-    <ChevronDown />
-  </SelectPrimitive.ScrollDownButton>
-));
-SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName;
-
-const SelectContent = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = 'popper', ...props }, ref) => (
-  <SelectPrimitive.Portal>
-    <SelectPrimitive.Content
+function SelectTrigger({ className, children, ref, ...props }: SelectTriggerProps) {
+  return (
+    <SelectPrimitive.Trigger
       ref={ref}
       className={cn(
-        'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-        position === 'popper' &&
-          'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+        'flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
         className
       )}
-      position={position}
       {...props}
     >
-      <SelectScrollUpButton />
-      <SelectPrimitive.Viewport
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronsUpDown className="h-4 w-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+export interface SelectScrollUpButtonProps
+  extends ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton> {
+  ref?: Ref<ElementRef<typeof SelectPrimitive.ScrollUpButton>>;
+}
+
+function SelectScrollUpButton({ className, ref, ...props }: SelectScrollUpButtonProps) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      ref={ref}
+      className={cn('flex cursor-default items-center justify-center py-1', className)}
+      {...props}
+    >
+      <ChevronUp />
+    </SelectPrimitive.ScrollUpButton>
+  );
+}
+
+export interface SelectScrollDownButtonProps
+  extends ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton> {
+  ref?: Ref<ElementRef<typeof SelectPrimitive.ScrollDownButton>>;
+}
+
+function SelectScrollDownButton({ className, ref, ...props }: SelectScrollDownButtonProps) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      ref={ref}
+      className={cn('flex cursor-default items-center justify-center py-1', className)}
+      {...props}
+    >
+      <ChevronDown />
+    </SelectPrimitive.ScrollDownButton>
+  );
+}
+
+export interface SelectContentProps
+  extends ComponentPropsWithoutRef<typeof SelectPrimitive.Content> {
+  ref?: Ref<ElementRef<typeof SelectPrimitive.Content>>;
+}
+
+function SelectContent({
+  className,
+  children,
+  position = 'popper',
+  ref,
+  ...props
+}: SelectContentProps) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        ref={ref}
         className={cn(
-          'p-1',
+          'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
           position === 'popper' &&
-            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]'
+            'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+          className
         )}
+        position={position}
+        {...props}
       >
-        {children}
-      </SelectPrimitive.Viewport>
-      <SelectScrollDownButton />
-    </SelectPrimitive.Content>
-  </SelectPrimitive.Portal>
-));
-SelectContent.displayName = SelectPrimitive.Content.displayName;
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            'p-1',
+            position === 'popper' &&
+              'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]'
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+}
 
-const SelectLabel = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Label>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
->(({ className, ...props }, ref) => (
-  <SelectPrimitive.Label
-    ref={ref}
-    className={cn('px-2 py-1.5 text-sm font-semibold', className)}
-    {...props}
-  />
-));
-SelectLabel.displayName = SelectPrimitive.Label.displayName;
+export interface SelectLabelProps extends ComponentPropsWithoutRef<typeof SelectPrimitive.Label> {
+  ref?: Ref<ElementRef<typeof SelectPrimitive.Label>>;
+}
 
-const SelectItem = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, ...props }, ref) => (
-  <SelectPrimitive.Item
-    ref={ref}
-    className={cn(
-      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
-      className
-    )}
-    {...props}
-  >
-    <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
-      <SelectPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
-      </SelectPrimitive.ItemIndicator>
-    </span>
-    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
-  </SelectPrimitive.Item>
-));
-SelectItem.displayName = SelectPrimitive.Item.displayName;
+function SelectLabel({ className, ref, ...props }: SelectLabelProps) {
+  return (
+    <SelectPrimitive.Label
+      ref={ref}
+      className={cn('px-2 py-1.5 text-sm font-semibold', className)}
+      {...props}
+    />
+  );
+}
 
-const SelectSeparator = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
->(({ className, ...props }, ref) => (
-  <SelectPrimitive.Separator
-    ref={ref}
-    className={cn('-mx-1 my-1 h-px bg-muted', className)}
-    {...props}
-  />
-));
-SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+export interface SelectItemProps extends ComponentPropsWithoutRef<typeof SelectPrimitive.Item> {
+  ref?: Ref<ElementRef<typeof SelectPrimitive.Item>>;
+}
+
+function SelectItem({ className, children, ref, ...props }: SelectItemProps) {
+  return (
+    <SelectPrimitive.Item
+      ref={ref}
+      className={cn(
+        'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        className
+      )}
+      {...props}
+    >
+      <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <Check className="h-4 w-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
+
+export interface SelectSeparatorProps
+  extends ComponentPropsWithoutRef<typeof SelectPrimitive.Separator> {
+  ref?: Ref<ElementRef<typeof SelectPrimitive.Separator>>;
+}
+
+function SelectSeparator({ className, ref, ...props }: SelectSeparatorProps) {
+  return (
+    <SelectPrimitive.Separator
+      ref={ref}
+      className={cn('-mx-1 my-1 h-px bg-muted', className)}
+      {...props}
+    />
+  );
+}
 
 export {
   Select,

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,24 +1,32 @@
-import * as React from 'react';
+import type { ComponentPropsWithoutRef, ElementRef, Ref } from 'react';
 import * as SeparatorPrimitive from '@radix-ui/react-separator';
 
 import { cn } from '@/lib/utils';
 
-const Separator = React.forwardRef<
-  React.ElementRef<typeof SeparatorPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
->(({ className, orientation = 'horizontal', decorative = true, ...props }, ref) => (
-  <SeparatorPrimitive.Root
-    ref={ref}
-    decorative={decorative}
-    orientation={orientation}
-    className={cn(
-      'shrink-0 bg-border',
-      orientation === 'horizontal' ? 'h-[1px] w-full' : 'h-full w-[1px]',
-      className
-    )}
-    {...props}
-  />
-));
-Separator.displayName = SeparatorPrimitive.Root.displayName;
+export interface SeparatorProps extends ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root> {
+  ref?: Ref<ElementRef<typeof SeparatorPrimitive.Root>>;
+}
+
+function Separator({
+  className,
+  orientation = 'horizontal',
+  decorative = true,
+  ref,
+  ...props
+}: SeparatorProps) {
+  return (
+    <SeparatorPrimitive.Root
+      ref={ref}
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        'shrink-0 bg-border',
+        orientation === 'horizontal' ? 'h-[1px] w-full' : 'h-full w-[1px]',
+        className
+      )}
+      {...props}
+    />
+  );
+}
 
 export { Separator };

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { ComponentPropsWithoutRef, ElementRef, HTMLAttributes, Ref } from 'react';
 import { X } from '@/components/ui/icon';
 import * as SheetPrimitive from '@radix-ui/react-dialog';
 import { cva, type VariantProps } from 'class-variance-authority';
@@ -13,20 +13,22 @@ const SheetClose = SheetPrimitive.Close;
 
 const SheetPortal = SheetPrimitive.Portal;
 
-const SheetOverlay = React.forwardRef<
-  React.ElementRef<typeof SheetPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
->(({ className, ...props }, ref) => (
-  <SheetPrimitive.Overlay
-    className={cn(
-      'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-      className
-    )}
-    {...props}
-    ref={ref}
-  />
-));
-SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
+export interface SheetOverlayProps extends ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay> {
+  ref?: Ref<ElementRef<typeof SheetPrimitive.Overlay>>;
+}
+
+function SheetOverlay({ className, ref, ...props }: SheetOverlayProps) {
+  return (
+    <SheetPrimitive.Overlay
+      className={cn(
+        'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+        className
+      )}
+      {...props}
+      ref={ref}
+    />
+  );
+}
 
 const sheetVariants = cva(
   'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out',
@@ -47,63 +49,74 @@ const sheetVariants = cva(
   }
 );
 
-interface SheetContentProps
-  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
-    VariantProps<typeof sheetVariants> {}
+export interface SheetContentProps
+  extends ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {
+  ref?: Ref<ElementRef<typeof SheetPrimitive.Content>>;
+}
 
-const SheetContent = React.forwardRef<
-  React.ElementRef<typeof SheetPrimitive.Content>,
-  SheetContentProps
->(({ side = 'right', className, children, ...props }, ref) => (
-  <SheetPortal>
-    <SheetOverlay />
-    <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </SheetPrimitive.Close>
-      {children}
-    </SheetPrimitive.Content>
-  </SheetPortal>
-));
-SheetContent.displayName = SheetPrimitive.Content.displayName;
+function SheetContent({ side = 'right', className, children, ref, ...props }: SheetContentProps) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        ref={ref}
+        className={cn(sheetVariants({ side }), className)}
+        {...props}
+      >
+        <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </SheetPrimitive.Close>
+        {children}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  );
+}
 
-const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn('flex flex-col space-y-2 text-center sm:text-left', className)} {...props} />
-);
-SheetHeader.displayName = 'SheetHeader';
+function SheetHeader({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={cn('flex flex-col space-y-2 text-center sm:text-left', className)} {...props} />
+  );
+}
 
-const SheetFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
-    {...props}
-  />
-);
-SheetFooter.displayName = 'SheetFooter';
+function SheetFooter({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
+      {...props}
+    />
+  );
+}
 
-const SheetTitle = React.forwardRef<
-  React.ElementRef<typeof SheetPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
->(({ className, ...props }, ref) => (
-  <SheetPrimitive.Title
-    ref={ref}
-    className={cn('text-lg font-semibold text-foreground', className)}
-    {...props}
-  />
-));
-SheetTitle.displayName = SheetPrimitive.Title.displayName;
+export interface SheetTitleProps extends ComponentPropsWithoutRef<typeof SheetPrimitive.Title> {
+  ref?: Ref<ElementRef<typeof SheetPrimitive.Title>>;
+}
 
-const SheetDescription = React.forwardRef<
-  React.ElementRef<typeof SheetPrimitive.Description>,
-  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
->(({ className, ...props }, ref) => (
-  <SheetPrimitive.Description
-    ref={ref}
-    className={cn('text-sm text-muted-foreground', className)}
-    {...props}
-  />
-));
-SheetDescription.displayName = SheetPrimitive.Description.displayName;
+function SheetTitle({ className, ref, ...props }: SheetTitleProps) {
+  return (
+    <SheetPrimitive.Title
+      ref={ref}
+      className={cn('text-lg font-semibold text-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+export interface SheetDescriptionProps
+  extends ComponentPropsWithoutRef<typeof SheetPrimitive.Description> {
+  ref?: Ref<ElementRef<typeof SheetPrimitive.Description>>;
+}
+
+function SheetDescription({ className, ref, ...props }: SheetDescriptionProps) {
+  return (
+    <SheetPrimitive.Description
+      ref={ref}
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
 
 export {
   Sheet,

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,23 +1,25 @@
-import * as React from 'react';
+import type { ComponentPropsWithoutRef, ElementRef, Ref } from 'react';
 import * as SliderPrimitive from '@radix-ui/react-slider';
 
 import { cn } from '@/lib/utils';
 
-const Slider = React.forwardRef<
-  React.ElementRef<typeof SliderPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <SliderPrimitive.Root
-    ref={ref}
-    className={cn('relative flex w-full touch-none select-none items-center', className)}
-    {...props}
-  >
-    <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20">
-      <SliderPrimitive.Range className="absolute h-full bg-primary" />
-    </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50" />
-  </SliderPrimitive.Root>
-));
-Slider.displayName = SliderPrimitive.Root.displayName;
+export interface SliderProps extends ComponentPropsWithoutRef<typeof SliderPrimitive.Root> {
+  ref?: Ref<ElementRef<typeof SliderPrimitive.Root>>;
+}
+
+function Slider({ className, ref, ...props }: SliderProps) {
+  return (
+    <SliderPrimitive.Root
+      ref={ref}
+      className={cn('relative flex w-full touch-none select-none items-center', className)}
+      {...props}
+    >
+      <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-primary/20">
+        <SliderPrimitive.Range className="absolute h-full bg-primary" />
+      </SliderPrimitive.Track>
+      <SliderPrimitive.Thumb className="block h-4 w-4 rounded-full border border-primary/50 bg-background shadow transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50" />
+    </SliderPrimitive.Root>
+  );
+}
 
 export { Slider };

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,27 +1,29 @@
-import * as React from 'react';
+import type { ComponentPropsWithoutRef, ElementRef, Ref } from 'react';
 import * as SwitchPrimitives from '@radix-ui/react-switch';
 
 import { cn } from '@/lib/utils';
 
-const Switch = React.forwardRef<
-  React.ElementRef<typeof SwitchPrimitives.Root>,
-  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
->(({ className, ...props }, ref) => (
-  <SwitchPrimitives.Root
-    className={cn(
-      'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
-      className
-    )}
-    {...props}
-    ref={ref}
-  >
-    <SwitchPrimitives.Thumb
+export interface SwitchProps extends ComponentPropsWithoutRef<typeof SwitchPrimitives.Root> {
+  ref?: Ref<ElementRef<typeof SwitchPrimitives.Root>>;
+}
+
+function Switch({ className, ref, ...props }: SwitchProps) {
+  return (
+    <SwitchPrimitives.Root
       className={cn(
-        'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0'
+        'peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+        className
       )}
-    />
-  </SwitchPrimitives.Root>
-));
-Switch.displayName = SwitchPrimitives.Root.displayName;
+      {...props}
+      ref={ref}
+    >
+      <SwitchPrimitives.Thumb
+        className={cn(
+          'pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0'
+        )}
+      />
+    </SwitchPrimitives.Root>
+  );
+}
 
 export { Switch };

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,46 +1,55 @@
-import * as React from 'react';
+import type { HTMLAttributes, Ref, TdHTMLAttributes, ThHTMLAttributes } from 'react';
 
 import { cn } from '@/lib/utils';
 
-const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
-  ({ className, ...props }, ref) => (
+export interface TableProps extends HTMLAttributes<HTMLTableElement> {
+  ref?: Ref<HTMLTableElement>;
+}
+
+function Table({ className, ref, ...props }: TableProps) {
+  return (
     <div className="relative w-full overflow-auto">
       <table ref={ref} className={cn('w-full caption-bottom text-sm', className)} {...props} />
     </div>
-  )
-);
-Table.displayName = 'Table';
+  );
+}
 
-const TableHeader = React.forwardRef<
-  HTMLTableSectionElement,
-  React.HTMLAttributes<HTMLTableSectionElement>
->(({ className, ...props }, ref) => (
-  <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
-));
-TableHeader.displayName = 'TableHeader';
+export interface TableHeaderProps extends HTMLAttributes<HTMLTableSectionElement> {
+  ref?: Ref<HTMLTableSectionElement>;
+}
 
-const TableBody = React.forwardRef<
-  HTMLTableSectionElement,
-  React.HTMLAttributes<HTMLTableSectionElement>
->(({ className, ...props }, ref) => (
-  <tbody ref={ref} className={cn('[&_tr:last-child]:border-0', className)} {...props} />
-));
-TableBody.displayName = 'TableBody';
+function TableHeader({ className, ref, ...props }: TableHeaderProps) {
+  return <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />;
+}
 
-const TableFooter = React.forwardRef<
-  HTMLTableSectionElement,
-  React.HTMLAttributes<HTMLTableSectionElement>
->(({ className, ...props }, ref) => (
-  <tfoot
-    ref={ref}
-    className={cn('border-t bg-muted/50 font-medium [&>tr]:last:border-b-0', className)}
-    {...props}
-  />
-));
-TableFooter.displayName = 'TableFooter';
+export interface TableBodyProps extends HTMLAttributes<HTMLTableSectionElement> {
+  ref?: Ref<HTMLTableSectionElement>;
+}
 
-const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
-  ({ className, ...props }, ref) => (
+function TableBody({ className, ref, ...props }: TableBodyProps) {
+  return <tbody ref={ref} className={cn('[&_tr:last-child]:border-0', className)} {...props} />;
+}
+
+export interface TableFooterProps extends HTMLAttributes<HTMLTableSectionElement> {
+  ref?: Ref<HTMLTableSectionElement>;
+}
+
+function TableFooter({ className, ref, ...props }: TableFooterProps) {
+  return (
+    <tfoot
+      ref={ref}
+      className={cn('border-t bg-muted/50 font-medium [&>tr]:last:border-b-0', className)}
+      {...props}
+    />
+  );
+}
+
+export interface TableRowProps extends HTMLAttributes<HTMLTableRowElement> {
+  ref?: Ref<HTMLTableRowElement>;
+}
+
+function TableRow({ className, ref, ...props }: TableRowProps) {
+  return (
     <tr
       ref={ref}
       className={cn(
@@ -49,46 +58,51 @@ const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTML
       )}
       {...props}
     />
-  )
-);
-TableRow.displayName = 'TableRow';
+  );
+}
 
-const TableHead = React.forwardRef<
-  HTMLTableCellElement,
-  React.ThHTMLAttributes<HTMLTableCellElement>
->(({ className, ...props }, ref) => (
-  <th
-    ref={ref}
-    className={cn(
-      'h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
-      className
-    )}
-    {...props}
-  />
-));
-TableHead.displayName = 'TableHead';
+export interface TableHeadProps extends ThHTMLAttributes<HTMLTableCellElement> {
+  ref?: Ref<HTMLTableCellElement>;
+}
 
-const TableCell = React.forwardRef<
-  HTMLTableCellElement,
-  React.TdHTMLAttributes<HTMLTableCellElement>
->(({ className, ...props }, ref) => (
-  <td
-    ref={ref}
-    className={cn(
-      'p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
-      className
-    )}
-    {...props}
-  />
-));
-TableCell.displayName = 'TableCell';
+function TableHead({ className, ref, ...props }: TableHeadProps) {
+  return (
+    <th
+      ref={ref}
+      className={cn(
+        'h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        className
+      )}
+      {...props}
+    />
+  );
+}
 
-const TableCaption = React.forwardRef<
-  HTMLTableCaptionElement,
-  React.HTMLAttributes<HTMLTableCaptionElement>
->(({ className, ...props }, ref) => (
-  <caption ref={ref} className={cn('mt-4 text-sm text-muted-foreground', className)} {...props} />
-));
-TableCaption.displayName = 'TableCaption';
+export interface TableCellProps extends TdHTMLAttributes<HTMLTableCellElement> {
+  ref?: Ref<HTMLTableCellElement>;
+}
+
+function TableCell({ className, ref, ...props }: TableCellProps) {
+  return (
+    <td
+      ref={ref}
+      className={cn(
+        'p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export interface TableCaptionProps extends HTMLAttributes<HTMLTableCaptionElement> {
+  ref?: Ref<HTMLTableCaptionElement>;
+}
+
+function TableCaption({ className, ref, ...props }: TableCaptionProps) {
+  return (
+    <caption ref={ref} className={cn('mt-4 text-sm text-muted-foreground', className)} {...props} />
+  );
+}
 
 export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,53 +1,59 @@
-import * as React from 'react';
+import type { ComponentPropsWithoutRef, ElementRef, Ref } from 'react';
 import * as TabsPrimitive from '@radix-ui/react-tabs';
 
 import { cn } from '@/lib/utils';
 
 const Tabs = TabsPrimitive.Root;
 
-const TabsList = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.List
-    ref={ref}
-    className={cn(
-      'inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground',
-      className
-    )}
-    {...props}
-  />
-));
-TabsList.displayName = TabsPrimitive.List.displayName;
+export interface TabsListProps extends ComponentPropsWithoutRef<typeof TabsPrimitive.List> {
+  ref?: Ref<ElementRef<typeof TabsPrimitive.List>>;
+}
 
-const TabsTrigger = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.Trigger
-    ref={ref}
-    className={cn(
-      'inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow',
-      className
-    )}
-    {...props}
-  />
-));
-TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+function TabsList({ className, ref, ...props }: TabsListProps) {
+  return (
+    <TabsPrimitive.List
+      ref={ref}
+      className={cn(
+        'inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground',
+        className
+      )}
+      {...props}
+    />
+  );
+}
 
-const TabsContent = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.Content
-    ref={ref}
-    className={cn(
-      'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-      className
-    )}
-    {...props}
-  />
-));
-TabsContent.displayName = TabsPrimitive.Content.displayName;
+export interface TabsTriggerProps extends ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger> {
+  ref?: Ref<ElementRef<typeof TabsPrimitive.Trigger>>;
+}
+
+function TabsTrigger({ className, ref, ...props }: TabsTriggerProps) {
+  return (
+    <TabsPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        'inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export interface TabsContentProps extends ComponentPropsWithoutRef<typeof TabsPrimitive.Content> {
+  ref?: Ref<ElementRef<typeof TabsPrimitive.Content>>;
+}
+
+function TabsContent({ className, ref, ...props }: TabsContentProps) {
+  return (
+    <TabsPrimitive.Content
+      ref={ref}
+      className={cn(
+        'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        className
+      )}
+      {...props}
+    />
+  );
+}
 
 export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,23 +1,22 @@
-import * as React from 'react';
+import type { TextareaHTMLAttributes, Ref } from 'react';
 
 import { cn } from '@/lib/utils';
 
-export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  ref?: Ref<HTMLTextAreaElement>;
+}
 
-const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ className, ...props }, ref) => {
-    return (
-      <textarea
-        className={cn(
-          'flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
-          className
-        )}
-        ref={ref}
-        {...props}
-      />
-    );
-  }
-);
-Textarea.displayName = 'Textarea';
+function Textarea({ className, ref, ...props }: TextareaProps) {
+  return (
+    <textarea
+      className={cn(
+        'flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+}
 
 export { Textarea };

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { ComponentPropsWithoutRef, ElementRef, Ref } from 'react';
 import { X } from '@/components/ui/icon';
 import * as ToastPrimitives from '@radix-ui/react-toast';
 import { cva, type VariantProps } from 'class-variance-authority';
@@ -7,20 +7,23 @@ import { cn } from '@/lib/utils';
 
 const ToastProvider = ToastPrimitives.Provider;
 
-const ToastViewport = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Viewport>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
->(({ className, ...props }, ref) => (
-  <ToastPrimitives.Viewport
-    ref={ref}
-    className={cn(
-      'fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]',
-      className
-    )}
-    {...props}
-  />
-));
-ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
+export interface ToastViewportProps
+  extends ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport> {
+  ref?: Ref<ElementRef<typeof ToastPrimitives.Viewport>>;
+}
+
+function ToastViewport({ className, ref, ...props }: ToastViewportProps) {
+  return (
+    <ToastPrimitives.Viewport
+      ref={ref}
+      className={cn(
+        'fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]',
+        className
+      )}
+      {...props}
+    />
+  );
+}
 
 const toastVariants = cva(
   'group pointer-events-auto relative flex w-full items-center justify-between space-x-2 overflow-hidden rounded-md border p-4 pr-6 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full',
@@ -38,10 +41,13 @@ const toastVariants = cva(
   }
 );
 
-const Toast = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Root>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> & VariantProps<typeof toastVariants>
->(({ className, variant, ...props }, ref) => {
+export interface ToastProps
+  extends ComponentPropsWithoutRef<typeof ToastPrimitives.Root>,
+    VariantProps<typeof toastVariants> {
+  ref?: Ref<ElementRef<typeof ToastPrimitives.Root>>;
+}
+
+function Toast({ className, variant, ref, ...props }: ToastProps) {
   return (
     <ToastPrimitives.Root
       ref={ref}
@@ -49,72 +55,77 @@ const Toast = React.forwardRef<
       {...props}
     />
   );
-});
-Toast.displayName = ToastPrimitives.Root.displayName;
+}
 
-const ToastAction = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Action>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
->(({ className, ...props }, ref) => (
-  <ToastPrimitives.Action
-    ref={ref}
-    className={cn(
-      'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-secondary focus:outline-none focus:ring-1 focus:ring-ring disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive',
-      className
-    )}
-    {...props}
-  />
-));
-ToastAction.displayName = ToastPrimitives.Action.displayName;
+export interface ToastActionProps extends ComponentPropsWithoutRef<typeof ToastPrimitives.Action> {
+  ref?: Ref<ElementRef<typeof ToastPrimitives.Action>>;
+}
 
-const ToastClose = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Close>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
->(({ className, ...props }, ref) => (
-  <ToastPrimitives.Close
-    ref={ref}
-    className={cn(
-      'absolute right-1 top-1 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-1 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600',
-      className
-    )}
-    toast-close=""
-    {...props}
-  >
-    <X className="h-4 w-4" />
-  </ToastPrimitives.Close>
-));
-ToastClose.displayName = ToastPrimitives.Close.displayName;
+function ToastAction({ className, ref, ...props }: ToastActionProps) {
+  return (
+    <ToastPrimitives.Action
+      ref={ref}
+      className={cn(
+        'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium transition-colors hover:bg-secondary focus:outline-none focus:ring-1 focus:ring-ring disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive',
+        className
+      )}
+      {...props}
+    />
+  );
+}
 
-const ToastTitle = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Title>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
->(({ className, ...props }, ref) => (
-  <ToastPrimitives.Title
-    ref={ref}
-    className={cn('text-sm font-semibold [&+div]:text-xs', className)}
-    {...props}
-  />
-));
-ToastTitle.displayName = ToastPrimitives.Title.displayName;
+export interface ToastCloseProps extends ComponentPropsWithoutRef<typeof ToastPrimitives.Close> {
+  ref?: Ref<ElementRef<typeof ToastPrimitives.Close>>;
+}
 
-const ToastDescription = React.forwardRef<
-  React.ElementRef<typeof ToastPrimitives.Description>,
-  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
->(({ className, ...props }, ref) => (
-  <ToastPrimitives.Description
-    ref={ref}
-    className={cn('text-sm opacity-90', className)}
-    {...props}
-  />
-));
-ToastDescription.displayName = ToastPrimitives.Description.displayName;
+function ToastClose({ className, ref, ...props }: ToastCloseProps) {
+  return (
+    <ToastPrimitives.Close
+      ref={ref}
+      className={cn(
+        'absolute right-1 top-1 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-1 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600',
+        className
+      )}
+      toast-close=""
+      {...props}
+    >
+      <X className="h-4 w-4" />
+    </ToastPrimitives.Close>
+  );
+}
 
-type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>;
+export interface ToastTitleProps extends ComponentPropsWithoutRef<typeof ToastPrimitives.Title> {
+  ref?: Ref<ElementRef<typeof ToastPrimitives.Title>>;
+}
+
+function ToastTitle({ className, ref, ...props }: ToastTitleProps) {
+  return (
+    <ToastPrimitives.Title
+      ref={ref}
+      className={cn('text-sm font-semibold [&+div]:text-xs', className)}
+      {...props}
+    />
+  );
+}
+
+export interface ToastDescriptionProps
+  extends ComponentPropsWithoutRef<typeof ToastPrimitives.Description> {
+  ref?: Ref<ElementRef<typeof ToastPrimitives.Description>>;
+}
+
+function ToastDescription({ className, ref, ...props }: ToastDescriptionProps) {
+  return (
+    <ToastPrimitives.Description
+      ref={ref}
+      className={cn('text-sm opacity-90', className)}
+      {...props}
+    />
+  );
+}
 
 type ToastActionElement = React.ReactElement<typeof ToastAction>;
 
 export {
-  type ToastProps,
   type ToastActionElement,
   ToastProvider,
   ToastViewport,

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { ComponentPropsWithoutRef, ElementRef, Ref } from 'react';
 import * as TogglePrimitive from '@radix-ui/react-toggle';
 import { cva, type VariantProps } from 'class-variance-authority';
 
@@ -26,17 +26,21 @@ const toggleVariants = cva(
   }
 );
 
-const Toggle = React.forwardRef<
-  React.ElementRef<typeof TogglePrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> & VariantProps<typeof toggleVariants>
->(({ className, variant, size, ...props }, ref) => (
-  <TogglePrimitive.Root
-    ref={ref}
-    className={cn(toggleVariants({ variant, size, className }))}
-    {...props}
-  />
-));
+export interface ToggleProps
+  extends ComponentPropsWithoutRef<typeof TogglePrimitive.Root>,
+    VariantProps<typeof toggleVariants> {
+  ref?: Ref<ElementRef<typeof TogglePrimitive.Root>>;
+}
 
-Toggle.displayName = TogglePrimitive.Root.displayName;
+function Toggle({ className, variant, size, ref, ...props }: ToggleProps) {
+  return (
+    <TogglePrimitive.Root
+      ref={ref}
+      className={cn(toggleVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
 
+// eslint-disable-next-line react-refresh/only-export-components -- toggleVariants is intentionally co-located
 export { Toggle, toggleVariants };

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { ComponentPropsWithoutRef, ElementRef, Ref } from 'react';
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 
 import { cn } from '@/lib/utils';
@@ -9,20 +9,23 @@ const Tooltip = TooltipPrimitive.Root;
 
 const TooltipTrigger = TooltipPrimitive.Trigger;
 
-const TooltipContent = React.forwardRef<
-  React.ElementRef<typeof TooltipPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
-  <TooltipPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    className={cn(
-      'z-50 overflow-hidden rounded-md bg-popover px-3 py-1.5 text-xs text-popover-foreground border animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-      className
-    )}
-    {...props}
-  />
-));
-TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+export interface TooltipContentProps
+  extends ComponentPropsWithoutRef<typeof TooltipPrimitive.Content> {
+  ref?: Ref<ElementRef<typeof TooltipPrimitive.Content>>;
+}
+
+function TooltipContent({ className, sideOffset = 4, ref, ...props }: TooltipContentProps) {
+  return (
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 overflow-hidden rounded-md bg-popover px-3 py-1.5 text-xs text-popover-foreground border animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        className
+      )}
+      {...props}
+    />
+  );
+}
 
 export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/src/components/ui/virtualized-list.tsx
+++ b/src/components/ui/virtualized-list.tsx
@@ -1,5 +1,5 @@
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { useRef, forwardRef, ReactNode } from 'react';
+import { useRef, type ReactNode, type Ref } from 'react';
 import { cn } from '@/lib/utils';
 
 interface VirtualizedListProps<T> {
@@ -146,56 +146,63 @@ export function VirtualizedGrid<T>({
   );
 }
 
+export interface WindowVirtualizedListProps<T> extends VirtualizedListProps<T> {
+  ref?: Ref<HTMLDivElement>;
+}
+
 /**
  * Window scroller for full-page virtualization
  * Use when the list takes up the entire viewport
  */
-export const WindowVirtualizedList = forwardRef<HTMLDivElement, VirtualizedListProps<unknown>>(
-  function WindowVirtualizedList(
-    { items, renderItem, itemHeight = 100, overscan = 5, className, estimateSize, gap = 0 },
-    ref
-  ) {
-    const virtualizer = useVirtualizer({
-      count: items.length,
-      getScrollElement: () => (typeof window !== 'undefined' ? document.documentElement : null),
-      estimateSize:
-        estimateSize ||
-        (typeof itemHeight === 'function' ? itemHeight : () => itemHeight as number),
-      overscan,
-    });
+export function WindowVirtualizedList<T>({
+  items,
+  renderItem,
+  itemHeight = 100,
+  overscan = 5,
+  className,
+  estimateSize,
+  gap = 0,
+  ref,
+}: WindowVirtualizedListProps<T>) {
+  const virtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => (typeof window !== 'undefined' ? document.documentElement : null),
+    estimateSize:
+      estimateSize || (typeof itemHeight === 'function' ? itemHeight : () => itemHeight as number),
+    overscan,
+  });
 
-    return (
-      <div ref={ref}>
-        <div
-          style={{
-            height: `${virtualizer.getTotalSize()}px`,
-            width: '100%',
-            position: 'relative',
-          }}
-        >
-          {virtualizer.getVirtualItems().map((virtualItem) => {
-            const item = items[virtualItem.index];
-            return (
-              <div
-                key={virtualItem.key}
-                style={{
-                  position: 'absolute',
-                  top: 0,
-                  left: 0,
-                  width: '100%',
-                  height: `${virtualItem.size}px`,
-                  transform: `translateY(${virtualItem.start + virtualItem.index * gap}px)`,
-                }}
-                className={className}
-              >
-                {renderItem(item, virtualItem.index)}
-              </div>
-            );
-          })}
-        </div>
+  return (
+    <div ref={ref}>
+      <div
+        style={{
+          height: `${virtualizer.getTotalSize()}px`,
+          width: '100%',
+          position: 'relative',
+        }}
+      >
+        {virtualizer.getVirtualItems().map((virtualItem) => {
+          const item = items[virtualItem.index];
+          return (
+            <div
+              key={virtualItem.key}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                height: `${virtualItem.size}px`,
+                transform: `translateY(${virtualItem.start + virtualItem.index * gap}px)`,
+              }}
+              className={className}
+            >
+              {renderItem(item, virtualItem.index)}
+            </div>
+          );
+        })}
       </div>
-    );
-  }
-);
+    </div>
+  );
+}
 
 export default VirtualizedList;


### PR DESCRIPTION
## Summary

- Convert all 42 `forwardRef` usages across UI components to React 19 ref-as-prop pattern
- Add optional `ref` prop to component interfaces using `Ref<T>` type
- Update HOC patterns (withChartErrorBoundary) to pass refs automatically
- Fix TypeScript interface conflicts with type aliases where needed

## Changes

This PR prepares the codebase for React 19 by migrating from `forwardRef` to the new ref-as-prop pattern where refs are passed as regular props. Key updates:

- Named function declarations replace arrow functions with forwardRef
- Interfaces now include `ref?: Ref<HTMLElement>` as optional prop
- Pre-existing lint warnings fixed with eslint-disable comments for co-located utilities

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 1698 tests pass (`npm test`)
- [x] TypeScript types valid
- [x] ESLint passes with zero warnings

Closes #1293

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized component architecture across the UI library by restructuring ref handling patterns while maintaining full backward compatibility. All affected components continue to function identically; this update improves internal code consistency and aligns with React 19 best practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->