### PR TITLE
fix: match remote-config-server workflow exactly

### DIFF
--- a/.github/workflows/run-agents.yml
+++ b/.github/workflows/run-agents.yml
@@ -11,4 +11,3 @@ jobs:
     uses: continuedev/continue/.github/workflows/continue-agents.yml@main
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Reverts to the exact same configuration as remote-config-server (only ANTHROPIC_API_KEY secret). 

The workflow configuration is now identical. The remaining difference is likely in **repository settings**:

**Settings → Actions → General → Workflow permissions** should be set to **"Read and write permissions"** for agents to modify PRs.