### PR TITLE
fix: replace next-themes with internal useTheme hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -134,7 +134,6 @@
         "lightningcss": "^1.30.1",
         "lint-staged": "^16.1.5",
         "msw": "^2.10.4",
-        "next-themes": "^0.4.6",
         "nock": "^14.0.4",
         "playwright": "^1.56.1",
         "postcss": "^8.4.47",
@@ -24660,17 +24659,6 @@
         "sass": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next-themes": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
-      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/@swc/helpers": {

--- a/package.json
+++ b/package.json
@@ -247,7 +247,6 @@
     "lightningcss": "^1.30.1",
     "lint-staged": "^16.1.5",
     "msw": "^2.10.4",
-    "next-themes": "^0.4.6",
     "nock": "^14.0.4",
     "playwright": "^1.56.1",
     "postcss": "^8.4.47",

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,4 +1,4 @@
-import { useTheme } from 'next-themes';
+import { useTheme } from '@/components/common/theming';
 import { Toaster as Sonner } from 'sonner';
 
 type ToasterProps = React.ComponentProps<typeof Sonner>;


### PR DESCRIPTION
## Summary

- Replaces `next-themes` dependency with internal `useTheme` hook from `@/components/common/theming`
- Removes unnecessary `next-themes` package dependency
- Fixes Netlify build failure caused by unresolved `next-themes` import

## Context

The Netlify build was failing after the React 19 upgrade with this error:
```
Rollup failed to resolve import "next-themes" from "src/components/ui/sonner.tsx"
```

Since this project uses its own theme system (not Next.js), the `next-themes` package was unnecessary. The `sonner.tsx` component now uses the existing internal theme hook.

## Test plan

- [x] `npm run build` passes locally
- [ ] Verify Netlify deploy preview builds successfully
- [ ] Verify toast notifications display correctly with theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal theming module implementation. No changes to user-facing functionality or application behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->