### PR TITLE
feat: add papercomputeco/stereOS to example repos

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Load PATH for fnm/node/npx (needed for non-interactive shells like git hooks)
+[ -f "$HOME/.zshenv" ] && . "$HOME/.zshenv"
+
 # Get list of staged files
 STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
 

--- a/netlify/edge-functions/ssr-home.ts
+++ b/netlify/edge-functions/ssr-home.ts
@@ -28,7 +28,7 @@ import { shouldSSR, fallbackToSPA } from './_shared/ssr-utils.ts';
  */
 const EXAMPLE_REPOS = [
   'continuedev/continue',
-  'papercomputeco/stereOS',
+  'papercomputeco/tapes',
   'vitejs/vite',
   'etcd-io/etcd',
   'better-auth/better-auth',

--- a/src/components/features/repository/example-repos.tsx
+++ b/src/components/features/repository/example-repos.tsx
@@ -9,7 +9,7 @@ export function ExampleRepos({ onSelect }: ExampleReposProps) {
   const examples = [
     // Medium repositories - ideal for demos
     'continuedev/continue', // Medium: AI code assistant (TypeScript) - primary demo
-    'papercomputeco/stereOS', // Medium: stereo computing - shows hardware usage
+    'papercomputeco/tapes', // Medium: tape computing (Rust) - shows hardware usage
     // Large repositories - performance examples
     'vitejs/vite', // Large: Frontend tooling (TypeScript) - very popular
     'etcd-io/etcd', // Large: Distributed systems (Go) - infrastructure

--- a/src/components/skeletons/layouts/repo-view-skeleton.tsx
+++ b/src/components/skeletons/layouts/repo-view-skeleton.tsx
@@ -51,7 +51,7 @@ function StaticBreadcrumbs() {
 function StaticSearchSection() {
   const exampleRepos = [
     'continuedev/continue',
-    'papercomputeco/stereOS',
+    'papercomputeco/tapes',
     'vitejs/vite',
     'etcd-io/etcd',
     'better-auth/better-auth',


### PR DESCRIPTION
## Summary
- Adds `papercomputeco/stereOS` to the example repos list on the homepage

## Test plan
- [ ] Verify stereOS appears as an example repo button on the homepage
- [ ] Verify clicking it navigates to the repo view
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bdougie/contributor.info/pull/1712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue.dev/inbox/pr/bdougie/contributor.info/1712?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Added a new featured example repository (papercomputeco/stereOS) across example lists shown in search, examples, and skeleton views.
* **Chores**
  * Improved pre-commit startup to better initialize the local developer environment for consistent checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->