### PR TITLE
fix: handle duplicate short link (409) by returning existing link

### DIFF
--- a/netlify/functions/create-short-url.ts
+++ b/netlify/functions/create-short-url.ts
@@ -163,7 +163,7 @@ export const handler: Handler = async (event: HandlerEvent) => {
         });
 
         const existingLinkResponse = await fetch(
-          `${DUB_API_BASE}/links?domain=${domain}&key=${encodeURIComponent(body.key)}`,
+          `${DUB_API_BASE}/links?domain=${encodeURIComponent(domain)}&key=${encodeURIComponent(body.key)}`,
           {
             headers: {
               Authorization: `Bearer ${DUB_API_KEY}`,
@@ -179,7 +179,19 @@ export const handler: Handler = async (event: HandlerEvent) => {
             console.log('Returning existing short URL:', existingLink.shortLink);
             return {
               statusCode: 200,
-              body: JSON.stringify(existingLink),
+              body: JSON.stringify({
+                id: existingLink.id,
+                domain: existingLink.domain,
+                key: existingLink.key,
+                url: existingLink.url,
+                shortLink: existingLink.shortLink,
+                qrCode: existingLink.qrCode ?? '',
+                createdAt: existingLink.createdAt,
+                updatedAt: existingLink.updatedAt,
+                clicks: existingLink.clicks ?? 0,
+                title: existingLink.title ?? null,
+                description: existingLink.description ?? null,
+              }),
               headers: { 'Content-Type': 'application/json' },
             };
           }


### PR DESCRIPTION
## Summary

Fixes an issue where existing short links returned a 409 Conflict error, causing the original URL to be copied instead of the oss.fyi short link.

- Detect 409 Conflict response from Dub API
- Fetch existing link via `GET /links?domain={domain}&key={key}`
- Return existing short link (oss.fyi in production)
- Fallback: construct URL manually if fetch fails

## Test Plan

- [ ] Test on deploy preview with existing short link
- [ ] Verify oss.fyi link is copied on production
- [ ] Verify new links still work correctly

Related: #1305

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Short URL creation now handles duplicate-key conflicts gracefully: if a provided key already exists, the system returns the existing short link (or synthesizes the expected short URL) so creation requests complete successfully without error.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->