### PR TITLE
feat: refresh star/fork events in daily metrics cron

### DIFF
--- a/src/lib/inngest/functions/capture-repository-metrics-cron.ts
+++ b/src/lib/inngest/functions/capture-repository-metrics-cron.ts
@@ -220,10 +220,26 @@ export const captureRepositoryMetricsCron = inngest.createFunction(
       );
     }
 
+    // Step 5: Trigger star/fork event capture for all active repositories
+    // This refreshes the github_events_cache so the activity feed stays up to date
+    let eventsTriggered = 0;
+    for (const repo of repositories) {
+      await step.sendEvent(`repo-events-${eventsTriggered}`, {
+        name: 'capture/repository.events',
+        data: {
+          repositoryId: repo.id,
+        },
+      });
+      eventsTriggered++;
+    }
+
+    console.log('[Metrics Cron] Triggered event capture for %d repositories', eventsTriggered);
+
     return {
       success: isSuccess,
       repositoriesProcessed: repositories.length,
       metricsInserted: totalMetricsInserted,
+      eventsTriggered,
       totalBatches,
       failedBatches,
       failedBatchErrors: failedBatchErrors.length > 0 ? failedBatchErrors : undefined,


### PR DESCRIPTION
## Summary
- Adds `capture/repository.events` fan-out to the daily metrics cron (`capture-repository-metrics-cron`)
- After capturing aggregate metrics, the cron now triggers star/fork event capture for every active repo
- This keeps `github_events_cache` fresh so the activity feed shows up-to-date stars and forks

Previously, star/fork events were only captured on initial repository tracking — they were never refreshed.

## Test plan
- [ ] Verify Inngest dashboard shows `capture-repository-events` jobs triggered after `capture-repository-metrics-cron` runs
- [ ] Check `github_events_cache` table has recent WatchEvent/ForkEvent entries for tracked repos
- [ ] Confirm activity feed shows fresh star/fork data when logged in
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bdougie/contributor.info/pull/1722" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue.dev/inbox/pr/bdougie/contributor.info/1722?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->