### PR TITLE
feat: add clear button to search inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2026-01-27 - Clear Button for Search Input
 **Learning:** Adding a clear button to search inputs significantly improves usability on mobile and desktop. When adding icons to input fields that already have other indicators (like loaders), dynamic positioning logic is required to prevent overlap while maintaining consistent padding.
 **Action:** Implemented a clear button in `GitHubSearchInput` with dynamic positioning logic to coexist with the loading spinner.
+
+## 2026-01-29 - Reusable Search Input Component
+**Learning:** Consolidating search input logic (search icon, input field, clear button) into a single reusable component prevents code duplication and ensures consistent UX (padding, focus states, accessibility) across the application.
+**Action:** Created `SearchInput` component and refactored workspace tables to use it.

--- a/src/components/features/workspace/WorkspaceDiscussionsTable.tsx
+++ b/src/components/features/workspace/WorkspaceDiscussionsTable.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
+import { SearchInput } from '@/components/ui/search-input';
 import { Skeleton } from '@/components/ui/skeleton';
 import { LastUpdated } from '@/components/ui/last-updated';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -22,7 +22,6 @@ import { useWorkspaceDiscussions } from '@/hooks/useWorkspaceDiscussions';
 import {
   MessageSquare,
   CheckCircle2,
-  Search,
   ExternalLink,
   ChevronUp,
   RefreshCw,
@@ -297,19 +296,14 @@ export function WorkspaceDiscussionsTable({
         <div className="mb-6 space-y-4">
           <div className="flex flex-col sm:flex-row gap-4">
             {/* Search */}
-            <div className="flex-1 relative">
-              <Search
-                className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground"
-                aria-hidden="true"
-              />
-              <Input
-                placeholder="Search discussions..."
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                className="pl-10"
-                aria-label="Search discussions"
-              />
-            </div>
+            <SearchInput
+              placeholder="Search discussions..."
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              onClear={() => setSearchTerm('')}
+              wrapperClassName="flex-1"
+              aria-label="Search discussions"
+            />
 
             {/* Sort */}
             <div className="flex gap-2" role="group" aria-label="Sort discussions">

--- a/src/components/features/workspace/WorkspaceIssuesTable.tsx
+++ b/src/components/features/workspace/WorkspaceIssuesTable.tsx
@@ -14,7 +14,7 @@ import {
 } from '@tanstack/react-table';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
+import { SearchInput } from '@/components/ui/search-input';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -30,7 +30,6 @@ import {
   Circle,
   CheckCircle2,
   XCircle,
-  Search,
   ChevronLeft,
   ChevronRight,
   ChevronsUpDown,
@@ -786,16 +785,15 @@ export function WorkspaceIssuesTable({
           <div className="flex items-center justify-between">
             <CardTitle className="hidden sm:block">Issues</CardTitle>
             <div className="flex items-center gap-2 w-full sm:w-auto">
-              <div className="relative flex-1 sm:flex-initial">
-                <Search className="absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
-                <Input
-                  placeholder="Search issues..."
-                  value={globalFilter ?? ''}
-                  onChange={(e) => setGlobalFilter(e.target.value)}
-                  className="pl-10 w-full sm:w-[300px]"
-                  aria-label="Search issues"
-                />
-              </div>
+              <SearchInput
+                placeholder="Search issues..."
+                value={globalFilter ?? ''}
+                onChange={(e) => setGlobalFilter(e.target.value)}
+                onClear={() => setGlobalFilter('')}
+                className="w-full sm:w-[300px]"
+                wrapperClassName="flex-1 sm:flex-initial"
+                aria-label="Search issues"
+              />
               {onExport && (
                 <Tooltip>
                   <TooltipTrigger asChild>

--- a/src/components/features/workspace/WorkspacePullRequestsTable.tsx
+++ b/src/components/features/workspace/WorkspacePullRequestsTable.tsx
@@ -13,7 +13,7 @@ import {
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
+import { SearchInput } from '@/components/ui/search-input';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { InlineCodeDiff } from '@/components/ui/code-diff';
@@ -22,7 +22,6 @@ import {
   GitBranch,
   XCircle,
   GitPullRequestDraft,
-  Search,
   ChevronUp,
   ChevronDown,
   ChevronsUpDown,
@@ -526,19 +525,15 @@ export function WorkspacePullRequestsTable({
           <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
             <CardTitle className="text-lg font-semibold">Pull Requests</CardTitle>
             <div className="flex items-center gap-2 w-full sm:w-auto">
-              <div className="relative flex-1 sm:flex-initial">
-                <Search
-                  className="absolute left-3 top-2.5 h-4 w-4 text-muted-foreground"
-                  aria-hidden="true"
-                />
-                <Input
-                  placeholder="Search pull requests..."
-                  value={globalFilter ?? ''}
-                  onChange={(e) => setGlobalFilter(e.target.value)}
-                  className="pl-10 w-full sm:w-[300px] min-h-[44px]"
-                  aria-label="Search pull requests"
-                />
-              </div>
+              <SearchInput
+                placeholder="Search pull requests..."
+                value={globalFilter ?? ''}
+                onChange={(e) => setGlobalFilter(e.target.value)}
+                onClear={() => setGlobalFilter('')}
+                className="w-full sm:w-[300px] min-h-[44px]"
+                wrapperClassName="flex-1 sm:flex-initial"
+                aria-label="Search pull requests"
+              />
               {onExport && (
                 <Tooltip>
                   <TooltipTrigger asChild>

--- a/src/components/ui/search-input.tsx
+++ b/src/components/ui/search-input.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { Search, X } from '@/components/ui/icon';
+import { Input, type InputProps } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+
+export interface SearchInputProps extends InputProps {
+  onClear?: () => void;
+  wrapperClassName?: string;
+}
+
+const SearchInput = React.forwardRef<HTMLInputElement, SearchInputProps>(
+  ({ className, wrapperClassName, value, onClear, onChange, ...props }, ref) => {
+    const showClearButton = value && String(value).length > 0;
+
+    return (
+      <div className={cn('relative', wrapperClassName)}>
+        <Search
+          className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none"
+          aria-hidden="true"
+        />
+        <Input
+          {...props}
+          value={value}
+          onChange={onChange}
+          className={cn('pl-10 pr-10 w-full', className)}
+          ref={ref}
+        />
+        {showClearButton && onClear && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="absolute right-1 top-1/2 -translate-y-1/2 h-7 w-7 text-muted-foreground hover:text-foreground"
+            onClick={onClear}
+            aria-label="Clear search"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+    );
+  }
+);
+SearchInput.displayName = 'SearchInput';
+
+export { SearchInput };


### PR DESCRIPTION
💡 **What**: Added a reusable `SearchInput` component that includes a "Clear" (X) button and a search icon. Refactored workspace tables to use this component.

🎯 **Why**: Users expect search inputs to have a quick way to clear the text. The previous implementation required manually clearing the text or didn't provide a clear button at all. Consolidating this logic reduces code duplication and ensures consistent styling and behavior.

📸 **Before/After**:
Before: Search inputs were manually constructed `div`s with an `Input` and a `Search` icon. No clear button was available.
After: Search inputs use `<SearchInput />` which includes the search icon and shows a clear button when text is entered.

♿ **Accessibility**:
- The clear button has `aria-label="Clear search"`.
- The search icon is hidden from screen readers (`aria-hidden="true"`).
- Keyboard navigation works as expected (clear button is focusable).

---
*PR created automatically by Jules for task [3464454881146134916](https://jules.google.com/task/3464454881146134916) started by @bdougie*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bdougie/contributor.info/pull/1643">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued · ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fbdougie%2Fcontributor.info%2Fpull%2F1643&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->