### PR TITLE
fix: correct SSR column names to match database schema

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -99,7 +99,7 @@
 [[edge_functions]]
   function = "ssr-repo"
   path = "/:owner/:repo"
-  excludedPath = ["/api/*", "/assets/*", "/js/*", "/css/*", "/icons/*", "/login", "/settings", "/admin/*", "/dev/*", "/i/*", "/workspaces/*", "/trending", "/widgets", "/changelog", "/privacy", "/terms", "/billing", "/invitation/*", "/*.js", "/*.css", "/*.json", "/*.png", "/*.svg", "/*.ico"]
+  excludedPath = ["/api/*", "/assets/*", "/js/*", "/css/*", "/icons/*", "/login", "/settings", "/admin/*", "/dev/*", "/i/*", "/workspaces/*", "/trending", "/widgets", "/changelog", "/privacy", "/terms", "/billing", "/invitation/*", "/spam/*", "/*.js", "/*.css", "/*.json", "/*.png", "/*.svg", "/*.ico"]
 
 # SSR for profile pages (user/org)
 # Must come after ssr-repo to avoid intercepting repo routes (though pattern differs)
@@ -107,7 +107,7 @@
 [[edge_functions]]
   function = "ssr-profile"
   path = "/:username"
-  excludedPath = ["/api/*", "/assets/*", "/js/*", "/css/*", "/icons/*", "/login", "/signup", "/settings", "/admin/*", "/dev/*", "/i/*", "/workspaces/*", "/trending", "/widgets", "/changelog", "/privacy", "/terms", "/billing", "/invitation/*", "/*.js", "/*.css", "/*.json", "/*.png", "/*.svg", "/*.ico", "/*.txt", "/*.xml"]
+  excludedPath = ["/api/*", "/assets/*", "/js/*", "/css/*", "/icons/*", "/login", "/signup", "/settings", "/admin/*", "/dev/*", "/i/*", "/workspaces/*", "/trending", "/widgets", "/changelog", "/privacy", "/terms", "/billing", "/invitation/*", "/spam", "/*.js", "/*.css", "/*.json", "/*.png", "/*.svg", "/*.ico", "/*.txt", "/*.xml"]
 
 # Edge Functions for social media meta tags
 # Detects crawler user-agents and injects dynamic og:image URLs

