### PR TITLE
feat: enrich RAG context with body, author, and timestamps

### DIFF
--- a/netlify/functions/chat.mts
+++ b/netlify/functions/chat.mts
@@ -60,6 +60,23 @@ interface RAGItem {
   url: string;
   state: string;
   repository_name: string;
+  body_preview: string | null;
+  created_at: string | null;
+  author_login: string | null;
+}
+
+function formatRelativeTime(isoDate: string): string {
+  const diffMs = Date.now() - new Date(isoDate).getTime();
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  const years = Math.floor(months / 12);
+  return `${years}y ago`;
 }
 
 interface EmbedQueryResponse {
@@ -148,7 +165,13 @@ async function retrieveRAGContext(
 
   const lines = relevant.map((item) => {
     const typeLabel = item.item_type === 'pull_request' ? 'PR' : item.item_type;
-    return `- [${typeLabel} #${item.number}](${item.url}): ${item.title} (${item.state}, relevance: ${Math.round(item.similarity * 100)}%)`;
+    const author = item.author_login ? ` by @${item.author_login}` : '';
+    const timeAgo = item.created_at ? `, ${formatRelativeTime(item.created_at)}` : '';
+    let line = `- [${typeLabel} #${item.number}](${item.url})${author} (${item.state}${timeAgo}): ${item.title}`;
+    if (item.body_preview) {
+      line += `\n  > ${item.body_preview.replace(/\n/g, ' ')}`;
+    }
+    return line;
   });
 
   return `\n\n## Related Repository Activity (from semantic search)\nThe following items from this repository are semantically related to the user's question:\n${lines.join('\n')}\n\nUse this context to provide more informed answers when relevant. Cite specific PRs, issues, or discussions when they help answer the question.`;

--- a/supabase/migrations/20260219000000_enrich_rag_context.sql
+++ b/supabase/migrations/20260219000000_enrich_rag_context.sql
@@ -1,0 +1,98 @@
+-- Enrich RAG context: add body_preview, created_at, and author_login to
+-- find_similar_items_cross_entity so the LLM can see content, recency, and authorship.
+
+-- Must drop first because the return type changed (new columns added)
+DROP FUNCTION IF EXISTS find_similar_items_cross_entity(VECTOR, UUID[], INTEGER, TEXT, TEXT);
+
+CREATE OR REPLACE FUNCTION find_similar_items_cross_entity(
+    query_embedding VECTOR(384),
+    repo_ids UUID[],
+    match_count INTEGER DEFAULT 5,
+    exclude_item_type TEXT DEFAULT NULL,
+    exclude_item_id TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+    item_type TEXT,
+    id TEXT,
+    title TEXT,
+    number INTEGER,
+    similarity FLOAT,
+    url TEXT,
+    state TEXT,
+    repository_name TEXT,
+    body_preview TEXT,
+    created_at TIMESTAMPTZ,
+    author_login TEXT
+) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        'issue'::TEXT as item_type,
+        i.id::TEXT as id,
+        i.title,
+        i.number,
+        (1 - (i.embedding <=> query_embedding))::FLOAT as similarity,
+        CONCAT('https://github.com/', r.full_name, '/issues/', i.number) as url,
+        i.state,
+        r.full_name as repository_name,
+        LEFT(i.body, 300) as body_preview,
+        i.created_at,
+        c.username as author_login
+    FROM issues i
+    JOIN repositories r ON i.repository_id = r.id
+    LEFT JOIN contributors c ON i.author_id = c.id
+    WHERE i.repository_id = ANY(repo_ids)
+    AND i.embedding IS NOT NULL
+    AND NOT (exclude_item_type IS NOT DISTINCT FROM 'issue' AND exclude_item_id IS NOT DISTINCT FROM i.id::TEXT)
+
+    UNION ALL
+
+    SELECT
+        'pull_request'::TEXT as item_type,
+        pr.id::TEXT as id,
+        pr.title,
+        pr.number,
+        (1 - (pr.embedding <=> query_embedding))::FLOAT as similarity,
+        CONCAT('https://github.com/', r.full_name, '/pull/', pr.number) as url,
+        pr.state,
+        r.full_name as repository_name,
+        LEFT(pr.body, 300) as body_preview,
+        pr.created_at,
+        c.username as author_login
+    FROM pull_requests pr
+    JOIN repositories r ON pr.repository_id = r.id
+    LEFT JOIN contributors c ON pr.author_id = c.id
+    WHERE pr.repository_id = ANY(repo_ids)
+    AND pr.embedding IS NOT NULL
+    AND NOT (exclude_item_type IS NOT DISTINCT FROM 'pull_request' AND exclude_item_id IS NOT DISTINCT FROM pr.id::TEXT)
+
+    UNION ALL
+
+    SELECT
+        'discussion'::TEXT as item_type,
+        d.id as id,
+        d.title,
+        d.number,
+        (1 - (d.embedding <=> query_embedding))::FLOAT as similarity,
+        d.url,
+        CASE WHEN d.is_answered THEN 'answered' ELSE 'open' END as state,
+        r.full_name as repository_name,
+        LEFT(d.body, 300) as body_preview,
+        d.created_at,
+        d.author_login as author_login
+    FROM discussions d
+    JOIN repositories r ON d.repository_id = r.id
+    WHERE d.repository_id = ANY(repo_ids)
+    AND d.embedding IS NOT NULL
+    AND NOT (exclude_item_type IS NOT DISTINCT FROM 'discussion' AND exclude_item_id IS NOT DISTINCT FROM d.id)
+
+    ORDER BY similarity DESC
+    LIMIT match_count;
+END;
+$$ LANGUAGE plpgsql;
+
+GRANT EXECUTE ON FUNCTION find_similar_items_cross_entity(VECTOR, UUID[], INTEGER, TEXT, TEXT) TO authenticated;
+GRANT EXECUTE ON FUNCTION find_similar_items_cross_entity(VECTOR, UUID[], INTEGER, TEXT, TEXT) TO anon;
+GRANT EXECUTE ON FUNCTION find_similar_items_cross_entity(VECTOR, UUID[], INTEGER, TEXT, TEXT) TO service_role;
+
+COMMENT ON FUNCTION find_similar_items_cross_entity IS 'Find similar items across all entity types (issues, pull requests, discussions) within workspace repositories using 384-dimension embeddings. Returns body preview, creation date, and author for enriched RAG context.';


### PR DESCRIPTION
## Summary
- Enriches the `find_similar_items_cross_entity` RPC to return `body_preview` (first 300 chars), `created_at`, and `author_login` alongside existing fields
- Updates the chat function's RAG formatting to show author attribution, relative timestamps, and a blockquoted body preview per matched item
- LEFT JOINs contributors for issues/PRs so items with null `author_id` still return; discussions use their existing `author_login` column

Closes #1677

## Test plan
- [x] Migration applied via Supabase MCP
- [x] `npm run build` passes
- [ ] Ask StarSearch a question on a repo with embeddings and confirm richer context in server logs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bdougie/contributor.info/pull/1679" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 3 no changes — [View all](https://hub.continue.dev/inbox/pr/bdougie/contributor.info/1679?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->