### PR TITLE
fix: route event backfill through server-side Netlify function

### DIFF
--- a/netlify/functions/trigger-event-backfill.ts
+++ b/netlify/functions/trigger-event-backfill.ts
@@ -1,0 +1,80 @@
+import { Handler } from '@netlify/functions';
+import { createClient } from '@supabase/supabase-js';
+import { inngest } from '../../src/lib/inngest/client';
+
+export const handler: Handler = async (event) => {
+  const headers = { 'Content-Type': 'application/json' };
+
+  if (event.httpMethod !== 'POST') {
+    return {
+      statusCode: 405,
+      headers: { ...headers, Allow: 'POST' },
+      body: JSON.stringify({ error: 'Method not allowed' }),
+    };
+  }
+
+  try {
+    const body = JSON.parse(event.body || '{}');
+    const { owner, repo } = body;
+
+    if (!owner || !repo) {
+      return {
+        statusCode: 400,
+        headers,
+        body: JSON.stringify({ error: 'owner and repo are required' }),
+      };
+    }
+
+    // Look up repository ID
+    const supabaseUrl = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
+    const supabaseKey =
+      process.env.SUPABASE_SERVICE_ROLE_KEY ||
+      process.env.VITE_SUPABASE_ANON_KEY ||
+      process.env.SUPABASE_ANON_KEY;
+
+    if (!supabaseUrl || !supabaseKey) {
+      return {
+        statusCode: 503,
+        headers,
+        body: JSON.stringify({ error: 'Database not configured' }),
+      };
+    }
+
+    const supabase = createClient(supabaseUrl, supabaseKey);
+    const { data: repoData } = await supabase
+      .from('repositories')
+      .select('id')
+      .eq('owner', owner)
+      .eq('name', repo)
+      .maybeSingle();
+
+    if (!repoData) {
+      return {
+        statusCode: 404,
+        headers,
+        body: JSON.stringify({ error: 'Repository not tracked' }),
+      };
+    }
+
+    const result = await inngest.send({
+      name: 'capture/repository.events',
+      data: { repositoryId: repoData.id },
+    });
+
+    console.log('Triggered event backfill for %s/%s (id: %s)', owner, repo, repoData.id);
+
+    return {
+      statusCode: 200,
+      headers,
+      body: JSON.stringify({ success: true, result }),
+    };
+  } catch (error) {
+    console.error('[trigger-event-backfill] Error:', error);
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return {
+      statusCode: 500,
+      headers,
+      body: JSON.stringify({ error: 'Internal server error', message }),
+    };
+  }
+};

--- a/src/hooks/use-repository-events.ts
+++ b/src/hooks/use-repository-events.ts
@@ -1,7 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { getSupabase } from '@/lib/supabase-lazy';
 import { abbreviateBios } from '@/lib/llm/abbreviate-bios';
-import { inngest } from '@/lib/inngest/client';
 
 export interface RepositoryEvent {
   id: string;
@@ -110,7 +109,7 @@ export function useRepositoryEvents(
 
           if (isStale) {
             hasTriggeredBackfill.current = true;
-            triggerEventBackfill(owner, repo, supabase);
+            triggerEventBackfill(owner, repo);
           }
         }
       } catch (err) {
@@ -127,25 +126,19 @@ export function useRepositoryEvents(
   return { events, loading, error };
 }
 
-async function triggerEventBackfill(
-  owner: string,
-  repo: string,
-  supabase: Awaited<ReturnType<typeof getSupabase>>
-) {
+async function triggerEventBackfill(owner: string, repo: string) {
   try {
-    const { data: repoData } = await supabase
-      .from('repositories')
-      .select('id')
-      .eq('owner', owner)
-      .eq('name', repo)
-      .maybeSingle();
-
-    if (!repoData) return;
-
-    await inngest.send({
-      name: 'capture/repository.events',
-      data: { repositoryId: repoData.id },
+    const response = await fetch('/.netlify/functions/trigger-event-backfill', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ owner, repo }),
     });
+
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      console.warn('Event backfill returned %s: %s', response.status, data.error || '');
+      return;
+    }
 
     console.log('Triggered star/fork event backfill for %s/%s', owner, repo);
   } catch (err) {


### PR DESCRIPTION
## Summary
- The on-demand star/fork event backfill was calling `inngest.send()` directly from the browser, but `VITE_INNGEST_EVENT_KEY` is intentionally not set in production (it's a server secret), so the call was a silent no-op
- Added a new Netlify function `trigger-event-backfill` that triggers the Inngest event server-side where keys are available
- Updated `use-repository-events` hook to call the Netlify function via `fetch()` instead of `inngest.send()`

## Test plan
- [ ] Deploy to preview and visit a tracked repo's feed page while logged in
- [ ] Verify console shows "Triggered star/fork event backfill" (not "Service disabled")
- [ ] Confirm star/fork events appear in the activity feed after backfill completes
- [ ] Verify untracked repos return 404 gracefully without errors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bdougie/contributor.info/pull/1725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 3 queued — [View all](https://hub.continue.dev/inbox/pr/bdougie/contributor.info/1725?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored event backfill triggering mechanism to use HTTP-based approach.
  * Enhanced error logging and handling for backfill operations to better capture and report failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->