### PR TITLE
feat: track OpenAI prompt cache hits in PostHog analytics

### DIFF
--- a/netlify/functions/agents/contributor-agent.mts
+++ b/netlify/functions/agents/contributor-agent.mts
@@ -200,6 +200,7 @@ export async function runContributorAgent(
     model: 'gpt-4o-mini',
     inputTokens: result.usage.inputTokens,
     outputTokens: result.usage.outputTokens,
+    cachedTokens: result.usage.inputTokenDetails?.cacheReadTokens ?? 0,
     latencyMs: Date.now() - agentStart,
     distinctId: context.distinctId,
     metadata: { tools_invoked: toolsInvoked, tools_invoked_count: toolsInvoked.length },

--- a/netlify/functions/agents/repo-health-agent.mts
+++ b/netlify/functions/agents/repo-health-agent.mts
@@ -495,6 +495,7 @@ export async function runRepoHealthAgent(
     model: 'gpt-4o-mini',
     inputTokens: result.usage.inputTokens,
     outputTokens: result.usage.outputTokens,
+    cachedTokens: result.usage.inputTokenDetails?.cacheReadTokens ?? 0,
     latencyMs: Date.now() - agentStart,
     distinctId: context.distinctId,
     metadata: { tools_invoked: toolsInvoked, tools_invoked_count: toolsInvoked.length },

--- a/netlify/functions/chat.mts
+++ b/netlify/functions/chat.mts
@@ -201,6 +201,7 @@ async function preprocessUserMessage(
     model: 'gpt-4o-mini',
     inputTokens: usage.inputTokens,
     outputTokens: usage.outputTokens,
+    cachedTokens: usage.inputTokenDetails?.cacheReadTokens ?? 0,
     latencyMs: Date.now() - preStart,
     distinctId,
     metadata: {
@@ -231,14 +232,35 @@ function buildManagerSystemPrompt(hasDatapipe: boolean, hasRepoContext: boolean)
     );
   }
 
-  return `You are an orchestration manager for repository analysis. Your job is to call the right sub-agent tools to answer the user's question.
+  return `You are an orchestration manager for repository analysis. Your job is to call the right sub-agent tools to answer the user's question about a GitHub repository.
+
+You are part of the contributor.info platform — a tool that helps open-source maintainers understand their repositories and contributor communities through data-driven insights.
 
 Available tools:
 ${tools.join('\n')}
 
-When the user's question spans multiple domains (e.g. "How healthy is this repo AND who are the top contributors?"), call multiple sub-agents in the same step so they run in parallel.
-When the question is domain-specific, call only the relevant sub-agent.${hasRepoContext ? '\nOnly use search_repository_context when the user asks about specific topics, features, or activity — not for general health or contributor questions.' : ''}
-Do not answer directly — always use tools to fetch real data.`;
+## Routing rules
+
+1. When the user's question spans multiple domains (e.g. "How healthy is this repo AND who are the top contributors?"), call multiple sub-agent tools in the same step so they execute in parallel for faster responses.
+2. When the question is clearly domain-specific, call only the relevant sub-agent to avoid unnecessary data fetching.
+3. Do not answer directly — always delegate to tools to fetch real, up-to-date data. Never fabricate statistics or repository information.${hasRepoContext ? '\n4. Only use search_repository_context when the user asks about specific topics, features, bugs, or historical activity — not for general health or contributor overview questions.' : ''}
+
+## Response quality guidelines
+
+When your sub-agents return data, the synthesizer will format a final response. To help it produce the best output:
+- Ensure tool calls include all relevant parameters so sub-agents return comprehensive data.
+- If a tool returns an error, do not retry — report the error so the synthesizer can inform the user gracefully.
+- Prefer calling fewer, more targeted tools over calling everything. Only request data that directly answers the user's question.
+
+## Scope boundaries
+
+You can only answer questions about GitHub repositories using the tools above. Topics you cannot help with include:
+- Specific code changes, commits, or diffs
+- CI/CD pipeline status or deployment details
+- Individual file contents or code review
+- Issues outside the repository's tracked data
+
+If the user asks about something outside your capabilities, respond with a brief explanation of what you can help with instead.`;
 }
 
 const CORS_HEADERS: Record<string, string> = {
@@ -550,7 +572,7 @@ export default async (req: Request, _context: Context) => {
       {
         repository: `${owner}/${repo}`,
         intent: preprocessResult?.intent,
-        rag_used: ragContext !== null,
+        rag_available: repoId !== null,
         has_datapipe: hasDatapipe,
         time_range: timeRange,
         off_topic: preprocessResult?.flags.offTopic ?? false,
@@ -579,6 +601,7 @@ export default async (req: Request, _context: Context) => {
       model: 'gpt-4o-mini',
       inputTokens: managerResult.usage.inputTokens,
       outputTokens: managerResult.usage.outputTokens,
+      cachedTokens: managerResult.usage.inputTokenDetails?.cacheReadTokens ?? 0,
       latencyMs: Date.now() - managerStart,
       distinctId: user.id,
       metadata: { dispatched_tools: dispatchedTools, dispatched_count: dispatchedTools.length },
@@ -637,9 +660,10 @@ export default async (req: Request, _context: Context) => {
               model: 'gpt-4.1',
               inputTokens: usage.inputTokens,
               outputTokens: usage.outputTokens,
+              cachedTokens: usage.inputTokenDetails?.cacheReadTokens ?? 0,
               latencyMs: Date.now() - synthStart,
               distinctId: user.id,
-              metadata: { rag_used: ragContext !== null },
+              metadata: { rag_available: repoId !== null },
             });
           })
           .catch(() => {});

--- a/netlify/functions/lib/llm-analytics.mts
+++ b/netlify/functions/lib/llm-analytics.mts
@@ -22,6 +22,8 @@ export interface LLMCallMetrics {
   latencyMs: number;
   /** PostHog distinct_id for per-user attribution — omit for anonymous */
   distinctId?: string;
+  /** Number of input tokens served from OpenAI's prompt cache */
+  cachedTokens?: number;
   /** Extra properties merged into the event (agent-specific metadata) */
   metadata?: Record<string, unknown>;
 }
@@ -39,6 +41,7 @@ export function trackLLMCall(metrics: LLMCallMetrics): void {
       $ai_input_tokens: metrics.inputTokens,
       $ai_output_tokens: metrics.outputTokens,
       $ai_latency: metrics.latencyMs,
+      ...(metrics.cachedTokens != null && { $ai_cached_tokens: metrics.cachedTokens }),
       agent: metrics.agent,
       ...metrics.metadata,
     },


### PR DESCRIPTION
## Summary

- Track `cacheReadTokens` from OpenAI responses in PostHog `$ai_generation` events (`$ai_cached_tokens` property) across all 5 LLM call sites (preprocessor, manager, repo-health, contributor, synthesizer)
- Fix runtime `ReferenceError` where `ragContext` was referenced but never defined — replaced with `repoId !== null`
- Enrich the manager system prompt with routing rules, quality guidelines, and scope boundaries to exceed OpenAI's 1,024-token prompt caching threshold

## How OpenAI prompt caching works

OpenAI [automatically caches](https://platform.openai.com/docs/guides/prompt-caching) the longest prefix of a prompt that exceeds 1,024 tokens. Cached prefixes get a **50% discount** on input token pricing. No API changes are needed — the SDK already returns `usage.inputTokenDetails.cacheReadTokens` indicating how many tokens were served from cache. This PR wires that value into our PostHog tracking so we can measure actual savings, and ensures our manager prompt is long enough to trigger caching.

## What changed and why

| File | What | Why |
|------|------|-----|
| `llm-analytics.mts` | Added `cachedTokens` to `LLMCallMetrics`, emit as `$ai_cached_tokens` | Single place to extend the analytics interface |
| `chat.mts` (preprocessor) | Pass `cacheReadTokens` | Track cache hits on the security preprocessor |
| `chat.mts` (manager) | Pass `cacheReadTokens` | Track cache hits on the orchestration manager |
| `chat.mts` (synthesizer) | Pass `cacheReadTokens` via resolved usage promise | `streamText` resolves usage async — same pattern |
| `chat.mts` (bug fix) | `ragContext` -> `repoId !== null` | `ragContext` was never defined, causing `ReferenceError` at runtime |
| `chat.mts` (prompt) | Expanded `buildManagerSystemPrompt()` | Push stable prefix past 1,024 tokens so OpenAI caches it |
| `repo-health-agent.mts` | Pass `cacheReadTokens` | Track cache hits on the repo-health sub-agent |
| `contributor-agent.mts` | Pass `cacheReadTokens` | Track cache hits on the contributor sub-agent |

## Key pattern: accessing cached token counts

The AI SDK v6 surfaces OpenAI's cache data differently depending on the call type:

```typescript
// generateText — usage is available synchronously on the result
const result = await generateText({ ... });
result.usage.inputTokenDetails?.cacheReadTokens; // number | undefined

// streamText — usage is a promise, resolved after the stream completes
const stream = streamText({ ... });
stream.usage.then((usage) => {
  usage.inputTokenDetails?.cacheReadTokens;
});
```

## Test plan

- [x] `npm run build` — TypeScript compiles cleanly
- [x] `npx vitest run netlify/functions/__tests__/` — all 179 tests pass
- [ ] Deploy to preview and verify `$ai_cached_tokens` appears in PostHog `$ai_generation` events
- [ ] Confirm cache hits increase on repeated queries to the same repo
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bdougie/contributor.info/pull/1699" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue.dev/inbox/pr/bdougie/contributor.info/1699?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced chat manager with repository-specific context and improved routing rules for better response quality.
* **Chores**
  * Added cache token tracking across agent functions to improve telemetry insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->