### PR TITLE
fix(ux): keep header and search visible during page loading

### DIFF
--- a/src/components/features/repository/repo-view.tsx
+++ b/src/components/features/repository/repo-view.tsx
@@ -35,6 +35,9 @@ import { UnifiedSyncButton } from './unified-sync-button';
 import { AddToWorkspaceButton } from '../workspace/AddToWorkspaceButton';
 import { useAnalytics } from '@/hooks/use-analytics';
 
+// Repository path pattern for parsing owner/repo from various formats (e.g., "owner/repo" or "github.com/owner/repo")
+const REPO_PATH_PATTERN = /(?:github\.com\/)?([^/]+)\/([^/]+)/;
+
 /**
  * Reusable repository search section component
  * Handles search input, example repos, and login requirements
@@ -128,7 +131,7 @@ export default function RepoView() {
   };
 
   const handleSearchInput = (repositoryPath: string) => {
-    const match = repositoryPath.match(/(?:github\.com\/)?([^/]+)\/([^/]+)/);
+    const match = repositoryPath.match(REPO_PATH_PATTERN);
     if (match) {
       const [, newOwner, newRepo] = match;
       handleRepositoryNavigation(`/${newOwner}/${newRepo}`);
@@ -140,7 +143,7 @@ export default function RepoView() {
   };
 
   const handleSelectExample = (repo: string) => {
-    const match = repo.match(/(?:github\.com\/)?([^/]+)\/([^/]+)/);
+    const match = repo.match(REPO_PATH_PATTERN);
     if (match) {
       const [, newOwner, newRepo] = match;
       handleRepositoryNavigation(`/${newOwner}/${newRepo}`);
@@ -216,11 +219,13 @@ export default function RepoView() {
         <section className="grid gap-8">
           <Card>
             <CardContent className="p-8">
-              <div className="space-y-4 animate-pulse">
-                <div className="text-center text-muted-foreground">Loading repository data...</div>
+              <div className="space-y-4 animate-pulse" role="status" aria-live="polite">
+                <div className="text-center text-muted-foreground">
+                  Loading repository data...
+                </div>
                 <div className="space-y-3">
                   {Array.from({ length: 3 }).map((_, i) => (
-                    <Card key={i} className="p-4">
+                    <Card key={i} className="p-4" aria-hidden="true">
                       <div className="space-y-3">
                         <div className="h-4 bg-muted rounded w-3/4"></div>
                         <div className="h-3 bg-muted rounded w-1/2"></div>


### PR DESCRIPTION
## Summary

- Removed full-page skeleton that replaced entire UI during loading
- Header, search bar, and example repos now stay visible during navigation
- Only content area shows loading skeleton

## Problem

When navigating between repo pages (e.g., `/TanStack/table` → `/continuedev/continue`), the entire page would flash to a skeleton, losing the header and search context. This felt jarring despite CLS being 0.

## Solution

| Before | After |
|--------|-------|
| Full-page skeleton replaces everything | Header + search remain stable |
| `showSkeleton` state + timeout logic | Simple state-based rendering |
| 3 second arbitrary timeout | Immediate transition when data ready |

## Changes

- Remove `RepoViewSkeleton` early return during `pending` state
- Add `checking` state handler with header + search + content skeleton
- Remove unused `showSkeleton` state and `RepoViewSkeleton` import

## Test plan

- [ ] Navigate to `/TanStack/table` - header/search should be visible immediately
- [ ] Navigate to `/continuedev/continue` - header/search remain stable
- [ ] Run performance trace - CLS should remain 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New repository search section with example repositories and clearer selection flow.
  * Input parsing so users can enter varied repository paths (e.g., owner/repo) and be routed correctly.
  * Login gating: after a second search while signed out, users are prompted to sign in and then returned to their search.

* **UX Improvements**
  * Consistent placeholder/loading visuals and unified skeleton handling during tracking checks.
  * Clearer handling of not-found and error states for repositories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->