### PR TITLE
fix: prevent permanent skeleton loaders for errored chat tool results

### DIFF
--- a/netlify/functions/chat.mts
+++ b/netlify/functions/chat.mts
@@ -696,8 +696,19 @@ export default async (req: Request, _context: Context) => {
               const subResult = tr.output as SubAgentResult | undefined;
 
               if (subResult?.kind === 'sub-agent-result') {
-                // Sub-agent result — re-emit individual tool events with original tool names
+                // Sub-agent result — re-emit individual tool events with original tool names.
+                // Build a set of errored tool call IDs so we skip both start + output for them,
+                // preventing the client from getting stuck with permanent skeleton loaders.
+                const erroredCallIds = new Set<string>();
+                for (const subTr of subResult.toolResults) {
+                  const output = subTr.output as Record<string, unknown> | undefined;
+                  if (output && typeof output === 'object' && 'error' in output) {
+                    erroredCallIds.add(subTr.toolCallId);
+                  }
+                }
+
                 for (const tc of subResult.toolCalls) {
+                  if (erroredCallIds.has(tc.toolCallId)) continue;
                   writer.write({
                     type: 'tool-input-start',
                     toolCallId: tc.toolCallId,
@@ -706,10 +717,7 @@ export default async (req: Request, _context: Context) => {
                   });
                 }
                 for (const subTr of subResult.toolResults) {
-                  const output = subTr.output as Record<string, unknown> | undefined;
-                  if (output && typeof output === 'object' && 'error' in output) {
-                    continue;
-                  }
+                  if (erroredCallIds.has(subTr.toolCallId)) continue;
                   writer.write({
                     type: 'tool-output-available',
                     toolCallId: subTr.toolCallId,

--- a/src/components/chat/chat-message.tsx
+++ b/src/components/chat/chat-message.tsx
@@ -112,7 +112,10 @@ export function ChatMessage({
     isUser ||
     message.parts.some((part) => {
       if (part.type === 'text' && part.text.trim()) return true;
-      if (part.type === 'dynamic-tool') return true;
+      if (part.type === 'dynamic-tool') {
+        // After streaming, only count tool parts that have output
+        return isStreaming || part.state === 'output-available';
+      }
       return false;
     });
 
@@ -155,6 +158,8 @@ export function ChatMessage({
                 </div>
               );
             }
+            // Hide tool parts that never received output after streaming ended
+            if (!isStreaming) return null;
             // Loading state for in-progress tool calls
             return (
               <div key={i} className="mt-2 space-y-2">


### PR DESCRIPTION
## Summary

- Fixes empty dark rectangles appearing in StarSearch chat when a sub-agent tool returns an error
- The server was emitting `tool-input-start` stream events for all tool calls but skipping `tool-output-available` for errored results, leaving `dynamic-tool` parts stuck as permanent skeleton loaders on the client
- Now builds a set of errored tool call IDs upfront and skips both start and output events for them
- Adds a defensive client-side fix: after streaming ends, hides any `dynamic-tool` parts that never received output instead of showing permanent skeletons

## Test plan

- [ ] Ask "Which PRs need attention?" on a repo with no tracked data — verify no empty rectangles appear
- [ ] Ask the same on a repo with valid data — verify PR alert cards render correctly
- [ ] Trigger a tool error scenario — verify the text response appears cleanly without skeleton artifacts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bdougie/contributor.info/pull/1703" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue.dev/inbox/pr/bdougie/contributor.info/1703?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for tool calls—failed tool calls no longer display as successful events in the chat interface.
  * Fixed empty tool placeholder rendering—incomplete tool results are now properly hidden when streaming completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->