### PR TITLE
⚡ Bolt: Use cached activity counts in SpamAwareActivityItem

### DIFF
--- a/src/components/features/activity/spam-aware-activity-item.tsx
+++ b/src/components/features/activity/spam-aware-activity-item.tsx
@@ -5,7 +5,7 @@ import { ContributorHoverCard } from '../contributor';
 import { useContext, useMemo } from 'react';
 import { BotIcon } from '@/components/ui/icon';
 import { RepoStatsContext } from '@/lib/repo-stats-context';
-import { createContributorStats } from '@/lib/contributor-utils';
+import { createContributorStats, getContributorActivityCounts } from '@/lib/contributor-utils';
 import { useContributorRole } from '@/hooks/useContributorRoles';
 import { SpamProbabilityBadge } from '@/components/features/spam/spam-indicator';
 
@@ -27,19 +27,9 @@ export function SpamAwareActivityItem({ activity }: SpamAwareActivityItemProps) 
 
   // Calculate reviews and comments count for this user
   const activityCounts = useMemo(() => {
-    let reviews = 0;
-    let comments = 0;
-
-    stats.pullRequests.forEach((pr) => {
-      if (pr.reviews) {
-        reviews += pr.reviews.filter((review) => review.user.login === user.name).length;
-      }
-      if (pr.comments) {
-        comments += pr.comments.filter((comment) => comment.user.login === user.name).length;
-      }
-    });
-
-    return { reviews, comments };
+    // Optimized: Use shared cache instead of O(N*M) loop
+    const allCounts = getContributorActivityCounts(stats.pullRequests);
+    return allCounts[user.name] || { reviews: 0, comments: 0 };
   }, [stats.pullRequests, user.name]);
 
   const getActivityColor = () => {


### PR DESCRIPTION
💡 What: 
Modified `SpamAwareActivityItem` to use the `getContributorActivityCounts` utility function from `@/lib/contributor-utils` instead of manually filtering `stats.pullRequests` inside a `useMemo` block.

🎯 Why: 
The previous implementation iterated over all PRs (O(N)) for *every* activity item rendered in a list (M items), resulting in an O(N*M) time complexity. By using `getContributorActivityCounts`, the PRs are iterated over once, and the results are cached in a `WeakMap`, reducing the per-item lookup time to O(1) amortized. This addresses a major bottleneck when rendering long activity feeds.

📊 Impact: 
Reduces the time complexity of calculating contributor activity counts from O(N*M) to O(N + M) (or O(1) per rendered item). This will significantly improve render times and reduce main thread blocking on pages displaying large lists of `SpamAwareActivityItem` components, especially for repositories with many PRs.

🔬 Measurement: 
1. Run `npm run test:unit -- src/components/features/activity/__tests__/activity-item-styling.test.tsx` to verify no regressions in activity item rendering.
2. Use React Profiler to measure the render time of a list containing many `SpamAwareActivityItem` components. The time spent in `useMemo` for `activityCounts` should be negligible compared to the previous implementation.

---
*PR created automatically by Jules for task [894202540937512078](https://jules.google.com/task/894202540937512078) started by @bdougie*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bdougie/contributor.info/pull/1776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
