### PR TITLE
fix(database): backfill repository_metrics_history previous_value

### DIFF
--- a/supabase/migrations/20251219000001_backfill_metrics_history_previous_value.sql
+++ b/supabase/migrations/20251219000001_backfill_metrics_history_previous_value.sql
@@ -7,31 +7,30 @@
 -- Related: #1418, PR #1419
 
 -- Backfill existing records with correct previous_value using LAG window function
-WITH ordered_metrics AS (
-  SELECT
-    id,
-    repository_id,
-    metric_type,
-    current_value,
-    captured_at,
-    LAG(current_value) OVER (
-      PARTITION BY repository_id, metric_type
-      ORDER BY captured_at
-    ) AS calculated_previous_value
-  FROM repository_metrics_history
-)
-UPDATE repository_metrics_history rmh
-SET previous_value = om.calculated_previous_value
-FROM ordered_metrics om
-WHERE rmh.id = om.id
-  AND rmh.previous_value IS NULL
-  AND om.calculated_previous_value IS NOT NULL;
-
--- Log backfill results
 DO $$
 DECLARE
   updated_count INTEGER;
 BEGIN
+  WITH ordered_metrics AS (
+    SELECT
+      id,
+      repository_id,
+      metric_type,
+      current_value,
+      captured_at,
+      LAG(current_value) OVER (
+        PARTITION BY repository_id, metric_type
+        ORDER BY captured_at
+      ) AS calculated_previous_value
+    FROM repository_metrics_history
+  )
+  UPDATE repository_metrics_history rmh
+  SET previous_value = om.calculated_previous_value
+  FROM ordered_metrics om
+  WHERE rmh.id = om.id
+    AND rmh.previous_value IS NULL
+    AND om.calculated_previous_value IS NOT NULL;
+
   GET DIAGNOSTICS updated_count = ROW_COUNT;
   RAISE NOTICE 'Backfilled % repository_metrics_history records with previous_value', updated_count;
 END $$;


### PR DESCRIPTION
## Summary
- Backfills existing `repository_metrics_history` records with correct `previous_value`
- Uses `LAG()` window function to calculate previous values from each metric series
- Companion to PR #1419 which fixes the function going forward

## Problem
PR #1419 fixes `capture_repository_metrics` to properly set `previous_value`, but 636+ existing records still have `NULL` values. The trending page continues showing 0% because `change_amount` and `change_percentage` (generated columns) depend on `previous_value`.

## Test plan
- [x] Migration syntax validated
- [ ] Apply migration and verify records updated
- [ ] Confirm trending page shows correct percentages

Fixes #1418

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Backfilled missing metric history data to improve data completeness and accuracy of historical tracking. This ensures more reliable metric comparisons and trend analysis across all repositories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->