### PR TITLE
Testing Secrets Inherit for Continue Agents

### DIFF
--- a/.github/workflows/run-agents.yml
+++ b/.github/workflows/run-agents.yml
@@ -9,4 +9,6 @@ on:
 jobs:
   agents:
     uses: continuedev/continue/.github/workflows/continue-agents.yml@main
-    secrets: inherit
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This PR tests if `secrets: inherit` allows the Continue agents to access GH_TOKEN properly. The conventional-title agent should update this title to: `test: secrets inherit for continue agents`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for token management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->