### PR TITLE
⚡ Bolt: lazy load UPlotChart

### DIFF
--- a/src/components/features/workspace/ActivityChart.tsx
+++ b/src/components/features/workspace/ActivityChart.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/lib/utils';
 import { Info, Layout, X } from '@/components/ui/icon';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Button } from '@/components/ui/button';
-import { UPlotChart } from '@/components/ui/charts/UPlotChart';
+import { LazyUPlotChart as UPlotChart } from '@/components/ui/charts/UPlotChart-lazy';
 import type { AlignedData, Options } from 'uplot';
 import { useMemo, useState, useEffect } from 'react';
 

--- a/src/components/features/workspace/TrendChart.tsx
+++ b/src/components/features/workspace/TrendChart.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/lib/utils';
 import { Info, Layout, X } from '@/components/ui/icon';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Button } from '@/components/ui/button';
-import { UPlotChart } from '@/components/ui/charts/UPlotChart';
+import { LazyUPlotChart as UPlotChart } from '@/components/ui/charts/UPlotChart-lazy';
 import type { AlignedData, Options } from 'uplot';
 import { useMemo, useState } from 'react';
 

--- a/src/components/features/workspace/__tests__/TrendChart.test.tsx
+++ b/src/components/features/workspace/__tests__/TrendChart.test.tsx
@@ -3,8 +3,8 @@ import { TrendChart } from '../TrendChart';
 import { vi, describe, it, expect } from 'vitest';
 
 // Mock UPlotChart to avoid canvas issues
-vi.mock('@/components/ui/charts/UPlotChart', () => ({
-  UPlotChart: () => <div data-testid="uplot-chart">Chart</div>,
+vi.mock('@/components/ui/charts/UPlotChart-lazy', () => ({
+  LazyUPlotChart: () => <div data-testid="uplot-chart">Chart</div>,
 }));
 
 // Mock ResizeObserver


### PR DESCRIPTION
💡 What: Lazy load `UPlotChart` in `TrendChart.tsx` and `ActivityChart.tsx` using `LazyUPlotChart` from `UPlotChart-lazy.tsx`.

🎯 Why: To reduce the initial bundle size and improve load performance for pages that use these charts, as identified in the performance analysis. `uplot` is a heavy dependency and should only be loaded when needed.

📊 Impact: Reduces initial bundle size by deferring `uplot` loading.

🔬 Measurement: Verified that `TrendChart` tests pass with the lazy component. Visually, the chart should load with a skeleton state initially.


---
*PR created automatically by Jules for task [15902840825838477103](https://jules.google.com/task/15902840825838477103) started by @bdougie*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bdougie/contributor.info/pull/1705" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue.dev/inbox/pr/bdougie/contributor.info/1705?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized chart component loading mechanism across the application.

* **Tests**
  * Updated test fixtures to align with refactored components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->