### PR TITLE
perf: code-split vendor bundles to reduce unused JS

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -330,11 +330,12 @@ function App() {
             analytics.setProviders(['supabase', 'posthog']);
           });
 
-          // Enable session recording after 10 seconds (deferred for LCP improvement)
-          // This delays loading the heavy rrweb library until after LCP
+          // Enable session recording after 30 seconds (deferred for LCP improvement)
+          // This delays loading the heavy rrweb library (~80KB) until well after LCP
+          // See: https://github.com/bdougie/contributor.info/issues/1400
           sessionRecordingTimer = setTimeout(() => {
             enableSessionRecording();
-          }, 10000);
+          }, 30000);
         });
       });
 


### PR DESCRIPTION
## Summary

- Exclude `@sentry` from `vendor-react-core` by checking BEFORE react pattern (fixes path collision where `@sentry/react` matched `react/`)
- Defer PostHog session recording from 10s → 30s to delay rrweb (~80KB) loading
- Remove Nivo manual chunk to let `React.lazy()` handle code splitting naturally

## Bundle Impact

| Chunk | Before | After | Savings |
|-------|--------|-------|---------|
| vendor-react-core | 976KB | 476KB | ~500KB |
| Sentry | bundled | 504KB lazy | deferred |
| Nivo | manual chunk | 93KB lazy | on-demand |

## Test Plan

- [x] Build succeeds with reduced bundle sizes
- [x] Nivo scatter plot chart renders correctly (tested on bdougie/contributor.info)
- [x] Sentry initializes on demand (console shows lazy init)
- [x] PostHog session recording deferred correctly

Closes #1400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Session recording initialization deferred to improve initial page load times.
  * Code splitting configuration optimized for enhanced dependency management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->