### PR TITLE
feat: add CSV export button to spam leaderboard

### DIFF
--- a/src/components/features/spam/spam-leaderboard-page.tsx
+++ b/src/components/features/spam/spam-leaderboard-page.tsx
@@ -7,7 +7,15 @@
 
 import { useState, useEffect, useMemo } from 'react';
 import { Link } from 'react-router';
-import { AlertTriangle, ExternalLink, Trophy, Users, Plus, Lock } from '@/components/ui/icon';
+import {
+  AlertTriangle,
+  ExternalLink,
+  Trophy,
+  Users,
+  Plus,
+  Lock,
+  Download,
+} from '@/components/ui/icon';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -22,6 +30,7 @@ import {
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { getVerifiedSpammers, type SpammerWithLatestPR } from '@/lib/spam/SpamReportService';
+import { exportSpammersToCSV } from '@/lib/utils/csv-export';
 import { useAuth } from '@/hooks/use-auth';
 
 function getRankColor(index: number): string {
@@ -61,6 +70,12 @@ export function SpamLeaderboardPage() {
   const visibleSpammers = isLoggedIn ? spammers : spammers.slice(0, 1);
   const hiddenCount = spammers.length - visibleSpammers.length;
 
+  const handleExportCSV = () => {
+    const date = new Date().toISOString().split('T')[0];
+    const filename = `verified-spammers_${date}.csv`;
+    exportSpammersToCSV(visibleSpammers, filename);
+  };
+
   return (
     <div className="container max-w-4xl mx-auto py-8 px-4">
       <Card>
@@ -76,16 +91,32 @@ export function SpamLeaderboardPage() {
                 PRs.
               </CardDescription>
             </div>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button asChild size="icon">
-                  <Link to="/spam/new" aria-label="Report Spam">
-                    <Plus className="h-4 w-4" />
-                  </Link>
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Report Spam</TooltipContent>
-            </Tooltip>
+            <div className="flex items-center gap-2">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    onClick={handleExportCSV}
+                    variant="outline"
+                    size="icon"
+                    disabled={visibleSpammers.length === 0 || isLoading}
+                    aria-label="Export to CSV"
+                  >
+                    <Download className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Export CSV</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button asChild size="icon">
+                    <Link to="/spam/new" aria-label="Report Spam">
+                      <Plus className="h-4 w-4" />
+                    </Link>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Report Spam</TooltipContent>
+              </Tooltip>
+            </div>
           </div>
         </CardHeader>
 

--- a/src/lib/utils/csv-export.ts
+++ b/src/lib/utils/csv-export.ts
@@ -228,3 +228,56 @@ export function exportDiscussionsToCSV(
   const csv = unparse(csvData);
   downloadCSV(csv, filename);
 }
+
+// ============================================
+// Spammers Export
+// ============================================
+
+export interface SpammerCSVRow {
+  Rank: number;
+  'GitHub Username': string;
+  'GitHub Profile': string;
+  'Spam PR Count': number;
+  'First Reported': string;
+  'Last Reported': string;
+  'Verification Status': string;
+  'Latest Spam PR': string;
+}
+
+/** Minimal interface for spammer data needed for CSV export */
+export interface SpammerExportData {
+  github_login: string;
+  spam_pr_count: number;
+  first_reported_at: string;
+  last_reported_at: string;
+  verification_status: string;
+  latest_pr_url: string | null;
+}
+
+/**
+ * Transforms spammer data into CSV-compatible format
+ */
+export function transformSpammersToCSV(spammers: SpammerExportData[]): SpammerCSVRow[] {
+  return spammers.map((spammer, index) => ({
+    Rank: index + 1,
+    'GitHub Username': spammer.github_login,
+    'GitHub Profile': `https://github.com/${spammer.github_login}`,
+    'Spam PR Count': spammer.spam_pr_count,
+    'First Reported': new Date(spammer.first_reported_at).toLocaleDateString(),
+    'Last Reported': new Date(spammer.last_reported_at).toLocaleDateString(),
+    'Verification Status': spammer.verification_status,
+    'Latest Spam PR': spammer.latest_pr_url || '',
+  }));
+}
+
+/**
+ * Exports spammers to CSV file
+ */
+export function exportSpammersToCSV(
+  spammers: SpammerExportData[],
+  filename = 'verified-spammers.csv'
+): void {
+  const csvData = transformSpammersToCSV(spammers);
+  const csv = unparse(csvData);
+  downloadCSV(csv, filename);
+}


### PR DESCRIPTION
## Summary

- Add CSV export functionality for the spam leaderboard page
- Export includes rank, GitHub username/profile, spam PR count, first/last reported dates, verification status, and latest spam PR URL
- Download button matches existing workspace CSV export patterns (icon-only with tooltip)

## Test plan

- [x] Visit /spam page as authenticated user
- [x] Click the download button (should export all visible spammers)
- [x] Verify CSV contains all expected columns
- [x] Visit /spam page as unauthenticated user
- [x] Verify download only exports the #1 spammer (visible data)

🤖 Generated with [Claude Code](https://claude.ai/code)

---

<!-- continue-task-summary-start -->

## Continue Tasks

| Status | Task | Actions |
|:-------|:-----|:--------|
| 🔄 Running | Optimize Website Performance | [View](https://hub.continue.dev/tasks/bd2c471d-a658-4898-9d9b-7cc1cc6af33c) |
| 🔄 Running | Supabase Performance Optimizer | [View](https://hub.continue.dev/tasks/4b7b0505-fdef-4b97-810c-bc063cc10e77) |
| 🔄 Running | Supabase security review | [View](https://hub.continue.dev/tasks/b58576fb-a59e-4fe1-a1a0-f1b34a4bdfb0) |
| 🔄 Running | Update PostHog Dashboards | [View](https://hub.continue.dev/tasks/212308eb-bf22-48ab-9fee-ef79a03a2fff) |

<sub>Powered by [Continue](https://hub.continue.dev)</sub>

<!-- continue-task-summary-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CSV export functionality to the spam leaderboard, enabling users to download the visible spammers list.
  * New Export CSV button with download icon provides quick access to export data, with intelligent disabling when unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->