### PR TITLE
fix: convert 5 SECURITY DEFINER views to security_invoker

### DIFF
--- a/supabase/migrations/20260428000003_fix_security_definer_views.sql
+++ b/supabase/migrations/20260428000003_fix_security_definer_views.sql
@@ -1,0 +1,30 @@
+-- Fix: 5 SECURITY DEFINER views (advisor: security_definer_view)
+--
+-- Postgres views default to SECURITY DEFINER behavior — they execute with
+-- the view-owner's permissions and bypass RLS on underlying tables. The
+-- advisor flags any view without `security_invoker = true` set explicitly.
+--
+-- Switching to SECURITY INVOKER means the view executes with the *querying*
+-- user's permissions and respects RLS on underlying tables. This is the
+-- safer default in modern Postgres (15+).
+--
+-- Verification per view:
+--   - users → app_users (public SELECT policy, qual=true) — safe
+--   - codeowners_with_repository → codeowners + repositories (both public read) — safe
+--   - items_needing_embeddings → issues + pull_requests + discussions +
+--       workspace_repositories — all public-readable. Caller is Inngest
+--       (service_role, bypasses RLS regardless).
+--   - items_needing_embeddings_priority → same. Caller is Inngest.
+--   - stuck_jobs_monitor → progressive_capture_jobs (service_role-only).
+--       No app callers found; used for manual ops monitoring.
+--       Tightening visibility to service_role-only is intended.
+
+BEGIN;
+
+ALTER VIEW public.users SET (security_invoker = true);
+ALTER VIEW public.codeowners_with_repository SET (security_invoker = true);
+ALTER VIEW public.items_needing_embeddings SET (security_invoker = true);
+ALTER VIEW public.items_needing_embeddings_priority SET (security_invoker = true);
+ALTER VIEW public.stuck_jobs_monitor SET (security_invoker = true);
+
+COMMIT;


### PR DESCRIPTION
## Summary

The Supabase security advisor flagged 5 views as `security_definer_view`. Postgres views default to SECURITY DEFINER behavior — they execute with the view-owner's permissions and bypass RLS on underlying tables. Setting `security_invoker = true` makes views respect the querying user's RLS context, which is the safer modern default (PG 15+).

### Views converted

| View | Underlying tables | Caller |
|---|---|---|
| \`users\` | \`app_users\` (public SELECT) | — |
| \`codeowners_with_repository\` | \`codeowners\`, \`repositories\` (both public read) | — |
| \`items_needing_embeddings\` | \`issues\`, \`pull_requests\`, \`discussions\`, \`workspace_repositories\` | Inngest (\`inngest-prod/index.ts:1712\`) |
| \`items_needing_embeddings_priority\` | same + \`workspaces\` | Inngest (\`compute-embeddings.ts:107\`) |
| \`stuck_jobs_monitor\` | \`progressive_capture_jobs\` (service_role only) | manual ops queries |

### Safety verification

- All Inngest callers use `supabaseAdmin` → service_role → `BYPASSRLS` → unaffected by view security mode
- All other underlying tables have public SELECT policies, so anon callers reading the views via PostgREST get identical results
- \`stuck_jobs_monitor\` was the one exception — now correctly hidden from anon, since \`progressive_capture_jobs\` has a service_role-only policy. No app code reads this view.

## Test plan

- [ ] Re-run \`get_advisors(security)\` — \`security_definer_view\` count: 5 → 0
- [ ] Confirm Inngest \`compute-embeddings\` job still finds items
- [ ] Confirm app's \`users\` view query (if any) still returns rows for anon
- [ ] Confirm \`stuck_jobs_monitor\` query from SQL editor still works (service_role context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bdougie/contributor.info/pull/1791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
