### PR TITLE
feat(trending): add pagination to trending repositories page

### DIFF
--- a/src/components/features/trending/TrendingPage.tsx
+++ b/src/components/features/trending/TrendingPage.tsx
@@ -421,12 +421,17 @@ export function TrendingPage({
                             onClick={handlePreviousPage}
                             disabled={currentPage === 1}
                             className="gap-1"
+                            aria-label="Go to previous page"
                           >
                             <ChevronLeft className="h-4 w-4" />
                             <span className="hidden sm:inline">Previous</span>
                           </Button>
 
-                          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                          <div
+                            className="flex items-center gap-2 text-sm text-muted-foreground"
+                            aria-live="polite"
+                            aria-atomic="true"
+                          >
                             <span>Page</span>
                             <Badge variant="secondary" className="px-2">
                               {currentPage}
@@ -440,6 +445,7 @@ export function TrendingPage({
                             onClick={handleNextPage}
                             disabled={currentPage === totalPages}
                             className="gap-1"
+                            aria-label="Go to next page"
                           >
                             <span className="hidden sm:inline">Next</span>
                             <ChevronRight className="h-4 w-4" />


### PR DESCRIPTION
## Summary

- Adds client-side pagination to the trending repositories grid
- Displays 12 repositories per page in the grid
- "Hottest Repository" card remains fixed at the top, unaffected by pagination
- Page automatically resets to 1 when filters (language, sort, time period) change
- Responsive Previous/Next controls with page indicator

## Test plan

- [ ] Navigate to /trending with 13+ repos and verify pagination controls appear
- [ ] Click Next/Previous buttons and confirm grid updates correctly
- [ ] Change language or sort filter and verify page resets to 1
- [ ] Verify "Hottest Repository" card stays visible on all pages
- [ ] Test on mobile viewport for responsive button layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added client-side pagination to Trending with Previous/Next controls and page badge indicators.
  * Pagination excludes the top "hottest" repository, which remains featured separately.
  * Pagination resets to page 1 when filters (language, sort, time period) change.
  * Trending page now accepts an optional className prop for custom styling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->