### PR TITLE
fix: migrate import_map.json into deno.json

### DIFF
--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -1,5 +1,7 @@
 {
-  "importMap": "./import_map.json",
+  "imports": {
+    "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2"
+  },
   "compilerOptions": {
     "lib": ["deno.window", "deno.ns"]
   },

--- a/supabase/functions/import_map.json
+++ b/supabase/functions/import_map.json
@@ -1,5 +1,0 @@
-{
-  "imports": {
-    "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2"
-  }
-}


### PR DESCRIPTION
## Summary

- Inlines the `imports` block from the legacy `import_map.json` directly into `supabase/functions/deno.json`
- Deletes the now-redundant `import_map.json` file
- Silences the Supabase CLI deprecation warning when deploying edge functions

## Details

The Supabase CLI warns when edge functions reference a separate `import_map.json` via the `importMap` field in `deno.json`. The recommended approach is to use an inline `imports` block instead. This is a config-only change — no edge function source code is affected since all functions already import via full URLs.

Closes #1675

## Test plan

- [x] `npm run build` passes
- [ ] Verify Supabase CLI no longer warns on edge function deploy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bdougie/contributor.info/pull/1701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue.dev/inbox/pr/bdougie/contributor.info/1701?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated Supabase dependency module configuration into the project's main configuration file for streamlined development setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->