### PR TITLE
fix: PR title links in workspace table

### DIFF
--- a/src/components/features/workspace/WorkspacePRsTab.tsx
+++ b/src/components/features/workspace/WorkspacePRsTab.tsx
@@ -75,7 +75,9 @@ export function WorkspacePRsTab({
   }, [error, refresh]);
 
   const handlePullRequestClick = (pr: PullRequest) => {
-    window.open(pr.url, '_blank', 'noopener,noreferrer');
+    // Construct GitHub URL from repository and PR number to ensure it's always valid
+    const githubUrl = `https://github.com/${pr.repository.owner}/${pr.repository.name}/pull/${pr.number}`;
+    window.open(githubUrl, '_blank', 'noopener,noreferrer');
   };
 
   const handleRepositoryClick = (owner: string, name: string) => {

--- a/src/hooks/useWorkspacePRs.ts
+++ b/src/hooks/useWorkspacePRs.ts
@@ -309,7 +309,7 @@ export function useWorkspacePRs({
       labels: [],
       reviewers,
       requested_reviewers: pr.reviewer_data?.requested_reviewers || [],
-      url: pr.html_url,
+      url: pr.html_url || `https://github.com/${repo?.owner || 'unknown'}/${repo?.name || 'unknown'}/pull/${pr.number}`,
     };
   }, []);
 


### PR DESCRIPTION
## Problem

Clicking on a PR title in the workspace table was linking to `repo/null` instead of the actual GitHub PR page. This was causing broken navigation for users trying to access pull requests from the workspace view.

## Root Cause

The issue had two components:

1. **Data Source Issue**: In the `useWorkspacePRs` hook, the `transformPR` function was setting `url: pr.html_url`, but `pr.html_url` could be null from the database, resulting in a null URL.

2. **Click Handler Issue**: In `WorkspacePRsTab.tsx`, the `handlePullRequestClick` function was using `pr.url` directly with `window.open(pr.url, ...)`, which would open `null` as a URL, causing the browser to navigate to `repo/null`.

## Solution

Fixed both issues to ensure PR links always work correctly:

1. **Fixed data transformation**: Updated the `transformPR` function in `useWorkspacePRs.ts` to construct a proper GitHub URL as a fallback when `html_url` is null:
   ```typescript
   url: pr.html_url || `https://github.com/${repo?.owner || 'unknown'}/${repo?.name || 'unknown'}/pull/${pr.number}`,
   ```

2. **Fixed click handler**: Updated the `handlePullRequestClick` function in `WorkspacePRsTab.tsx` to always construct the GitHub URL from the repository data and PR number:
   ```typescript
   const handlePullRequestClick = (pr: PullRequest) => {
     // Construct GitHub URL from repository and PR number to ensure it's always valid
     const githubUrl = `https://github.com/${pr.repository.owner}/${pr.repository.name}/pull/${pr.number}`;
     window.open(githubUrl, '_blank', 'noopener,noreferrer');
   };
   ```

## Testing

- ✅ TypeScript compilation passes
- ✅ All existing workspace-related tests pass
- ✅ Created and verified specific tests for URL construction logic
- ✅ No regressions in existing functionality

## Files Changed

- `src/components/features/workspace/WorkspacePRsTab.tsx` - Fixed click handler to construct GitHub URL
- `src/hooks/useWorkspacePRs.ts` - Added fallback URL construction when html_url is null

This ensures that PR title links will always work correctly, even when the database doesn't have the `html_url` populated, by constructing the GitHub URL from the repository owner, name, and PR number.

@bdougie can click here to [continue refining the PR](https://app.all-hands.dev/conversations/151c69c9c37c451591addeaf3f23adc3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of pull request URL construction to ensure links open correctly when viewing workspace pull requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->