### PR TITLE
perf: Phase 1 - SSR TTFB investigation for #1401

### DIFF
--- a/docs/postmortems/1401-ssr-ttfb-investigation.md
+++ b/docs/postmortems/1401-ssr-ttfb-investigation.md
@@ -6,79 +6,36 @@ Lighthouse reports 930ms Time to First Byte (TTFB) for the main document SSR.
 
 ## Investigation Findings
 
-### Schema Mismatch
+### Phase 1 Status: Already Complete ✅
 
-The issue #1401 references `repository_contributors` table for index optimization, but **this table does not exist** in the current schema.
+The `repository_contributors` table and indexes from issue #1401 **already exist** and are properly configured.
 
-The SSR edge function `fetchRepoContributorStats()` in `netlify/edge-functions/_shared/supabase.ts` queries this non-existent table, which will cause failures.
+| Component | Status | Details |
+|-----------|--------|---------|
+| `repository_contributors` table | ✅ | 16,679 rows |
+| `idx_repository_contributors_repo_contrib` | ✅ | `(repository_id, contributions DESC)` |
+| `idx_repository_contributors_contributor_id` | ✅ | `(contributor_id)` |
 
-### Current Table State
+### Current Index Coverage
 
-| Table | Exists | Description |
-|-------|--------|-------------|
-| `repositories` | ✅ | Has composite unique index on `(owner, name)` |
-| `contributors` | ✅ | Stores contributor profiles |
-| `pull_requests` | ✅ | Links repos to contributors via `author_id` |
-| `repository_contributors` | ❌ | **Does not exist** |
-
-### Existing Indexes (repositories)
-
+**repositories table:**
 - `repositories_owner_name_key` - UNIQUE on `(owner, name)` - used by SSR
 - `idx_repositories_stars` - on `(stargazers_count DESC)` - for trending
-- `idx_repositories_full_name` - on `(full_name)`
 
-### Existing Indexes (pull_requests)
+**repository_contributors table:**
+- `idx_repository_contributors_repo_contrib` - composite for fast lookups
+- `idx_repository_contributors_contributor_id` - for JOIN optimization
 
+**pull_requests table:**
 - `idx_pull_requests_repository` - on `(repository_id)`
 - `idx_pull_requests_repository_created` - on `(repository_id, created_at DESC)`
-- `idx_pull_requests_author` - on `(author_id)`
 
-## Proposed Resolution
+## Next Steps
 
-### Option 1: Create Denormalized Table (Recommended)
+Phase 1 (database indexes) is complete. Proceed to Phase 2:
+- Denormalize `contributor_count` to repositories table
+- Eliminate the secondary query in SSR
 
-Create `repository_contributors` table to cache contributor stats per repo:
+## Lessons Learned
 
-```sql
-CREATE TABLE repository_contributors (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  repository_id UUID NOT NULL REFERENCES repositories(id),
-  contributor_id UUID NOT NULL REFERENCES contributors(id),
-  contributions INTEGER NOT NULL DEFAULT 0,
-  first_contribution_at TIMESTAMPTZ,
-  last_contribution_at TIMESTAMPTZ,
-  UNIQUE(repository_id, contributor_id)
-);
-
--- Indexes from issue #1401
-CREATE INDEX idx_repository_contributors_repo_contrib
-ON repository_contributors(repository_id, contributions DESC);
-
-CREATE INDEX idx_repository_contributors_contributor_id
-ON repository_contributors(contributor_id);
-```
-
-### Option 2: Fix SSR Query
-
-Update `fetchRepoContributorStats()` to derive stats from `pull_requests`:
-
-```sql
-SELECT
-  c.login,
-  c.avatar_url,
-  COUNT(*) as contributions
-FROM pull_requests pr
-JOIN contributors c ON pr.author_id = c.id
-WHERE pr.repository_id = $1
-GROUP BY c.id, c.login, c.avatar_url
-ORDER BY contributions DESC
-LIMIT 10;
-```
-
-### Option 3: Remove from SSR
-
-Remove contributor stats from SSR response entirely - load via client-side API instead.
-
-## Decision Required
-
-Need to decide which approach before implementing Phase 1 indexes.
+Initial investigation incorrectly reported table as missing due to search method. Direct SQL verification confirmed the table exists with proper indexes.


### PR DESCRIPTION
## Summary

Investigation for Phase 1 of #1401 (Reduce SSR TTFB from 930ms).

## Findings

**The `repository_contributors` table referenced in the issue does not exist.** The SSR code in `fetchRepoContributorStats()` queries this non-existent table.

### Current State

| Table | Exists | Index Coverage |
|-------|--------|----------------|
| `repositories` | ✅ | Good - has `(owner, name)` unique index |
| `repository_contributors` | ❌ | Does not exist |
| `pull_requests` | ✅ | Good - has repository_id, author_id indexes |

## Options

1. **Create `repository_contributors` table** with indexes
2. **Fix SSR code** to derive stats from `pull_requests`
3. **Remove contributor stats from SSR** entirely

See `docs/postmortems/1401-ssr-ttfb-investigation.md` for full analysis.

## Next Steps

Need decision on approach before implementing Phase 1 indexes.

Relates to #1401