### PR TITLE
fix(a11y): add descriptive alt text for remaining avatar images

### DIFF
--- a/src/components/features/workspace/AddRepositoryModal.tsx
+++ b/src/components/features/workspace/AddRepositoryModal.tsx
@@ -650,7 +650,7 @@ export function AddRepositoryModal({
                       <div className="flex items-center gap-2">
                         <img
                           src={repo.owner.avatar_url}
-                          alt={repo.owner.login}
+                          alt={`${repo.owner.login}'s avatar`}
                           className="h-5 w-5 rounded"
                         />
                         <span className="font-medium text-sm truncate">{repo.full_name}</span>

--- a/src/components/features/workspace/WorkspaceDiscussionsTable.tsx
+++ b/src/components/features/workspace/WorkspaceDiscussionsTable.tsx
@@ -536,7 +536,7 @@ export function WorkspaceDiscussionsTable({
                               >
                                 <img
                                   src={`https://github.com/${discussion.repositories.owner}.png?size=20`}
-                                  alt={discussion.repositories.owner}
+                                  alt={`${discussion.repositories.owner}'s avatar`}
                                   className="h-4 w-4 rounded"
                                 />
                                 <span>{discussion.repositories.name}</span>

--- a/src/components/features/workspace/WorkspaceSpamTab.tsx
+++ b/src/components/features/workspace/WorkspaceSpamTab.tsx
@@ -279,7 +279,7 @@ export function WorkspaceSpamTab({
                         <div className="flex items-center gap-2">
                           <img
                             src={pr.author.avatar_url || getFallbackAvatar()}
-                            alt={pr.author.username}
+                            alt={`${pr.author.username}'s avatar`}
                             className="h-6 w-6 rounded-full flex-shrink-0"
                           />
                           <span className="text-sm whitespace-nowrap">{pr.author.username}</span>


### PR DESCRIPTION
## Summary

This PR adds descriptive alt text to three additional workspace components that were missing proper accessibility labels for avatar images.

## Changes

### Files Updated:
- **WorkspaceDiscussionsTable.tsx** (line 537): Repository owner avatar now has `alt={\`${owner}'s avatar\`}`
- **WorkspaceSpamTab.tsx** (line 280): PR author avatar now has `alt={\`${username}'s avatar\`}`
- **AddRepositoryModal.tsx** (line 651): Repository owner avatar now has `alt={\`${login}'s avatar\`}`

## WCAG Compliance

**Level:** A
**Success Criterion:** 1.1.1 Non-text Content
**Severity:** High

### User Impact
- **Affected Users:** Screen reader users, users with images disabled
- **Improvement:** Screen readers can now describe avatar images to blind users

## Testing Instructions

1. Navigate to workspace discussions, spam tab, or add repository modal
2. Use a screen reader (NVDA, JAWS, or VoiceOver) to navigate to avatar images
3. Verify the screen reader announces "[username]'s avatar" for each image

## Related Issues

Addresses remaining items from #1559

---

This [task](https://hub.continue.dev/task/52adbbff-eb09-454b-8db3-74f0f49c3a27) was co-authored by bdougieyo and [Continue](https://continue.dev).

---

<!-- continue-task-summary-start -->

## Continue Tasks

| Status | Task | Actions |
|:-------|:-----|:--------|
| 🔄 Running | Supabase security review | [View](https://hub.continue.dev/tasks/fdb86154-8632-4495-be98-4516ad7cc102) |
| 🔄 Running | Supabase Performance Optimizer | [View](https://hub.continue.dev/tasks/e33d5a64-7e18-4cad-a3fa-c7812cea2565) |
| 🔄 Running | Optimize Website Performance | [View](https://hub.continue.dev/tasks/5e95e6fc-c0ac-400b-82a2-c3ca9d70dee7) |
| 🔴 Closed | Accessibility Fix Agent | [PR](https://github.com/bdougie/contributor.info/pull/1565) · [View](https://hub.continue.dev/tasks/2beb63ca-9168-4a87-bd8b-f790b8a64035) |

<sub>Powered by [Continue](https://hub.continue.dev)</sub>

<!-- continue-task-summary-end -->