### PR TITLE
feat: add clear button to search input

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-12-22 - Standardized Button Loading State
 **Learning:** The codebase had multiple manual implementations of loading spinners inside buttons. Standardizing this into the Button component simplifies usage and ensures consistency.
 **Action:** Use `isLoading` prop on `Button` instead of manually adding `Loader2` icons.
+
+## 2026-01-27 - Clear Button for Search Input
+**Learning:** Adding a clear button to search inputs significantly improves usability on mobile and desktop. When adding icons to input fields that already have other indicators (like loaders), dynamic positioning logic is required to prevent overlap while maintaining consistent padding.
+**Action:** Implemented a clear button in `GitHubSearchInput` with dynamic positioning logic to coexist with the loading spinner.

--- a/src/components/ui/__tests__/github-search-input.test.tsx
+++ b/src/components/ui/__tests__/github-search-input.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GitHubSearchInput } from '../github-search-input';
+
+// Mock dependencies
+const mockSetQuery = vi.fn();
+const mockClearResults = vi.fn();
+
+vi.mock('@/hooks/use-github-search', () => ({
+  useGitHubSearch: () => ({
+    query: '',
+    setQuery: mockSetQuery,
+    results: [],
+    loading: false,
+    error: null,
+    clearResults: mockClearResults,
+  }),
+}));
+
+const mockTrackRepoSearchInitiated = vi.fn();
+const mockTrackRepoSearchQueryEntered = vi.fn();
+const mockTrackSearchResultsViewed = vi.fn();
+const mockTrackRepositorySelectedFromSearch = vi.fn();
+const mockTrackRepoSearchResultClicked = vi.fn();
+const mockTrackRepoSearchCompleted = vi.fn();
+
+vi.mock('@/hooks/use-analytics', () => ({
+  useAnalytics: () => ({
+    trackRepoSearchInitiated: mockTrackRepoSearchInitiated,
+    trackRepoSearchQueryEntered: mockTrackRepoSearchQueryEntered,
+    trackSearchResultsViewed: mockTrackSearchResultsViewed,
+    trackRepositorySelectedFromSearch: mockTrackRepositorySelectedFromSearch,
+    trackRepoSearchResultClicked: mockTrackRepoSearchResultClicked,
+    trackRepoSearchCompleted: mockTrackRepoSearchCompleted,
+  }),
+}));
+
+vi.mock('@/hooks/use-time-formatter', () => ({
+  useTimeFormatter: () => ({
+    formatRelativeTime: () => '2 hours ago',
+  }),
+}));
+
+vi.mock('@/components/ui/organization-avatar', () => ({
+  OrganizationAvatar: (props: any) => <div data-testid="org-avatar" {...props} />,
+}));
+
+// Mock icons
+vi.mock('@/components/ui/icon', () => ({
+  SearchIcon: (props: any) => <span data-testid="search-icon" {...props} />,
+  Star: () => <span />,
+  Clock: () => <span />,
+  GitBranch: () => <span />,
+  Loader2: (props: any) => <span data-testid="loader" {...props} />,
+  X: (props: any) => <span data-testid="x-icon" {...props} />,
+}));
+
+describe('GitHubSearchInput', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders correctly with placeholder', () => {
+    render(<GitHubSearchInput onSearch={() => {}} placeholder="Test placeholder" />);
+    expect(screen.getByPlaceholderText('Test placeholder')).toBeDefined();
+  });
+
+  it('does not show clear button when input is empty', () => {
+    render(<GitHubSearchInput onSearch={() => {}} />);
+    expect(screen.queryByTestId('clear-button')).toBeNull();
+  });
+
+  it('shows clear button when input has text', () => {
+    render(<GitHubSearchInput onSearch={() => {}} value="react" />);
+    expect(screen.getByTestId('clear-button')).toBeDefined();
+  });
+
+  it('clears input when clear button is clicked', () => {
+    render(<GitHubSearchInput onSearch={() => {}} value="react" />);
+    const clearButton = screen.getByTestId('clear-button');
+    const input = screen.getByRole('combobox');
+
+    fireEvent.click(clearButton);
+
+    expect(input.getAttribute('value')).toBe('');
+    expect(screen.queryByTestId('clear-button')).toBeNull();
+  });
+
+  it('updates input value on change', () => {
+      render(<GitHubSearchInput onSearch={() => {}} />);
+      const input = screen.getByRole('combobox');
+      fireEvent.change(input, { target: { value: 'test' } });
+      expect(input.getAttribute('value')).toBe('test');
+  });
+});

--- a/src/components/ui/github-search-input.tsx
+++ b/src/components/ui/github-search-input.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
-import { SearchIcon, Star, Clock, GitBranch, Loader2 } from '@/components/ui/icon';
+import { SearchIcon, Star, Clock, GitBranch, Loader2, X } from '@/components/ui/icon';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
@@ -228,6 +228,13 @@ export function GitHubSearchInput({
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
+  const handleClear = () => {
+    setInputValue('');
+    setSelectedIndex(-1);
+    setShowDropdown(false);
+    inputRef.current?.focus();
+  };
+
   return (
     <div className={cn('relative', className)}>
       <form onSubmit={handleSubmit} className="flex gap-4">
@@ -239,7 +246,10 @@ export function GitHubSearchInput({
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}
             onFocus={handleInputFocus}
-            className="w-full pr-8"
+            className={cn(
+              'w-full pr-8',
+              loading && inputValue.length > 0 && 'pr-14'
+            )}
             autoComplete="off"
             role="combobox"
             aria-autocomplete="list"
@@ -254,9 +264,27 @@ export function GitHubSearchInput({
           />
           {/* Loading spinner in input field */}
           {loading && inputValue.length > 1 && (
-            <div className="absolute right-2 top-1/2 -translate-y-1/2">
+            <div
+              className={cn(
+                'absolute top-1/2 -translate-y-1/2 pointer-events-none',
+                inputValue.length > 0 ? 'right-8' : 'right-2'
+              )}
+            >
               <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
             </div>
+          )}
+
+          {/* Clear button */}
+          {inputValue.length > 0 && (
+            <button
+              type="button"
+              onClick={handleClear}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground focus:outline-none p-1 rounded-sm hover:bg-muted"
+              aria-label="Clear search"
+              data-testid="clear-button"
+            >
+              <X className="h-3 w-3" />
+            </button>
           )}
 
           {/* Dropdown with search results */}


### PR DESCRIPTION
💡 **What:** Added a clear button ('X' icon) to the `GitHubSearchInput` component.
🎯 **Why:** To improve usability by allowing users to quickly clear the search field without manually backspacing.
📸 **Before/After:** The search input now shows an 'X' button when text is present.
♿ **Accessibility:** Added `aria-label="Clear search"` to the button and ensured focus is returned to the input after clearing.

Verified with unit tests and frontend screenshot verification.

---
*PR created automatically by Jules for task [6848803930501315336](https://jules.google.com/task/6848803930501315336) started by @bdougie*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bdougie/contributor.info/pull/1641">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued · ✅ 2 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fbdougie%2Fcontributor.info%2Fpull%2F1641&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clear button to search inputs that appears when text is entered, enabling users to quickly reset the search field without manual deletion.
  * Implemented smart positioning logic for the clear button to prevent overlap with loading spinners and other indicators.

* **Tests**
  * Added comprehensive test suite validating search input functionality and user interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->