### PR TITLE
chore: replace argo-cd with papercomputeco/tapes in examples

### DIFF
--- a/netlify/edge-functions/ssr-home.ts
+++ b/netlify/edge-functions/ssr-home.ts
@@ -28,8 +28,7 @@ import { shouldSSR, fallbackToSPA } from './_shared/ssr-utils.ts';
  */
 const EXAMPLE_REPOS = [
   'continuedev/continue',
-  'argoproj/argo-cd',
-  'TanStack/table',
+  'papercomputeco/tapes',
   'vitejs/vite',
   'etcd-io/etcd',
   'better-auth/better-auth',

--- a/src/components/features/repository/example-repos.tsx
+++ b/src/components/features/repository/example-repos.tsx
@@ -9,9 +9,7 @@ export function ExampleRepos({ onSelect }: ExampleReposProps) {
   const examples = [
     // Medium repositories - ideal for demos
     'continuedev/continue', // Medium: AI code assistant (TypeScript) - primary demo
-    'argoproj/argo-cd', // Medium: DevOps tool (Go) - shows enterprise usage
-    'TanStack/table', // Medium: Headless UI (TypeScript) - Data Grid
-
+    'papercomputeco/tapes', // Medium: tape computing (Rust) - shows hardware usage
     // Large repositories - performance examples
     'vitejs/vite', // Large: Frontend tooling (TypeScript) - very popular
     'etcd-io/etcd', // Large: Distributed systems (Go) - infrastructure

--- a/src/components/skeletons/layouts/repo-view-skeleton.tsx
+++ b/src/components/skeletons/layouts/repo-view-skeleton.tsx
@@ -51,8 +51,7 @@ function StaticBreadcrumbs() {
 function StaticSearchSection() {
   const exampleRepos = [
     'continuedev/continue',
-    'argoproj/argo-cd',
-    'TanStack/table',
+    'papercomputeco/tapes',
     'vitejs/vite',
     'etcd-io/etcd',
     'better-auth/better-auth',


### PR DESCRIPTION
## Summary
- Replace `argoproj/argo-cd` with `papercomputeco/tapes` in the "Popular examples" buttons on the home page
- Remove `TanStack/table` from the example list

## Changed Files
- `src/components/features/repository/example-repos.tsx`
- `src/components/skeletons/layouts/repo-view-skeleton.tsx`
- `netlify/edge-functions/ssr-home.ts`

## Test plan
- [ ] Verify home page renders the updated example buttons
- [ ] Verify clicking `papercomputeco/tapes` navigates correctly
- [ ] Verify SSR home page matches client-side examples
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bdougie/contributor.info/pull/1664" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 5 failed · ▶️ 2 not started — [View all](https://hub.continue.dev/inbox/pr/bdougie/contributor.info/1664?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated example repositories displayed throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->