### PR TITLE
⚡ Bolt: Optimize UserAvatar image size for GitHub avatars

### DIFF
--- a/src/components/ui/__tests__/user-avatar.test.tsx
+++ b/src/components/ui/__tests__/user-avatar.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { UserAvatar } from '../user-avatar';
+
+describe('UserAvatar', () => {
+  it('renders with basic props', () => {
+    render(
+      <UserAvatar
+        src="https://example.com/avatar.jpg"
+        alt="John Doe"
+      />
+    );
+
+    const img = screen.getByRole('img');
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute('src', 'https://example.com/avatar.jpg');
+    expect(img).toHaveAttribute('alt', 'John Doe');
+  });
+
+  it('optimizes GitHub avatar URLs with size parameter', () => {
+    // This test should fail initially, as the optimization is not yet implemented
+    render(
+      <UserAvatar
+        src="https://avatars.githubusercontent.com/u/123456"
+        alt="GitHub User"
+        size={48}
+      />
+    );
+
+    const img = screen.getByRole('img');
+    // Expect the URL to be optimized with size and version params
+    expect(img).toHaveAttribute('src', 'https://avatars.githubusercontent.com/u/123456?s=48&v=4');
+  });
+
+  it('leaves non-GitHub URLs untouched', () => {
+    render(
+      <UserAvatar
+        src="https://example.com/avatar.jpg"
+        alt="External User"
+        size={48}
+      />
+    );
+
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('src', 'https://example.com/avatar.jpg');
+  });
+});

--- a/src/components/ui/user-avatar.tsx
+++ b/src/components/ui/user-avatar.tsx
@@ -1,3 +1,5 @@
+import { optimizeAvatarUrl } from '@/lib/optimized-avatar-utils';
+
 interface UserAvatarProps {
   src: string;
   alt: string;
@@ -13,9 +15,12 @@ export function UserAvatar({
   priority = false,
   lazy = true,
 }: UserAvatarProps) {
+  // Optimize the image source for GitHub avatars to reduce download size
+  const optimizedSrc = optimizeAvatarUrl(src, size);
+
   return (
     <img
-      src={src}
+      src={optimizedSrc || src}
       alt={alt}
       width={size}
       height={size}


### PR DESCRIPTION
💡 What: Optimized the `UserAvatar` component to request resized images from GitHub's avatar service.
🎯 Why: GitHub avatars are often served at full resolution even when displayed at small sizes (e.g. 48x48), wasting bandwidth and impacting LCP.
📊 Impact: Reduces image payload size for user avatars, improving loading performance and reducing data usage.
🔬 Measurement: Verified with unit tests ensuring `s` parameter is appended to GitHub URLs.

---
*PR created automatically by Jules for task [17941429752604611359](https://jules.google.com/task/17941429752604611359) started by @bdougie*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bdougie/contributor.info/pull/1709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * GitHub avatar images now benefit from automatic URL optimization, enhancing performance and appearance.

* **Tests**
  * Added comprehensive test coverage for avatar URL optimization, including handling of both GitHub and external image sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->