### PR TITLE
refactor: standardize loading state in slack button

### DIFF
--- a/src/components/features/slack/RepositorySlackButton.tsx
+++ b/src/components/features/slack/RepositorySlackButton.tsx
@@ -333,10 +333,11 @@ export function RepositorySlackButton({ owner, repo }: RepositorySlackButtonProp
 
                 <Button
                   onClick={handleSaveChannel}
-                  disabled={!selectedChannel || isSaving}
+                  disabled={!selectedChannel}
+                  isLoading={isSaving}
                   className="w-full"
                 >
-                  {isSaving ? 'Saving...' : 'Enable Notifications'}
+                  Enable Notifications
                 </Button>
               </div>
             )}
@@ -354,15 +355,9 @@ export function RepositorySlackButton({ owner, repo }: RepositorySlackButtonProp
                   </p>
                 </div>
 
-                <Button onClick={handleConnectSlack} disabled={isConnecting} className="w-full">
-                  {isConnecting ? (
-                    'Connecting...'
-                  ) : (
-                    <>
-                      <SlackIcon className="h-4 w-4 mr-2" />
-                      Connect to Slack
-                    </>
-                  )}
+                <Button onClick={handleConnectSlack} isLoading={isConnecting} className="w-full">
+                  {!isConnecting && <SlackIcon className="h-4 w-4 mr-2" />}
+                  Connect to Slack
                 </Button>
               </div>
             )}

--- a/src/components/features/slack/__tests__/RepositorySlackButton.test.tsx
+++ b/src/components/features/slack/__tests__/RepositorySlackButton.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { RepositorySlackButton } from '../RepositorySlackButton';
+import { vi, describe, it, expect } from 'vitest';
+
+// Mock dependencies
+vi.mock('@/hooks/use-github-auth', () => ({
+  useGitHubAuth: () => ({
+    isLoggedIn: true,
+  }),
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({
+    toast: vi.fn(),
+  }),
+}));
+
+vi.mock('react-router', () => ({
+  useSearchParams: () => [new URLSearchParams(), vi.fn()],
+}));
+
+vi.mock('@/services/user-slack-integration.service', () => ({
+  getUserSlackIntegrationForRepo: vi.fn().mockResolvedValue(null),
+  getPendingIntegrationForRepo: vi.fn().mockResolvedValue(null),
+  initiateUserSlackOAuth: vi.fn().mockReturnValue(new Promise(() => {})), // Never resolves to keep loading state
+  getChannelsForUserIntegration: vi.fn(),
+  setUserIntegrationChannel: vi.fn(),
+  deleteUserSlackIntegration: vi.fn(),
+}));
+
+// Mock UI components that might cause issues
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+describe('RepositorySlackButton', () => {
+  const defaultProps = {
+    owner: 'test-owner',
+    repo: 'test-repo',
+  };
+
+  it('renders correctly when logged in', () => {
+    render(<RepositorySlackButton {...defaultProps} />);
+    const button = screen.getByRole('button', { name: /Connect Slack/i });
+    expect(button).toBeInTheDocument();
+  });
+
+  it('shows loading state when connecting', () => {
+    render(<RepositorySlackButton {...defaultProps} />);
+
+    // Open dialog
+    const openButton = screen.getByRole('button', { name: /Connect Slack/i });
+    fireEvent.click(openButton);
+
+    // Find "Connect to Slack" button inside dialog
+    const connectButton = screen.getByRole('button', { name: /Connect to Slack/i });
+
+    // Click connect
+    fireEvent.click(connectButton);
+
+    // Expect button to be disabled (loading state)
+    expect(connectButton).toBeDisabled();
+
+    // Text should still be present
+    expect(screen.getByText('Connect to Slack')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Standardized the loading state implementation in `RepositorySlackButton` by leveraging the `isLoading` prop of the `Button` component. This replaces manual text changes (e.g., "Connecting...") and icon handling with the standard UI pattern, improving consistency and code maintainability. Added a new unit test file `src/components/features/slack/__tests__/RepositorySlackButton.test.tsx` to verify the behavior.

---
*PR created automatically by Jules for task [16763509310158190828](https://jules.google.com/task/16763509310158190828) started by @bdougie*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bdougie/contributor.info/pull/1652">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 2 queued · ✅ 2 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fbdougie%2Fcontributor.info%2Fpull%2F1652&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined loading state handling for Slack connection and notification channel assignment with improved visual feedback during operations.

* **Tests**
  * Added unit test coverage for Slack button component functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->