### PR TITLE
fix: add github token to continue agents workflow

### DIFF
--- a/.github/workflows/run-agents.yml
+++ b/.github/workflows/run-agents.yml
@@ -15,3 +15,4 @@ jobs:
     uses: continuedev/continue/.github/workflows/continue-agents.yml@main
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Enables Continue agents to actually modify PRs by passing GITHUB_TOKEN to the reusable workflow.

## Changes
- Adds `GITHUB_TOKEN` secret to Continue Agents workflow
- Allows conventional-title agent to update PR titles
- Allows deploy-checklist agent to update PR descriptions

## Testing
The conventional-title agent in PR #1487 correctly identified the title should be changed but couldn't update it without this token.