### PR TITLE
Fix the Continue Agents Workflow Startup Failure

### DIFF
--- a/.github/workflows/run-agents.yml
+++ b/.github/workflows/run-agents.yml
@@ -13,4 +13,5 @@ jobs:
       pull-requests: write
       checks: write
     uses: continuedev/continue/.github/workflows/continue-agents.yml@main
-    secrets: inherit
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
Fixes startup failure by using `secrets: inherit` instead of explicitly passing GITHUB_TOKEN.

## Issue
GitHub Actions doesn't allow passing GITHUB_TOKEN as an explicit secret to reusable workflows - it causes a startup_failure.

## Solution
Use `secrets: inherit` to automatically pass all repository secrets including GITHUB_TOKEN and ANTHROPIC_API_KEY.

## Testing
This PR itself will test the fix - the agent should update this non-conventional title to: `fix: continue agents workflow startup failure`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to refine secret handling.

---

**Note:** No user-facing changes in this release.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->