### PR TITLE
fix: aria-hidden menu contains focusable descendants

### DIFF
--- a/src/components/common/layout/navigation-overlay.tsx
+++ b/src/components/common/layout/navigation-overlay.tsx
@@ -194,7 +194,7 @@ export function NavigationOverlay({ isOpen, onOpenChange, children }: Navigation
             'transition-all duration-300 ease-in-out',
             isOpen ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-4'
           )}
-          aria-hidden={!isOpen}
+          inert={!isOpen ? true : undefined}
         >
           {children}
         </div>


### PR DESCRIPTION
## Summary

- Replace `aria-hidden` with `inert` attribute on mobile nav menu content
- `inert` properly removes all focusable descendants from tab order and accessibility tree when menu is closed

## Problem

Lighthouse flagged: `[aria-hidden="true"]` elements contain focusable descendants. The mobile nav had buttons inside an `aria-hidden` container, making them invisible to screen readers but still tabbable.

## Solution

Use the `inert` attribute which handles this correctly by making the entire subtree non-interactive when closed.

## Test plan

- [ ] Open mobile nav, verify buttons are focusable
- [ ] Close mobile nav, verify Tab key skips menu buttons
- [ ] Run Lighthouse accessibility audit

Fixes #1626

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- continue-task-summary-start -->

## Continue Tasks

| Status | Task | Actions |
|:-------|:-----|:--------|
| 🔄 Running | Optimize Website Performance | [View](https://hub.continue.dev/tasks/314c72de-ec4a-4b06-b242-d5512e1ed465) |
| 🔄 Running | Supabase Performance Optimizer | [View](https://hub.continue.dev/tasks/767bc23f-825e-4b56-a1c8-b6e9b7b85457) |
| 🔄 Running | Supabase security review | [View](https://hub.continue.dev/tasks/680bf894-dd13-4a23-83fb-46622e5dae04) |
| 🔄 Running | Update PostHog Dashboards | [View](https://hub.continue.dev/tasks/388aa9e0-661a-4e97-bfd1-ae844b3208e3) |

<sub>Powered by [Continue](https://hub.continue.dev)</sub>

<!-- continue-task-summary-end -->