### PR TITLE
fix(a11y): use proper label element for select-all checkbox

### DIFF
--- a/src/components/features/workspace/WorkspaceBackfillManager.tsx
+++ b/src/components/features/workspace/WorkspaceBackfillManager.tsx
@@ -332,11 +332,11 @@ export function WorkspaceBackfillManager({
               checked={selectedRepos.size === repositories.length}
               onChange={handleSelectAll}
               className="h-4 w-4 rounded border-gray-300"
-              aria-label="Select all repositories for backfill"
             />
-            <span className="text-sm text-muted-foreground">
+            <label htmlFor="select-all-repos" className="text-sm text-muted-foreground cursor-pointer">
+              <span className="sr-only">Select all repositories for backfill. </span>
               {selectedRepos.size} of {repositories.length} selected
-            </span>
+            </label>
           </div>
 
           <Button


### PR DESCRIPTION
## Summary

Improves the accessibility of the select-all checkbox in WorkspaceBackfillManager by using a proper `<label>` element instead of `aria-label`.

## Changes

- Replace `aria-label` attribute with a `<label>` element using `htmlFor`
- Add `sr-only` span with full context ("Select all repositories for backfill")
- Add `cursor-pointer` class to label for better UX

## Why This Is Better

1. **Larger click target**: The label text ("X of Y selected") becomes clickable
2. **Semantic HTML**: Uses proper label association via `htmlFor` attribute
3. **Screen reader support**: `sr-only` text provides full context while visible text shows status
4. **WCAG compliance**: Meets 1.3.1 (Info and Relationships) and 4.1.2 (Name, Role, Value)

## Testing

- Screen readers will announce: "Select all repositories for backfill. X of Y selected"
- Clicking the label text toggles the checkbox
- Visual appearance unchanged

---

This [task](https://hub.continue.dev/task/da58c6a5-0a3d-4446-a055-0c5fd5e760c4) was co-authored by bdougieyo and [Continue](https://continue.dev).

---

<!-- continue-task-summary-start -->

## Continue Tasks

| Status | Task | Actions |
|:-------|:-----|:--------|
| 🔄 Running | Supabase security review | [View](https://hub.continue.dev/tasks/df22b9d1-9c62-4b93-aced-861473c5e630) |
| 🔄 Running | Supabase Performance Optimizer | [View](https://hub.continue.dev/tasks/86ad67d1-fe0e-43e6-b690-ee0fa1cb9397) |
| 🔄 Running | Optimize Website Performance | [View](https://hub.continue.dev/tasks/37e4443a-b707-43a7-80c3-e3fa6973c8a4) |
| 🔄 Running | Accessibility Fix Agent | [View](https://hub.continue.dev/tasks/a6fbfd7b-6f07-4130-a9da-ec66f4bc7635) |

<sub>Powered by [Continue](https://hub.continue.dev)</sub>

<!-- continue-task-summary-end -->