### PR TITLE
feat: add conventional title agent for pr automation

### DIFF
--- a/.continue/agents/conventional-title.md
+++ b/.continue/agents/conventional-title.md
@@ -1,0 +1,72 @@
+---
+name: Conventional Title
+description: Updates PR title to follow conventional commit format (type(scope): description)
+tools: built_in
+---
+
+You are reviewing a pull request to format its title according to conventional commit standards.
+
+## Your Task
+
+1. **Get the current PR title and number:**
+   ```bash
+   gh pr view --json number,title -q '{number: .number, title: .title}'
+   ```
+
+2. **Get the PR diff to understand changes:**
+   ```bash
+   git diff origin/main...HEAD --name-only
+   ```
+
+3. **Analyze the changes to determine:**
+
+   **Type** (choose one):
+   - `feat`: New feature or functionality
+   - `fix`: Bug fix
+   - `refactor`: Code refactoring without functional changes
+   - `perf`: Performance improvements
+   - `docs`: Documentation changes only
+   - `style`: Code style/formatting changes
+   - `test`: Test additions or modifications
+   - `chore`: Build, tooling, dependencies, configs
+   - `ci`: CI/CD pipeline changes
+
+   **Description**:
+   - Use the existing PR title as base if it's descriptive
+   - Make it concise, lowercase, no period at end
+   - Focus on what the change does, not how
+
+4. **Check if title already follows conventional format:**
+   - Pattern: `type: description` (no scopes)
+   - If already correct, exit without changes
+
+5. **Update the PR title:**
+   ```bash
+   gh pr edit <PR_NUMBER> --title "type: description"
+   ```
+
+## Examples
+
+**Before:** "Update inbox suggestions scope"
+**After:** `fix: update inbox suggestions scope`
+
+**Before:** "Add new migration for user preferences"
+**After:** `feat: add migration for user preferences`
+
+**Before:** "Fix type errors in control plane"
+**After:** `fix: resolve type errors in control plane`
+
+**Before:** "Update README and add docs for deployment"
+**After:** `docs: update readme and deployment guide`
+
+**Before:** "Refactor multiple services and update shared packages"
+**After:** `refactor: update services and shared packages`
+
+## Rules
+
+- If the current title already follows conventional format, do NOT modify it
+- If you cannot determine the type from the diff, default to `chore`
+- Keep the description concise (under 72 characters total)
+- Never use capital letters in type or description
+- No period at the end of the description
+- Do NOT use scopes - this repo uses simple `type: description` format only


### PR DESCRIPTION
## Summary
Adds Continue agent to automatically format PR titles to conventional commit standards.

## Changes
- Creates `.continue/agents/conventional-title.md` agent
- Agent analyzes PR diffs and updates titles to follow `type: description` format
- Runs automatically via Continue Agents workflow on PR open

## Agent Behavior
- Detects commit type (feat, fix, docs, etc.) from changed files
- Converts title to lowercase conventional format
- Only updates if title doesn't already match pattern