### PR TITLE
fix: drop always-true RLS policies on rate_limits

### DIFF
--- a/supabase/migrations/20260428000000_harden_rate_limits_rls.sql
+++ b/supabase/migrations/20260428000000_harden_rate_limits_rls.sql
@@ -1,0 +1,33 @@
+-- Fix: rate_limits has four always-true RLS policies (advisor: rls_policy_always_true)
+--
+-- Current policies on public.rate_limits:
+--   service_only_all       — ALL,    service_role only           (correct)
+--   rate_limits_select     — SELECT, anon|authenticated|service  (USING true)       — bypass
+--   rate_limits_insert     — INSERT, anon|authenticated|service  (WITH CHECK true)  — bypass
+--   rate_limits_update     — UPDATE, anon|authenticated|service  (USING+WITH CHECK true) — bypass
+--   rate_limits_delete     — DELETE, anon|authenticated|service  (USING true)       — bypass
+--
+-- Because RLS policies are OR'd together, the four loose policies override the
+-- correct service_only_all policy. The DELETE one is the worst: any anon
+-- caller with the publishable key can DELETE rows, defeating rate limiting
+-- entirely.
+--
+-- All current writers (netlify/functions/lib/rate-limiter.mts and
+-- supabase/functions/codeowners/index.ts) authenticate with the
+-- service_role key, so the service_only_all policy is sufficient.
+--
+-- Note: netlify/functions/api-*.mts fall back to SUPABASE_ANON_KEY when
+-- SUPABASE_SERVICE_ROLE_KEY is not set. After this migration, any deploy
+-- missing the service-role key will fail to write rate limits (silent under
+-- supabase-js — the request returns OK with zero affected rows). Production
+-- has 2536 successful updates on this table, so service-role is currently
+-- configured correctly; this is a deploy-config concern to track separately.
+
+BEGIN;
+
+DROP POLICY IF EXISTS rate_limits_select ON public.rate_limits;
+DROP POLICY IF EXISTS rate_limits_insert ON public.rate_limits;
+DROP POLICY IF EXISTS rate_limits_update ON public.rate_limits;
+DROP POLICY IF EXISTS rate_limits_delete ON public.rate_limits;
+
+COMMIT;


### PR DESCRIPTION
## Summary

The Supabase security advisor flagged `rate_limits` for `rls_policy_always_true` on four policies. The DELETE policy is the worst — any client with the publishable key can wipe rate-limit rows.

### Current policies on `public.rate_limits`

| Policy | Cmd | Roles | Clause | Issue |
|---|---|---|---|---|
| `service_only_all` | ALL | service_role | role = service_role | ✅ correct |
| `rate_limits_select` | SELECT | anon, authenticated, service | USING true | bypass |
| `rate_limits_insert` | INSERT | anon, authenticated, service | WITH CHECK true | bypass |
| `rate_limits_update` | UPDATE | anon, authenticated, service | USING + WITH CHECK true | bypass |
| `rate_limits_delete` | DELETE | anon, authenticated, service | USING true | **anon DELETE — defeats rate limiting** |

Postgres OR's permissive policies, so the four loose ones override `service_only_all`.

### Fix

Drop the four loose policies. `service_only_all` remains and is sufficient — all current writers use `service_role`:

- `netlify/functions/lib/rate-limiter.mts` (used by api-track-repository, api-file-tree, api-suggested-codeowners, api-suggest-reviewers)
- `supabase/functions/codeowners/index.ts`

Production telemetry confirms service_role is configured (`n_tup_upd: 2536` on this table over the last year of stats).

## Deploy-config caveat

`netlify/functions/api-*.mts` fall back to `SUPABASE_ANON_KEY` if `SUPABASE_SERVICE_ROLE_KEY` is missing. After this migration, any deploy missing the service-role key will silently fail rate-limit writes (supabase-js returns OK with zero affected rows). Currently the env var is set in production, but worth tracking as a separate hardening — fail fast instead of silently disabling rate limiting.

## Test plan

- [ ] Verify only `service_only_all` remains on `public.rate_limits` after apply
- [ ] Confirm rate limiter still functions (check `n_tup_upd` on `rate_limits` continues to climb post-deploy)
- [ ] Re-run `get_advisors(security)` — `rls_policy_always_true` count should drop from 36 → 33

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced rate limiting security by removing overly permissive access controls, ensuring fair usage policies are properly enforced for all users and preventing potential bypass attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bdougie/contributor.info/pull/1788" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
