### PR TITLE
refactor: standardize loading states for slack buttons

### DIFF
--- a/src/components/features/slack/RepositorySlackButton.tsx
+++ b/src/components/features/slack/RepositorySlackButton.tsx
@@ -66,6 +66,7 @@ export function RepositorySlackButton({ owner, repo }: RepositorySlackButtonProp
   const [loadingChannels, setLoadingChannels] = useState(false);
   const [selectedChannel, setSelectedChannel] = useState<string>('');
   const [isSaving, setIsSaving] = useState(false);
+  const [isDisconnecting, setIsDisconnecting] = useState(false);
 
   // Define callbacks before useEffects that depend on them
   const loadExistingIntegration = useCallback(async () => {
@@ -218,6 +219,7 @@ export function RepositorySlackButton({ owner, repo }: RepositorySlackButtonProp
   async function handleDisconnect() {
     if (!integration) return;
 
+    setIsDisconnecting(true);
     try {
       await deleteUserSlackIntegration(integration.id);
       setIntegration(null);
@@ -235,6 +237,8 @@ export function RepositorySlackButton({ owner, repo }: RepositorySlackButtonProp
         description: 'Failed to disconnect Slack',
         variant: 'destructive',
       });
+    } finally {
+      setIsDisconnecting(false);
     }
   }
 
@@ -297,7 +301,12 @@ export function RepositorySlackButton({ owner, repo }: RepositorySlackButtonProp
                   )}
                 </div>
 
-                <Button variant="destructive" onClick={handleDisconnect} className="w-full">
+                <Button
+                  variant="destructive"
+                  onClick={handleDisconnect}
+                  className="w-full"
+                  isLoading={isDisconnecting}
+                >
                   Disconnect Slack
                 </Button>
               </div>
@@ -334,9 +343,10 @@ export function RepositorySlackButton({ owner, repo }: RepositorySlackButtonProp
                 <Button
                   onClick={handleSaveChannel}
                   disabled={!selectedChannel || isSaving}
+                  isLoading={isSaving}
                   className="w-full"
                 >
-                  {isSaving ? 'Saving...' : 'Enable Notifications'}
+                  Enable Notifications
                 </Button>
               </div>
             )}
@@ -354,15 +364,14 @@ export function RepositorySlackButton({ owner, repo }: RepositorySlackButtonProp
                   </p>
                 </div>
 
-                <Button onClick={handleConnectSlack} disabled={isConnecting} className="w-full">
-                  {isConnecting ? (
-                    'Connecting...'
-                  ) : (
-                    <>
-                      <SlackIcon className="h-4 w-4 mr-2" />
-                      Connect to Slack
-                    </>
-                  )}
+                <Button
+                  onClick={handleConnectSlack}
+                  disabled={isConnecting}
+                  isLoading={isConnecting}
+                  className="w-full"
+                >
+                  <SlackIcon className="h-4 w-4 mr-2" />
+                  Connect to Slack
                 </Button>
               </div>
             )}


### PR DESCRIPTION
This PR standardizes the loading states in the `RepositorySlackButton` component by using the `isLoading` prop provided by the `Button` component. This ensures consistent visual feedback for users during asynchronous operations such as connecting to Slack, enabling notifications, and disconnecting. It also introduces a `isDisconnecting` state to explicitly handle the loading state during the disconnect process.

---
*PR created automatically by Jules for task [16945725777193402618](https://jules.google.com/task/16945725777193402618) started by @bdougie*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bdougie/contributor.info/pull/1651">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued · ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fbdougie%2Fcontributor.info%2Fpull%2F1651&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes & UI Improvements**
  * Enhanced loading state feedback for Slack disconnect operations
  * Consistent visual indicators during connect, disconnect, and notification enable actions
  * Simplified button labels for clearer user interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->