### PR TITLE
fix: enable RLS on github_events_cache partitions and drop empty ones

### DIFF
--- a/supabase/migrations/20260427000000_secure_github_events_cache_partitions.sql
+++ b/supabase/migrations/20260427000000_secure_github_events_cache_partitions.sql
@@ -1,0 +1,85 @@
+-- Fix: RLS disabled on github_events_cache partitions (security advisor: rls_disabled_in_public)
+--
+-- Background: github_events_cache is a partitioned table. RLS was enabled on
+-- the parent and on partitions through 2025_10, but the migration that creates
+-- new monthly partitions did not enable RLS on subsequent children. The
+-- security advisor flagged 9 partitions exposed via PostgREST without RLS.
+--
+-- Of those 9, four are empty (0 rows, 0 inserts since stats reset 2025-04-08)
+-- plus _2025_11 which is also empty. The remaining four hold real data and
+-- continue to receive writes from gh-datapipe (via service_role).
+--
+-- This migration:
+--   1. Enables RLS on the four active partitions and adds policies that
+--      mirror _2025_10 (service_role manages, public reads).
+--   2. Drops five confirmed-empty partitions (_2025_04, _05, _07, _08, _11)
+--      that have never received data and are exposing 96kB each with no RLS.
+--
+-- Note: gh-datapipe writes via the service_role key, which bypasses RLS, so
+-- enabling RLS does not affect ingestion.
+
+BEGIN;
+
+-- =====================================================
+-- STEP 1: Enable RLS + policies on active partitions
+-- =====================================================
+
+DO $$
+DECLARE
+  partition_name text;
+BEGIN
+  FOREACH partition_name IN ARRAY ARRAY[
+    'github_events_cache_2025_12',
+    'github_events_cache_2026_01',
+    'github_events_cache_2026_02',
+    'github_events_cache_2026_03'
+  ]
+  LOOP
+    EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', partition_name);
+
+    EXECUTE format(
+      'DROP POLICY IF EXISTS %I ON public.%I',
+      'service_role_manage_' || partition_name,
+      partition_name
+    );
+    EXECUTE format(
+      'CREATE POLICY %I ON public.%I FOR ALL TO public USING ((SELECT auth.role()) = ''service_role'')',
+      'service_role_manage_' || partition_name,
+      partition_name
+    );
+
+    EXECUTE format(
+      'DROP POLICY IF EXISTS %I ON public.%I',
+      'public_read_' || partition_name,
+      partition_name
+    );
+    EXECUTE format(
+      'CREATE POLICY %I ON public.%I FOR SELECT TO public USING (true)',
+      'public_read_' || partition_name,
+      partition_name
+    );
+  END LOOP;
+END $$;
+
+-- =====================================================
+-- STEP 2: Drop empty partitions with no RLS
+-- =====================================================
+-- Each was verified empty: 0 live tuples and 0 inserts since the stats reset
+-- on 2025-04-08. Detaching first lets us DROP without affecting the parent.
+
+ALTER TABLE public.github_events_cache DETACH PARTITION public.github_events_cache_2025_04;
+DROP TABLE public.github_events_cache_2025_04;
+
+ALTER TABLE public.github_events_cache DETACH PARTITION public.github_events_cache_2025_05;
+DROP TABLE public.github_events_cache_2025_05;
+
+ALTER TABLE public.github_events_cache DETACH PARTITION public.github_events_cache_2025_07;
+DROP TABLE public.github_events_cache_2025_07;
+
+ALTER TABLE public.github_events_cache DETACH PARTITION public.github_events_cache_2025_08;
+DROP TABLE public.github_events_cache_2025_08;
+
+ALTER TABLE public.github_events_cache DETACH PARTITION public.github_events_cache_2025_11;
+DROP TABLE public.github_events_cache_2025_11;
+
+COMMIT;


### PR DESCRIPTION
## Summary

The Supabase security advisor flagged 9 `github_events_cache_*` partitions in `public` without RLS (`rls_disabled_in_public`, ERROR level). Root cause: the migration that creates new monthly partitions stopped enabling RLS after `_2025_10`, so every child after that was exposed via PostgREST.

This PR closes the gap in two parts:

**1. Enable RLS on the four active partitions** (`_2025_12`, `_2026_01`, `_2026_02`, `_2026_03`)

Policies mirror the working `_2025_10` pattern:
- `service_role_manage_<partition>` — `FOR ALL` to `public` USING `auth.role() = 'service_role'`
- `public_read_<partition>` — `FOR SELECT` to `public` USING `true`

**2. Drop five empty partitions** (`_2025_04`, `_05`, `_07`, `_08`, `_11`)

Each was verified empty: 0 live tuples and 0 inserts since the stats reset (2025-04-08, ~12 months of activity). They were holding 96kB each and exposing the schema with no RLS.

### Why this is safe for gh-datapipe

`../gh-datapipe` writes via the `service_role` key, which bypasses RLS — so enabling RLS does not affect ingestion. Dropping the empty partitions also doesn't affect ingestion because new events for those date ranges would still need a partition created first; current writes go to recent months.

### Follow-ups (separate PRs)

- The 36 always-true RLS policies (P0 — `rate_limits` is the worst, anon DELETE)
- 5 SECURITY DEFINER views, 4 exposed materialized views, 2 listable storage buckets
- The partition-creation migration itself needs the `ENABLE RLS` + policy block restored so this gap doesn't reappear
- Postgres upgrade and `vector` / `http` extension moves out of `public`

## Test plan

- [ ] Verify the 4 active partitions show `rls_enabled = true` after apply
- [ ] Verify `service_role_manage_*` and `public_read_*` policies exist on each
- [ ] Verify the 5 empty partitions no longer appear in `pg_inherits` for `github_events_cache`
- [ ] Re-run `get_advisors(security)` — expect 9 fewer `rls_disabled_in_public` errors
- [ ] Confirm gh-datapipe ingestion still writes to `_2026_03` (or current month) post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bdougie/contributor.info/pull/1785" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened backend data storage security by implementing enhanced access controls and improved protection policies to better safeguard user information.
  * Removed outdated and unused data segments to optimize performance, reduce storage requirements, and improve system reliability and operational stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->