### PR TITLE
Testing GitHub Token Access for Continue Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,3 +185,4 @@ The application uses an intelligent hybrid routing system to handle repository s
 ## License
 
 [MIT License](LICENSE)# Force rebuild
+<!-- Testing github.token access -->


### PR DESCRIPTION
This PR tests if using `github.token` allows the Continue conventional-title agent to successfully update the PR title. Expected result: title should be changed to `test: github token access for continue agents`