### PR TITLE
fix: enable RLS on public tables missing row-level security (#1363)

### DIFF
--- a/supabase/migrations/20251216000002_enable_rls_missing_tables_1363.sql
+++ b/supabase/migrations/20251216000002_enable_rls_missing_tables_1363.sql
@@ -17,8 +17,13 @@ CREATE POLICY public_read_github_events_cache_2025_10
 CREATE POLICY service_role_manage_github_events_2025_10
   ON public.github_events_cache_2025_10
   FOR ALL
-  TO public
-  USING ((SELECT auth.role()) = 'service_role');
+  TO service_role
+  USING (
+    (SELECT auth.role()) = 'service_role'
+  )
+  WITH CHECK (
+    (SELECT auth.role()) = 'service_role'
+  );
 
 -- 2. contributor_analytics (workspace-scoped analytics)
 -- Pattern: workspace members can read, service_role manages
@@ -50,8 +55,13 @@ CREATE POLICY workspace_read_contributor_analytics
 CREATE POLICY service_role_manage_contributor_analytics
   ON public.contributor_analytics
   FOR ALL
-  TO public
-  USING ((SELECT auth.role()) = 'service_role');
+  TO service_role
+  USING (
+    (SELECT auth.role()) = 'service_role'
+  )
+  WITH CHECK (
+    (SELECT auth.role()) = 'service_role'
+  );
 
 COMMENT ON TABLE public.github_events_cache_2025_10 IS 'October 2025 GitHub events cache partition - RLS enabled';
 COMMENT ON TABLE public.contributor_analytics IS 'Contributor analytics and enrichment data - workspace-scoped RLS';


### PR DESCRIPTION
## Summary

Enables Row Level Security (RLS) on 2 tables flagged by Supabase security advisor.

## Changes

| Table | RLS Policy |
|-------|------------|
| `github_events_cache_2025_10` | Public read, service_role write |
| `contributor_analytics` | Workspace members read, service_role write |

## Policy Details

**github_events_cache_2025_10** (matches other partition tables):
- Public read access (analytics data)
- Service role manages all operations (gh-datapipe)

**contributor_analytics** (workspace-scoped):
- Workspace members/owners can read their workspace analytics
- Public workspaces viewable by anyone
- Service role manages all operations (background jobs)

## Testing

- Migration applied via Supabase MCP
- Security advisor no longer flags these tables

Closes #1363

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database security by implementing row-level access controls on GitHub events cache and contributor analytics tables to ensure proper data isolation and permission management across different user roles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->