### PR TITLE
fix: auto-create github_events_cache partitions with RLS

### DIFF
--- a/supabase/migrations/20260427000001_auto_create_events_cache_partition_with_rls.sql
+++ b/supabase/migrations/20260427000001_auto_create_events_cache_partition_with_rls.sql
@@ -1,0 +1,121 @@
+-- Fix: auto-create monthly github_events_cache partitions with RLS enabled
+--
+-- Background: create_monthly_partition() existed in migration 20250120 but is
+-- not present in production (likely dropped at some point). New monthly
+-- partitions have been created manually, and many were created without RLS
+-- enabled, exposing them via PostgREST. The current month (2026_04) is also
+-- missing, which means any insert with a current-month timestamp errors with
+-- "no partition of relation github_events_cache found for row" — a likely
+-- contributor to gh-datapipe / Inngest write failures.
+--
+-- This migration:
+--   1. Restores ensure_events_cache_partition(date) — idempotent helper that
+--      creates one month's partition with RLS + policies in a single call.
+--   2. Restores create_monthly_partition() to call the helper for next month.
+--   3. Calls the helper for current month (2026-04) and next month (2026-05)
+--      to close the immediate gap.
+--   4. Schedules a pg_cron job on the 25th of every month to keep the
+--      following month's partition pre-staged.
+--
+-- Policies match the _2025_10 pattern: service_role manages, public can read.
+
+BEGIN;
+
+-- =====================================================
+-- STEP 1: Idempotent partition helper
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION public.ensure_events_cache_partition(target_date date)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  start_date     date := date_trunc('month', target_date)::date;
+  end_date       date := (date_trunc('month', target_date) + interval '1 month')::date;
+  partition_name text := 'github_events_cache_' || to_char(start_date, 'YYYY_MM');
+  manage_policy  text := 'service_role_manage_' || partition_name;
+  read_policy    text := 'public_read_' || partition_name;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public' AND c.relname = partition_name
+  ) THEN
+    EXECUTE format(
+      'CREATE TABLE public.%I PARTITION OF public.github_events_cache FOR VALUES FROM (%L) TO (%L)',
+      partition_name, start_date, end_date
+    );
+  END IF;
+
+  EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', partition_name);
+
+  EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', manage_policy, partition_name);
+  EXECUTE format(
+    'CREATE POLICY %I ON public.%I FOR ALL TO public USING ((SELECT auth.role()) = ''service_role'')',
+    manage_policy, partition_name
+  );
+
+  EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', read_policy, partition_name);
+  EXECUTE format(
+    'CREATE POLICY %I ON public.%I FOR SELECT TO public USING (true)',
+    read_policy, partition_name
+  );
+
+  RETURN partition_name;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.ensure_events_cache_partition(date) FROM public, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.ensure_events_cache_partition(date) TO service_role;
+
+-- =====================================================
+-- STEP 2: Restore create_monthly_partition() to call the helper
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION public.create_monthly_partition()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  PERFORM public.ensure_events_cache_partition((CURRENT_DATE + interval '1 month')::date);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.create_monthly_partition() FROM public, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.create_monthly_partition() TO service_role;
+
+-- =====================================================
+-- STEP 3: Close the current-month gap
+-- =====================================================
+-- 2026-04 partition is missing in production; current-month inserts have been
+-- failing. Create it now along with 2026-05 to pre-stage next month.
+
+SELECT public.ensure_events_cache_partition(CURRENT_DATE);
+SELECT public.ensure_events_cache_partition((CURRENT_DATE + interval '1 month')::date);
+
+-- =====================================================
+-- STEP 4: Schedule monthly auto-creation
+-- =====================================================
+-- Runs on the 25th at 00:00 UTC, well before month-end so the next partition
+-- is in place before any insert needs it.
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+    IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'create-events-cache-partition') THEN
+      PERFORM cron.unschedule('create-events-cache-partition');
+    END IF;
+
+    PERFORM cron.schedule(
+      'create-events-cache-partition',
+      '0 0 25 * *',
+      $cmd$ SELECT public.create_monthly_partition(); $cmd$
+    );
+  END IF;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Two bugs surfaced while investigating the RLS gap in #1785:

**1. The current-month partition `_2026_04` does not exist in production.**
Today is 2026-04-27 — every insert with a current-month timestamp has been erroring with `no partition of relation "github_events_cache" found for row`. This is a likely contributor to the recent gh-datapipe / Inngest write failures. gh-datapipe and Inngest's `capture-repository-events` both insert events with `created_at = now()`, so they have effectively been blocked from writing for ~27 days.

**2. `create_monthly_partition()` doesn't exist in production** even though migration `20250120_github_events_classification.sql` defines it. Recent monthly partitions appear to have been created manually, and several were created without RLS enabled — that's the root cause of #1785.

This PR fixes both.

## Changes

### `ensure_events_cache_partition(target_date date)` (new helper)
Idempotent. Creates the partition for `target_date`'s month if missing, then **always** enables RLS and recreates the `service_role_manage_*` and `public_read_*` policies. `SECURITY DEFINER` with `search_path = ''`. Only `service_role` can execute it.

### `create_monthly_partition()` (restored, simplified)
Calls the helper for next month. Same security profile.

### Immediate gap-closing
Calls `ensure_events_cache_partition(CURRENT_DATE)` and `ensure_events_cache_partition(CURRENT_DATE + interval '1 month')` so `_2026_04` and `_2026_05` exist with RLS as soon as this migration applies.

### pg_cron schedule
Schedules `create-events-cache-partition` to run at `00:00 UTC on the 25th` of each month — well before month-end, so the next partition is always in place. Wrapped in an `IF EXISTS pg_extension` check so the migration is portable to environments without `pg_cron`.

## Why this is safe

- `ensure_events_cache_partition` is idempotent — no-op on existing partitions, only re-applies policies.
- gh-datapipe and Inngest both write via `service_role`, which bypasses RLS — adding RLS to new partitions does not affect ingestion.
- All app code reads via `.select()` and the `public_read` policy preserves anon access.
- Schedule guard prevents duplicate cron job rows on re-apply.

## Relationship to #1785

#1785 closes the existing gap (4 active partitions get RLS, 5 empty partitions get dropped). This PR prevents the gap from reopening on `_2026_05`, `_2026_06`, etc. They can merge in either order — they don't conflict.

## Test plan

- [ ] After apply, verify `_2026_04` and `_2026_05` exist as partitions of `github_events_cache` with `relrowsecurity = true`
- [ ] Verify `service_role_manage_github_events_cache_2026_04` and `public_read_github_events_cache_2026_04` policies exist (and same for `_2026_05`)
- [ ] Verify gh-datapipe and Inngest can resume writing current-month events (confirm via `n_tup_ins` on `_2026_04` increasing)
- [ ] Verify `cron.job` has one row named `create-events-cache-partition` with schedule `0 0 25 * *`
- [ ] Re-run `get_advisors(security)` — confirm no new `rls_disabled_in_public` for events cache partitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bdougie/contributor.info/pull/1786" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