--- a/netlify/edge-functions/_shared/html-template.ts
+++ b/netlify/edge-functions/_shared/html-template.ts
@@ -40,8 +40,8 @@ export interface TrendingPageData {
     name: string;
     full_name: string;
     description: string | null;
-    stargazer_count: number;
-    fork_count: number;
+    stargazers_count: number;
+    forks_count: number;
     language: string | null;
     topics: string[] | null;
     score: number;
@@ -57,8 +57,8 @@ export interface RepoPageData {
     name: string;
     full_name: string;
     description: string | null;
-    stargazer_count: number;
-    fork_count: number;
+    stargazers_count: number;
+    forks_count: number;
     language: string | null;
     topics: string[] | null;
     updated_at: string;
@@ -88,7 +88,7 @@ export interface WorkspacesPageData {
       name: string;
       owner: string;
       language: string | null;
-      stargazer_count: number;
+      stargazers_count: number;
     }>;
   }>;
   stats?: {
@@ -117,7 +117,7 @@ export interface WorkspaceDetailPageData {
       owner: string;
       description: string | null;
       language: string | null;
-      stargazer_count: number;
+      stargazers_count: number;
     }>;
     owner: {
       id: string;

--- a/netlify/edge-functions/_shared/supabase.ts
+++ b/netlify/edge-functions/_shared/supabase.ts
@@ -44,8 +44,8 @@ export interface RepoData {
   name: string;
   full_name: string;
   description: string | null;
-  stargazer_count: number;
-  fork_count: number;
+  stargazers_count: number;
+  forks_count: number;
   language: string | null;
   topics: string[] | null;
   contributor_count?: number;
@@ -77,8 +77,8 @@ export async function fetchRepository(owner: string, repo: string): Promise<Repo
       name,
       full_name,
       description,
-      stargazer_count,
-      fork_count,
+      stargazers_count,
+      forks_count,
       language,
       topics,
       updated_at
@@ -111,15 +111,15 @@ export async function fetchRepositoriesByOwner(owner: string, limit = 25): Promi
       name,
       full_name,
       description,
-      stargazer_count,
-      fork_count,
+      stargazers_count,
+      forks_count,
       language,
       topics,
       updated_at
     `
     )
     .eq('owner', owner)
-    .order('stargazer_count', { ascending: false })
+    .order('stargazers_count', { ascending: false })
     .limit(limit);
 
   if (error) {
@@ -146,14 +146,14 @@ export async function fetchTrendingRepos(limit = 20): Promise<TrendingRepo[]> {
       name,
       full_name,
       description,
-      stargazer_count,
-      fork_count,
+      stargazers_count,
+      forks_count,
       language,
       topics,
       updated_at
     `
     )
-    .order('stargazer_count', { ascending: false })
+    .order('stargazers_count', { ascending: false })
     .limit(limit);
 
   if (error) {
@@ -164,7 +164,7 @@ export async function fetchTrendingRepos(limit = 20): Promise<TrendingRepo[]> {
   // Add score calculation (simplified for edge function performance)
   return (data || []).map((repo) => ({
     ...repo,
-    score: repo.stargazer_count + repo.fork_count * 2,
+    score: repo.stargazers_count + repo.forks_count * 2,
     recent_prs: 0, // Would need additional query
     recent_contributors: 0, // Would need additional query
   })) as TrendingRepo[];
@@ -281,7 +281,7 @@ export interface WorkspacePreview extends WorkspaceData {
     name: string;
     owner: string;
     language: string | null;
-    stargazer_count: number;
+    stargazers_count: number;
   }>;
 }
 
@@ -413,7 +413,7 @@ export async function fetchUserWorkspaces(
             name,
             owner,
             language,
-            stargazer_count
+            stargazers_count
           )
         `
         )
@@ -429,7 +429,7 @@ export async function fetchUserWorkspaces(
             name: string;
             owner: string;
             language: string | null;
-            stargazer_count: number;
+            stargazers_count: number;
           };
           return repo;
         });
@@ -497,7 +497,7 @@ export interface WorkspaceDetailData {
     owner: string;
     description: string | null;
     language: string | null;
-    stargazer_count: number;
+    stargazers_count: number;
   }>;
   owner: {
     id: string;
@@ -562,7 +562,7 @@ export async function fetchWorkspaceBySlug(slug: string): Promise<WorkspaceDetai
             owner,
             description,
             language,
-            stargazer_count
+            stargazers_count
           )
         `
       )
@@ -599,7 +599,7 @@ export async function fetchWorkspaceBySlug(slug: string): Promise<WorkspaceDetai
         owner: string;
         description: string | null;
         language: string | null;
-        stargazer_count: number;
+        stargazers_count: number;
       };
       return repo;
     });

--- a/netlify/edge-functions/social-meta.ts
+++ b/netlify/edge-functions/social-meta.ts
@@ -75,6 +75,7 @@ function getMetaTagsForPath(pathname: string): MetaTags {
     'auth',
     'privacy',
     'terms',
+    'spam',
   ];
 
   // Check if first segment is reserved

