### PR TITLE
fix(a11y): add aria-label to select-all checkbox in WorkspaceBackfillManager

### DIFF
--- a/src/components/features/workspace/WorkspaceBackfillManager.tsx
+++ b/src/components/features/workspace/WorkspaceBackfillManager.tsx
@@ -332,6 +332,7 @@ export function WorkspaceBackfillManager({
               checked={selectedRepos.size === repositories.length}
               onChange={handleSelectAll}
               className="h-4 w-4 rounded border-gray-300"
+              aria-label="Select all repositories for backfill"
             />
             <span className="text-sm text-muted-foreground">
               {selectedRepos.size} of {repositories.length} selected


### PR DESCRIPTION
## Summary

Adds an accessible label to the select-all checkbox in WorkspaceBackfillManager to ensure screen readers can properly announce the control's purpose.

## Changes

- Added `aria-label="Select all repositories for backfill"` to the select-all checkbox

## Related

- Addresses code review comment on PR #1563

---

This [task](https://hub.continue.dev/task/ef493d68-d212-4154-969f-9034facf345e) was co-authored by bdougieyo and [Continue](https://continue.dev).

---

<!-- continue-task-summary-start -->

## Continue Tasks

| Status | Task | Actions |
|:-------|:-----|:--------|
| 🔄 Running | Supabase security review | [View](https://hub.continue.dev/tasks/e485bef4-5454-48ef-932f-d122bfa832eb) |
| 🔄 Running | Supabase Performance Optimizer | [View](https://hub.continue.dev/tasks/6159f583-3566-4006-bcd5-b0482d32f774) |
| 🔄 Running | Optimize Website Performance | [View](https://hub.continue.dev/tasks/1f1bc918-5b18-4a5f-8f93-8c7975e654a5) |
| 🔴 Closed | Accessibility Fix Agent | [PR](https://github.com/bdougie/contributor.info/pull/1591) · [View](https://hub.continue.dev/tasks/da58c6a5-0a3d-4446-a055-0c5fd5e760c4) |
| 🔄 Running | Update PostHog Dashboards | [View](https://hub.continue.dev/tasks/f879aa93-c31a-4f01-bdde-d4c526079af3) |

<sub>Powered by [Continue](https://hub.continue.dev)</sub>

<!-- continue-task-summary-end -->