### PR TITLE
fix(netlify): use SUPABASE_URL env var for server-side functions

### DIFF
--- a/netlify/functions/api-repository-status.mts
+++ b/netlify/functions/api-repository-status.mts
@@ -88,8 +88,12 @@ export default async (req: Request, _context: Context) => {
 
   try {
     // Initialize Supabase client
-    const supabaseUrl = process.env.VITE_SUPABASE_URL;
-    const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.VITE_SUPABASE_ANON_KEY;
+    // Use SUPABASE_URL (server-side) first, fall back to VITE_ prefix for local dev
+    const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+    const supabaseKey =
+      process.env.SUPABASE_SERVICE_ROLE_KEY ||
+      process.env.SUPABASE_ANON_KEY ||
+      process.env.VITE_SUPABASE_ANON_KEY;
 
     if (!supabaseUrl || !supabaseKey) {
       console.error('Missing Supabase configuration');

--- a/netlify/functions/api-track-repository.mts
+++ b/netlify/functions/api-track-repository.mts
@@ -305,9 +305,10 @@ export default async (req: Request, context: Context) => {
       const { createClient } = await import('@supabase/supabase-js');
 
       // Get Supabase credentials
-      const supabaseUrl = process.env.VITE_SUPABASE_URL;
+      // Use SUPABASE_URL (server-side) first, fall back to VITE_ prefix for local dev
+      const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
       const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-      const supabaseAnonKey = process.env.VITE_SUPABASE_ANON_KEY;
+      const supabaseAnonKey = process.env.SUPABASE_ANON_KEY || process.env.VITE_SUPABASE_ANON_KEY;
 
       // Use service key if available, otherwise use anon key (for local dev)
       const supabaseKey = supabaseServiceKey || supabaseAnonKey;

--- a/netlify/functions/github-app-installation-status.mts
+++ b/netlify/functions/github-app-installation-status.mts
@@ -1,8 +1,9 @@
 import type { Context } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.VITE_SUPABASE_URL || '';
-const supabaseAnonKey = process.env.VITE_SUPABASE_ANON_KEY || '';
+// Use SUPABASE_URL (server-side) first, fall back to VITE_ prefix for local dev
+const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || '';
+const supabaseAnonKey = process.env.SUPABASE_ANON_KEY || process.env.VITE_SUPABASE_ANON_KEY || '';
 
 export default async (req: Request, _context: Context) => {
   // CORS headers

--- a/netlify/functions/workspace-sync.ts
+++ b/netlify/functions/workspace-sync.ts
@@ -109,8 +109,9 @@ async function verifyWorkspaceAccess(
     return { authorized: false, error: 'Missing authorization token' };
   }
 
-  const supabaseUrl = process.env.VITE_SUPABASE_URL;
-  const supabaseAnonKey = process.env.VITE_SUPABASE_ANON_KEY;
+  // Use SUPABASE_URL (server-side) first, fall back to VITE_ prefix for local dev
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const supabaseAnonKey = process.env.SUPABASE_ANON_KEY || process.env.VITE_SUPABASE_ANON_KEY;
 
   if (!supabaseUrl || !supabaseAnonKey) {
     return { authorized: false, error: 'Supabase configuration missing' };


### PR DESCRIPTION
## Summary

Fixes repository tracking failing with "Missing Supabase configuration keys" error when tracking new repos like `/TanStack/table`.

## Root Cause

Netlify Functions don't have access to `VITE_*` prefixed environment variables in production. The tracking functions were using `VITE_SUPABASE_URL` which returns `undefined` in production.

## Changes

Updated 4 Netlify functions to use `SUPABASE_URL` (server-side convention) first, with `VITE_*` prefix as fallback for local development:

- `api-track-repository.mts`
- `api-repository-status.mts`
- `github-app-installation-status.mts`
- `workspace-sync.ts`

## Test Plan

- [ ] Deploy to preview
- [ ] Track a new repository (e.g., TanStack/table)
- [ ] Verify no "Missing Supabase configuration" errors in Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend credential resolution to prioritize server-side environment variables with fallback support for development environments, improving flexibility across different deployment configurations while maintaining backward compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->