### PR TITLE
perf: optimize progressive loading to skip redundant fetches on cache hit

### DIFF
--- a/src/hooks/use-progressive-repo-data.ts
+++ b/src/hooks/use-progressive-repo-data.ts
@@ -95,15 +95,19 @@ export function useProgressiveRepoData(
 
     // Update stage progress (inline function to avoid dependency issues)
     const updateStage = (stage: LoadingStage, updates: Partial<ProgressiveDataState>) => {
-      setData((prev) => ({
-        ...prev,
-        ...updates,
-        currentStage: stage,
-        stageProgress: {
-          ...prev.stageProgress,
-          [stage]: true,
-        },
-      }));
+      setData((prev) => {
+        // Correctly merge stageProgress if it exists in updates (e.g. from cache)
+        const newStageProgress = updates.stageProgress
+          ? { ...prev.stageProgress, ...updates.stageProgress, [stage]: true }
+          : { ...prev.stageProgress, [stage]: true };
+
+        return {
+          ...prev,
+          ...updates,
+          currentStage: stage,
+          stageProgress: newStageProgress,
+        };
+      });
     };
 
     // Stage 1: Load critical data (< 500ms target) - inline function
@@ -115,8 +119,14 @@ export function useProgressiveRepoData(
           const cached = progressiveCache[cacheKey];
 
           if (cached && Date.now() - cached.timestamp < CACHE_DURATION) {
-            updateStage('critical', cached.data);
-            return cached.data.basicInfo;
+            // Restore the full state from cache, including currentStage
+            updateStage(cached.data.currentStage, cached.data);
+            // Return cached data info to allow skipping subsequent stages
+            return {
+              basicInfo: cached.data.basicInfo,
+              fromCache: true,
+              cachedStage: cached.data.currentStage,
+            };
           }
 
           // Fetch minimal data for above-the-fold content with retry
@@ -165,7 +175,7 @@ export function useProgressiveRepoData(
 
           updateStage('critical', { basicInfo });
 
-          return basicInfo;
+          return { basicInfo, fromCache: false };
         } catch (error) {
           span?.setStatus('error');
           console.error('Failed to load critical data:', error);
@@ -328,9 +338,51 @@ export function useProgressiveRepoData(
         });
 
         // Stage 1: Critical data (immediate)
-        await loadCriticalData(owner, repo);
+        const criticalResult = await loadCriticalData(owner, repo);
 
         if (abortController.signal.aborted) return;
+
+        // Optimization: If we loaded complete data from cache, we can skip the rest
+        if (criticalResult?.fromCache) {
+          // If cached data was at least 'full' (or better), we have stats and lottery factor
+          // So we can skip loadFullData
+          if (
+            criticalResult.cachedStage === 'full' ||
+            criticalResult.cachedStage === 'enhancement' ||
+            criticalResult.cachedStage === 'complete'
+          ) {
+            // If cached data was complete, we can skip everything
+            if (criticalResult.cachedStage === 'complete') {
+              return;
+            }
+
+            // If we are here, we might need enhancement data (direct commits)
+            // But currently enhancement data is not fully cached in progressiveCache (only stats are)
+            // So we should proceed to loadEnhancementData unless we are sure.
+
+            // However, we CAN skip loadFullData which is the heavy lifting
+            if (abortController.signal.aborted) return;
+
+            // Skip Stage 2 and go to Stage 3
+            if ('requestIdleCallback' in window) {
+              requestIdleCallback(
+                () => {
+                  if (!abortController.signal.aborted) {
+                    loadEnhancementData(owner, repo);
+                  }
+                },
+                { timeout: 5000 }
+              );
+            } else {
+              setTimeout(() => {
+                if (!abortController.signal.aborted) {
+                  loadEnhancementData(owner, repo);
+                }
+              }, 2000);
+            }
+            return;
+          }
+        }
 
         // Stage 2: Full data (after critical)
         await loadFullData(owner, repo);


### PR DESCRIPTION
💡 What: Optimized `useProgressiveRepoData` hook to check for cached "full" or "complete" data during the critical loading phase. If found, it restores the full state and skips subsequent redundant API calls.

🎯 Why: Previously, even if data was cached (e.g. from a recent visit), the hook would reload the critical data from cache but still proceed to re-fetch the full data and re-calculate lottery factors, wasting bandwidth and CPU.

📊 Impact:
- Reduces network requests by 1 large API call (`fetchPRDataSmart`) and 1 DB call per revisit within 5 minutes.
- Reduces CPU usage by skipping `calculateLotteryFactor`.
- Improves perceived performance when navigating back to a repository.

🔬 Measurement:
- Verified that `loadFullData` is skipped when `loadCriticalData` returns a full cache hit.
- Verified that `stageProgress` and `currentStage` are correctly restored (via code review fix).
- `npm run lint`, `npm run typecheck`, and `npm test` passed.

---
*PR created automatically by Jules for task [15773193461700583406](https://jules.google.com/task/15773193461700583406) started by @bdougie*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bdougie/contributor.info/pull/1666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 6 failed · ▶️ 2 not started — [View all](https://hub.continue.dev/inbox/pr/bdougie/contributor.info/1666?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->