--- a/netlify/edge-functions/ssr-profile.ts
+++ b/netlify/edge-functions/ssr-profile.ts
@@ -258,7 +258,7 @@ function renderProfileContent(username: string, repos: RepoData[]): SafeHTML {
                                         points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"
                                       />
                                     </svg>
-                                    ${formatNumber(repo.stargazer_count)}
+                                    ${formatNumber(repo.stargazers_count)}
                                   </span>
                                   <span class="flex items-center gap-1">
                                     <svg
@@ -277,7 +277,7 @@ function renderProfileContent(username: string, repos: RepoData[]): SafeHTML {
                                       <path d="M6 9v1a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V9" />
                                       <path d="M12 12v3" />
                                     </svg>
-                                    ${formatNumber(repo.fork_count)}
+                                    ${formatNumber(repo.forks_count)}
                                   </span>
                                 </div>
                               </div>

--- a/netlify/edge-functions/ssr-repo.ts
+++ b/netlify/edge-functions/ssr-repo.ts
@@ -284,7 +284,7 @@ function renderRepoContent(
                       d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"
                     />
                   </svg>
-                  ${formatNumber(repo.stargazer_count)} stars
+                  ${formatNumber(repo.stargazers_count)} stars
                 </a>
                 <a
                   href="https://github.com/${repo.full_name}/forks"
@@ -297,7 +297,7 @@ function renderRepoContent(
                       d="M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-.878a2.25 2.25 0 1 1 1.5 0v.878a2.25 2.25 0 0 1-2.25 2.25h-1.5v2.128a2.251 2.251 0 1 1-1.5 0V8.5h-1.5A2.25 2.25 0 0 1 3.5 6.25v-.878a2.25 2.25 0 1 1 1.5 0ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Zm6.75.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm-3 8.75a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z"
                     />
                   </svg>
-                  ${formatNumber(repo.fork_count)} forks
+                  ${formatNumber(repo.forks_count)} forks
                 </a>
                 <span class="flex items-center gap-1">
                   <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 16 16">
@@ -485,8 +485,8 @@ async function handler(request: Request, context: Context) {
           name: repoData.name,
           full_name: repoData.full_name,
           description: repoData.description,
-          stargazer_count: repoData.stargazer_count,
-          fork_count: repoData.fork_count,
+          stargazers_count: repoData.stargazers_count,
+          forks_count: repoData.forks_count,
           language: repoData.language,
           topics: repoData.topics,
           updated_at: repoData.updated_at,

--- a/netlify/edge-functions/ssr-trending.ts
+++ b/netlify/edge-functions/ssr-trending.ts
@@ -84,7 +84,7 @@ function renderRepoCard(repo: TrendingRepo, isHottest = false): SafeHTML {
                 d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"
               />
             </svg>
-            ${formatNumber(repo.stargazer_count)}
+            ${formatNumber(repo.stargazers_count)}
           </span>
           <span class="flex items-center gap-1">
             <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 16 16">
@@ -92,7 +92,7 @@ function renderRepoCard(repo: TrendingRepo, isHottest = false): SafeHTML {
                 d="M5 5.372v.878c0 .414.336.75.75.75h4.5a.75.75 0 0 0 .75-.75v-.878a2.25 2.25 0 1 1 1.5 0v.878a2.25 2.25 0 0 1-2.25 2.25h-1.5v2.128a2.251 2.251 0 1 1-1.5 0V8.5h-1.5A2.25 2.25 0 0 1 3.5 6.25v-.878a2.25 2.25 0 1 1 1.5 0ZM5 3.25a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Zm6.75.75a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm-3 8.75a.75.75 0 1 0-1.5 0 .75.75 0 0 0 1.5 0Z"
               />
             </svg>
-            ${formatNumber(repo.fork_count)}
+            ${formatNumber(repo.forks_count)}
           </span>
         </div>
       </div>
@@ -265,8 +265,8 @@ async function handler(request: Request, context: Context) {
           name: r.name,
           full_name: r.full_name,
           description: r.description,
-          stargazer_count: r.stargazer_count,
-          fork_count: r.fork_count,
+          stargazers_count: r.stargazers_count,
+          forks_count: r.forks_count,
           language: r.language,
           topics: r.topics,
           score: r.score,

--- a/netlify/edge-functions/ssr-workspace-detail.ts
+++ b/netlify/edge-functions/ssr-workspace-detail.ts
@@ -243,7 +243,7 @@ function renderWorkspaceContent(workspace: WorkspaceDetailData): SafeHTML {
                                   d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"
                                 />
                               </svg>
-                              ${formatNumber(repo.stargazer_count)}
+                              ${formatNumber(repo.stargazers_count)}
                             </span>
                             <span class="text-muted-foreground/50">${repo.owner}</span>
                           </div>


### PR DESCRIPTION
## Summary
- Edge functions were querying `stargazer_count` and `fork_count` but the actual database columns are `stargazers_count` and `forks_count`
- This caused all SSR pages (repo, profile, trending, workspaces) to fail silently, rendering only the nav shell with no content
- Also adds `/spam` route exclusions to SSR edge function paths in `netlify.toml`

## Files Changed
- `netlify/edge-functions/_shared/supabase.ts` — fixed column names in all queries and interfaces
- `netlify/edge-functions/_shared/html-template.ts` — fixed type interfaces
- `netlify/edge-functions/ssr-repo.ts` — fixed column references in template
- `netlify/edge-functions/ssr-profile.ts` — fixed column references in template
- `netlify/edge-functions/ssr-trending.ts` — fixed column references in template
- `netlify/edge-functions/ssr-workspace-detail.ts` — fixed column references in template
- `netlify/edge-functions/social-meta.ts` — added spam to reserved paths
- `netlify.toml` — added spam route exclusions

## Test plan
- [ ] Verify SSR renders full content on repo pages (e.g. `/open-sauced/pizza-verse`)
- [ ] Verify profile pages render repository cards with star/fork counts
- [ ] Verify trending page renders with correct stats
- [ ] Verify workspace detail pages render repository previews

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bdougie/contributor.info/pull/1655" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 5 failed — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fbdougie%2Fcontributor.info%2Fpull%2F1655&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized repository statistics field naming for consistency across data interfaces, queries, and server-side rendering components.
  * Updated related data references to align with new naming conventions.

* **Chores**
  * Added spam path exclusions and enhanced reserved path handling for improved URL routing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->