### PR TITLE
fix: resolve Inngest step replay bug and incorrect DELETE trigger guard

### DIFF
--- a/src/lib/inngest/functions/capture-repository-metrics-cron.ts
+++ b/src/lib/inngest/functions/capture-repository-metrics-cron.ts
@@ -1,13 +1,14 @@
 import { inngest } from '../client';
 import { supabase } from '../supabase-server';
+import { makeGitHubRequest } from '../github-client';
 
 /**
  * Cron job to capture repository metrics for trending detection
  *
  * This function:
  * 1. Fetches all active, public repositories
- * 2. Captures current metrics (stars, forks, contributors, PRs, issues, watchers)
- * 3. Stores them in repository_metrics_history table
+ * 2. Refreshes metadata (stars, forks, issues, watchers) from GitHub REST API
+ * 3. Captures current metrics into repository_metrics_history table
  * 4. The database trigger automatically marks significant changes
  *
  * Runs daily at midnight UTC to capture metrics for trending detection.
@@ -27,6 +28,13 @@ interface MetricCapture {
   repository_id: string;
   metric_type: string;
   current_value: number;
+}
+
+interface GitHubRepoResponse {
+  stargazers_count: number;
+  forks_count: number;
+  open_issues_count: number;
+  watchers_count: number;
 }
 
 // Use Record instead of Map for JSON serialization through Inngest steps
@@ -76,7 +84,76 @@ export const captureRepositoryMetricsCron = inngest.createFunction(
 
     console.log('[Metrics Cron] Found %d repositories to process', repositories.length);
 
-    // Step 2: Get contributor counts for all repositories (using Record for JSON serialization)
+    // Step 2: Refresh repository metadata from GitHub API before capturing metrics
+    // This ensures stargazers_count, forks_count, etc. are current — not stale from discovery time
+    const refreshBatches = Math.ceil(repositories.length / BATCH_SIZE);
+    let totalRefreshed = 0;
+
+    for (let i = 0; i < refreshBatches; i++) {
+      const batchStart = i * BATCH_SIZE;
+      const batchEnd = Math.min((i + 1) * BATCH_SIZE, repositories.length);
+      const batch = repositories.slice(batchStart, batchEnd);
+
+      const refreshed = await step.run(`refresh-metadata-batch-${i}`, async () => {
+        let updated = 0;
+
+        for (const repo of batch) {
+          try {
+            const ghData = await makeGitHubRequest<GitHubRepoResponse>(
+              `/repos/${repo.owner}/${repo.name}`
+            );
+
+            // Update the repositories table with fresh counts
+            const { error } = await supabase
+              .from('repositories')
+              .update({
+                stargazers_count: ghData.stargazers_count,
+                forks_count: ghData.forks_count,
+                open_issues_count: ghData.open_issues_count,
+                watchers_count: ghData.watchers_count,
+                last_updated_at: new Date().toISOString(),
+              })
+              .eq('id', repo.id);
+
+            if (error) {
+              console.warn(
+                '[Metrics Cron] Failed to update metadata for %s/%s: %s',
+                repo.owner,
+                repo.name,
+                error.message
+              );
+            } else {
+              // Update the in-memory repo object so metrics capture uses fresh values
+              repo.stargazers_count = ghData.stargazers_count;
+              repo.forks_count = ghData.forks_count;
+              repo.open_issues_count = ghData.open_issues_count;
+              repo.watchers_count = ghData.watchers_count;
+              updated++;
+            }
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            console.warn(
+              '[Metrics Cron] GitHub API error for %s/%s: %s',
+              repo.owner,
+              repo.name,
+              message
+            );
+          }
+        }
+
+        return updated;
+      });
+
+      totalRefreshed += refreshed;
+    }
+
+    console.log(
+      '[Metrics Cron] Refreshed metadata for %d/%d repositories',
+      totalRefreshed,
+      repositories.length
+    );
+
+    // Step 3: Get contributor counts for all repositories (using Record for JSON serialization)
     const contributorCounts = await step.run(
       'fetch-contributor-counts',
       async (): Promise<CountsRecord> => {
@@ -95,7 +172,7 @@ export const captureRepositoryMetricsCron = inngest.createFunction(
       }
     );
 
-    // Step 3: Get PR counts for all repositories (using Record for JSON serialization)
+    // Step 4: Get PR counts for all repositories (using Record for JSON serialization)
     const prCounts = await step.run('fetch-pr-counts', async (): Promise<CountsRecord> => {
       const { data, error } = await supabase.rpc('get_repository_pr_counts');
 
@@ -111,7 +188,7 @@ export const captureRepositoryMetricsCron = inngest.createFunction(
       return counts;
     });
 
-    // Step 4: Capture metrics in batches, tracking failures
+    // Step 5: Capture metrics in batches, tracking failures
     let totalMetricsInserted = 0;
     let failedBatches = 0;
     const totalBatches = Math.ceil(repositories.length / BATCH_SIZE);
@@ -220,7 +297,7 @@ export const captureRepositoryMetricsCron = inngest.createFunction(
       );
     }
 
-    // Step 5: Trigger star/fork event capture for all active repositories
+    // Step 6: Trigger star/fork event capture for all active repositories
     // This refreshes the github_events_cache so the activity feed stays up to date
     let eventsTriggered = 0;
     for (const repo of repositories) {
@@ -238,6 +315,7 @@ export const captureRepositoryMetricsCron = inngest.createFunction(
     return {
       success: isSuccess,
       repositoriesProcessed: repositories.length,
+      metadataRefreshed: totalRefreshed,
       metricsInserted: totalMetricsInserted,
       eventsTriggered,
       totalBatches,

--- a/src/lib/inngest/functions/capture-repository-metrics-cron.ts
+++ b/src/lib/inngest/functions/capture-repository-metrics-cron.ts
@@ -40,6 +40,9 @@ interface GitHubRepoResponse {
 // Use Record instead of Map for JSON serialization through Inngest steps
 type CountsRecord = Record<string, number>;
 
+// Refreshed metadata keyed by repo ID, serialized through Inngest steps
+type RefreshedMetadataRecord = Record<string, GitHubRepoResponse>;
+
 const BATCH_SIZE = 50;
 
 export const captureRepositoryMetricsCron = inngest.createFunction(
@@ -86,65 +89,69 @@ export const captureRepositoryMetricsCron = inngest.createFunction(
 
     // Step 2: Refresh repository metadata from GitHub API before capturing metrics
     // This ensures stargazers_count, forks_count, etc. are current — not stale from discovery time
+    // Return refreshed data through Inngest step return values (not in-memory mutation) so it
+    // survives step replay/retry — see CountsRecord pattern above.
     const refreshBatches = Math.ceil(repositories.length / BATCH_SIZE);
     let totalRefreshed = 0;
+    const refreshedMetadata: RefreshedMetadataRecord = {};
 
     for (let i = 0; i < refreshBatches; i++) {
       const batchStart = i * BATCH_SIZE;
       const batchEnd = Math.min((i + 1) * BATCH_SIZE, repositories.length);
       const batch = repositories.slice(batchStart, batchEnd);
 
-      const refreshed = await step.run(`refresh-metadata-batch-${i}`, async () => {
-        let updated = 0;
+      const batchRefreshed = await step.run(
+        `refresh-metadata-batch-${i}`,
+        async (): Promise<{ updated: number; metadata: RefreshedMetadataRecord }> => {
+          let updated = 0;
+          const metadata: RefreshedMetadataRecord = {};
 
-        for (const repo of batch) {
-          try {
-            const ghData = await makeGitHubRequest<GitHubRepoResponse>(
-              `/repos/${repo.owner}/${repo.name}`
-            );
+          for (const repo of batch) {
+            try {
+              const ghData = await makeGitHubRequest<GitHubRepoResponse>(
+                `/repos/${repo.owner}/${repo.name}`
+              );
 
-            // Update the repositories table with fresh counts
-            const { error } = await supabase
-              .from('repositories')
-              .update({
-                stargazers_count: ghData.stargazers_count,
-                forks_count: ghData.forks_count,
-                open_issues_count: ghData.open_issues_count,
-                watchers_count: ghData.watchers_count,
-                last_updated_at: new Date().toISOString(),
-              })
-              .eq('id', repo.id);
+              // Update the repositories table with fresh counts
+              const { error } = await supabase
+                .from('repositories')
+                .update({
+                  stargazers_count: ghData.stargazers_count,
+                  forks_count: ghData.forks_count,
+                  open_issues_count: ghData.open_issues_count,
+                  watchers_count: ghData.watchers_count,
+                  last_updated_at: new Date().toISOString(),
+                })
+                .eq('id', repo.id);
 
-            if (error) {
+              if (error) {
+                console.warn(
+                  '[Metrics Cron] Failed to update metadata for %s/%s: %s',
+                  repo.owner,
+                  repo.name,
+                  error.message
+                );
+              } else {
+                metadata[repo.id] = ghData;
+                updated++;
+              }
+            } catch (err) {
+              const message = err instanceof Error ? err.message : String(err);
               console.warn(
-                '[Metrics Cron] Failed to update metadata for %s/%s: %s',
+                '[Metrics Cron] GitHub API error for %s/%s: %s',
                 repo.owner,
                 repo.name,
-                error.message
+                message
               );
-            } else {
-              // Update the in-memory repo object so metrics capture uses fresh values
-              repo.stargazers_count = ghData.stargazers_count;
-              repo.forks_count = ghData.forks_count;
-              repo.open_issues_count = ghData.open_issues_count;
-              repo.watchers_count = ghData.watchers_count;
-              updated++;
             }
-          } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
-            console.warn(
-              '[Metrics Cron] GitHub API error for %s/%s: %s',
-              repo.owner,
-              repo.name,
-              message
-            );
           }
+
+          return { updated, metadata };
         }
+      );
 
-        return updated;
-      });
-
-      totalRefreshed += refreshed;
+      totalRefreshed += batchRefreshed.updated;
+      Object.assign(refreshedMetadata, batchRefreshed.metadata);
     }
 
     console.log(
@@ -205,27 +212,33 @@ export const captureRepositoryMetricsCron = inngest.createFunction(
           const metricsToCapture: MetricCapture[] = [];
 
           for (const repo of batch) {
-            // Add base metrics from repository table
+            // Prefer refreshed metadata (survives Inngest replay), fall back to fetch-repositories values
+            const fresh = refreshedMetadata[repo.id];
+            const stars = fresh?.stargazers_count ?? repo.stargazers_count ?? 0;
+            const forks = fresh?.forks_count ?? repo.forks_count ?? 0;
+            const issues = fresh?.open_issues_count ?? repo.open_issues_count ?? 0;
+            const watchers = fresh?.watchers_count ?? repo.watchers_count ?? 0;
+
             metricsToCapture.push(
               {
                 repository_id: repo.id,
                 metric_type: 'stars',
-                current_value: repo.stargazers_count || 0,
+                current_value: stars,
               },
               {
                 repository_id: repo.id,
                 metric_type: 'forks',
-                current_value: repo.forks_count || 0,
+                current_value: forks,
               },
               {
                 repository_id: repo.id,
                 metric_type: 'issues',
-                current_value: repo.open_issues_count || 0,
+                current_value: issues,
               },
               {
                 repository_id: repo.id,
                 metric_type: 'watchers',
-                current_value: repo.watchers_count || 0,
+                current_value: watchers,
               }
             );
 

--- a/supabase/migrations/20260319_sync_workspace_tracked_repos_trigger.sql
+++ b/supabase/migrations/20260319_sync_workspace_tracked_repos_trigger.sql
@@ -1,0 +1,141 @@
+-- Migration: Auto-sync workspace_tracked_repositories when repos are added/removed via UI
+--
+-- Root cause: The app writes to workspace_repositories (display junction table) but never
+-- populates workspace_tracked_repositories (sync scheduling table). The cron that syncs
+-- issues queries workspace_tracked_repositories — which has zero rows — so it always no-ops.
+--
+-- This migration:
+-- 1. Creates a trigger function to sync workspace_tracked_repositories on INSERT/DELETE
+-- 2. Backfills existing workspace_repositories entries that are missing from workspace_tracked_repositories
+
+-- =============================================================================
+-- 1. Trigger function: sync workspace_tracked_repositories on workspace_repositories changes
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION sync_workspace_tracked_repositories()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tracked_repo_id UUID;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    -- Look up tracked_repositories.id via repository_id
+    SELECT id INTO v_tracked_repo_id
+    FROM tracked_repositories
+    WHERE repository_id = NEW.repository_id;
+
+    IF v_tracked_repo_id IS NULL THEN
+      RAISE NOTICE 'No tracked_repository found for repository_id %. Skipping workspace_tracked_repositories sync.', NEW.repository_id;
+      RETURN NEW;
+    END IF;
+
+    -- Insert into workspace_tracked_repositories with sensible defaults
+    INSERT INTO workspace_tracked_repositories (
+      workspace_id,
+      tracked_repository_id,
+      added_by,
+      fetch_issues,
+      fetch_commits,
+      fetch_reviews,
+      fetch_comments,
+      sync_frequency_hours,
+      priority_score,
+      next_sync_at,
+      is_active
+    ) VALUES (
+      NEW.workspace_id,
+      v_tracked_repo_id,
+      NEW.added_by,
+      TRUE,
+      TRUE,
+      TRUE,
+      TRUE,
+      24,
+      50,
+      NOW(),  -- Trigger immediate first sync
+      TRUE
+    )
+    ON CONFLICT (workspace_id, tracked_repository_id) DO NOTHING;
+
+    RETURN NEW;
+
+  ELSIF TG_OP = 'DELETE' THEN
+    -- Look up tracked_repositories.id via repository_id
+    SELECT id INTO v_tracked_repo_id
+    FROM tracked_repositories
+    WHERE repository_id = OLD.repository_id;
+
+    IF v_tracked_repo_id IS NULL THEN
+      RETURN OLD;
+    END IF;
+
+    -- Only delete if the repo isn't referenced by any other workspace
+    IF NOT EXISTS (
+      SELECT 1
+      FROM workspace_repositories
+      WHERE repository_id = OLD.repository_id
+        AND workspace_id != OLD.workspace_id
+    ) THEN
+      DELETE FROM workspace_tracked_repositories
+      WHERE workspace_id = OLD.workspace_id
+        AND tracked_repository_id = v_tracked_repo_id;
+    END IF;
+
+    RETURN OLD;
+  END IF;
+
+  RETURN NULL;
+END;
+$$;
+
+-- =============================================================================
+-- 2. Create the trigger on workspace_repositories
+-- =============================================================================
+
+DROP TRIGGER IF EXISTS trg_sync_workspace_tracked_repos ON workspace_repositories;
+
+CREATE TRIGGER trg_sync_workspace_tracked_repos
+  AFTER INSERT OR DELETE ON workspace_repositories
+  FOR EACH ROW
+  EXECUTE FUNCTION sync_workspace_tracked_repositories();
+
+-- =============================================================================
+-- 3. Backfill: insert workspace_tracked_repositories for existing workspace_repositories
+--    that don't already have a corresponding entry
+-- =============================================================================
+
+INSERT INTO workspace_tracked_repositories (
+  workspace_id,
+  tracked_repository_id,
+  added_by,
+  fetch_issues,
+  fetch_commits,
+  fetch_reviews,
+  fetch_comments,
+  sync_frequency_hours,
+  priority_score,
+  next_sync_at,
+  is_active
+)
+SELECT
+  wr.workspace_id,
+  tr.id,
+  wr.added_by,
+  TRUE,
+  TRUE,
+  TRUE,
+  TRUE,
+  24,
+  50,
+  NOW(),
+  TRUE
+FROM workspace_repositories wr
+JOIN tracked_repositories tr ON tr.repository_id = wr.repository_id
+LEFT JOIN workspace_tracked_repositories wtr
+  ON wtr.workspace_id = wr.workspace_id
+  AND wtr.tracked_repository_id = tr.id
+WHERE wtr.id IS NULL
+ON CONFLICT (workspace_id, tracked_repository_id) DO NOTHING;

--- a/supabase/migrations/20260319_sync_workspace_tracked_repos_trigger.sql
+++ b/supabase/migrations/20260319_sync_workspace_tracked_repos_trigger.sql
@@ -72,17 +72,10 @@ BEGIN
       RETURN OLD;
     END IF;
 
-    -- Only delete if the repo isn't referenced by any other workspace
-    IF NOT EXISTS (
-      SELECT 1
-      FROM workspace_repositories
-      WHERE repository_id = OLD.repository_id
-        AND workspace_id != OLD.workspace_id
-    ) THEN
-      DELETE FROM workspace_tracked_repositories
-      WHERE workspace_id = OLD.workspace_id
-        AND tracked_repository_id = v_tracked_repo_id;
-    END IF;
+    -- Delete this workspace's tracking entry (scoped to workspace_id, safe for shared repos)
+    DELETE FROM workspace_tracked_repositories
+    WHERE workspace_id = OLD.workspace_id
+      AND tracked_repository_id = v_tracked_repo_id;
 
     RETURN OLD;
   END IF;


### PR DESCRIPTION
## Summary

- **Inngest metadata refresh lost on replay**: The refresh step mutated `repo` objects in outer scope, but Inngest memoizes step return values. On retry/replay the mutations were silently discarded, causing metrics capture to use stale GitHub counts. Fixed by returning refreshed metadata through the step's serialized return value (`RefreshedMetadataRecord`) and reading from it in the capture step.
- **SQL DELETE trigger guard blocked workspace cleanup**: The `NOT EXISTS` guard checked if other workspaces tracked the same repo, but the `DELETE` was already scoped to `workspace_id`. When repos were shared across workspaces, removing from one left orphaned `workspace_tracked_repositories` rows. Fixed by removing the guard.

Found during code review of #1754.

## Test plan

- [ ] Verify metrics cron captures fresh GitHub counts after metadata refresh, including on Inngest retry
- [ ] Verify removing a repo from a workspace deletes the `workspace_tracked_repositories` row even when another workspace tracks the same repo
- [ ] Confirm TypeScript types pass (`npm run build`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bdougie/contributor.info/pull/1756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository metrics (stars, forks, open issues, watchers) now refresh more reliably from GitHub for up-to-date counts.
* **Bug Fixes**
  * Workspace repository sync: removing a repository from a workspace now consistently removes its tracked entry so lists stay accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->