### PR TITLE
fix: restrict 4 PostgREST-exposed materialized views

### DIFF
--- a/src/hooks/use-user-workspaces.ts
+++ b/src/hooks/use-user-workspaces.ts
@@ -131,7 +131,7 @@ async function fetchUserWorkspaces(
 
   // 1. Fetch workspace stats from materialized view (replaces 2N queries)
   const { data: workspaceStats } = await supabase
-    .from('workspace_preview_stats')
+    .from('workspace_preview_stats_secure')
     .select('workspace_id, repository_count, member_count')
     .in('workspace_id', workspaceIdsArray)
     .returns<WorkspacePreviewStats[]>();

--- a/supabase/migrations/20260428000004_restrict_exposed_materialized_views.sql
+++ b/supabase/migrations/20260428000004_restrict_exposed_materialized_views.sql
@@ -1,0 +1,54 @@
+-- Fix: 4 materialized views exposed via PostgREST (advisor: materialized_view_in_api)
+--
+-- Materialized views can't have RLS policies, so direct exposure to anon /
+-- authenticated allows anyone with the publishable key to query stats for
+-- private/restricted entities just by knowing their IDs.
+--
+-- Three of the four matviews have no app callers; revoking anon/authenticated
+-- access removes them from the API surface entirely. service_role keeps full
+-- access for refresh and ops queries.
+--
+-- workspace_preview_stats is used by the frontend (use-user-workspaces.ts).
+-- We replace direct access with a SECURITY INVOKER wrapper view that
+-- inner-joins to public.workspaces — the RLS policies on that table filter
+-- out workspaces the caller can't see. Frontend code update lands in the
+-- same PR.
+
+BEGIN;
+
+-- =====================================================
+-- 3 unused matviews: revoke from anon/authenticated
+-- =====================================================
+
+REVOKE ALL ON public.repository_contribution_stats FROM anon, authenticated;
+REVOKE ALL ON public.quality_score_rankings        FROM anon, authenticated;
+REVOKE ALL ON public.workspace_topic_clusters      FROM anon, authenticated;
+
+-- =====================================================
+-- workspace_preview_stats: wrap with SECURITY INVOKER view
+-- =====================================================
+-- Frontend will query workspace_preview_stats_secure instead. The wrapper
+-- joins to workspaces, which has RLS, so anon/authenticated only see stats
+-- for workspaces they're authorized to see (public workspaces, owned, or
+-- workspaces where they're a member).
+
+REVOKE ALL ON public.workspace_preview_stats FROM anon, authenticated;
+
+CREATE OR REPLACE VIEW public.workspace_preview_stats_secure
+  WITH (security_invoker = true) AS
+SELECT s.workspace_id,
+       s.workspace_name,
+       s.workspace_slug,
+       s.repository_count,
+       s.member_count,
+       s.pinned_repository_count,
+       s.last_updated
+FROM public.workspace_preview_stats s
+INNER JOIN public.workspaces w ON w.id = s.workspace_id;
+
+GRANT SELECT ON public.workspace_preview_stats_secure TO anon, authenticated, service_role;
+
+COMMENT ON VIEW public.workspace_preview_stats_secure IS
+  'RLS-filtered wrapper around workspace_preview_stats matview. The JOIN to workspaces enforces visibility; anon/authenticated only see stats for workspaces they can read.';
+
+COMMIT;


### PR DESCRIPTION
## Summary

The Supabase advisor flagged 4 materialized views as `materialized_view_in_api`. Matviews can't carry RLS, so direct exposure to anon/authenticated lets anyone query stats for restricted entities just by knowing their IDs.

### Three unused matviews — revoked from anon/authenticated

No app callers found in `src/`, `supabase/functions/`, or `netlify/`:
- \`repository_contribution_stats\`
- \`quality_score_rankings\`
- \`workspace_topic_clusters\`

These no longer surface via PostgREST. `service_role` keeps full access for refresh jobs and ops queries.

### `workspace_preview_stats` — wrapped with RLS-aware view

Caller: \`src/hooks/use-user-workspaces.ts:134\`. The matview holds preview stats for **all** active workspaces (public and private). Anon could enumerate private workspace metadata by guessing IDs.

**Fix**:
1. Revoke direct access from anon/authenticated.
2. Create \`workspace_preview_stats_secure\` as `SECURITY INVOKER` view that inner-joins to \`public.workspaces\`. The workspaces table's RLS policies (\`rls_ws_select_member\`, \`rls_ws_select_public\`) filter out workspaces the caller can't see.
3. Frontend hook updated to query the wrapper.

```sql
CREATE OR REPLACE VIEW public.workspace_preview_stats_secure
  WITH (security_invoker = true) AS
SELECT s.workspace_id, s.workspace_name, s.workspace_slug,
       s.repository_count, s.member_count, s.pinned_repository_count, s.last_updated
FROM public.workspace_preview_stats s
INNER JOIN public.workspaces w ON w.id = s.workspace_id;
```

## Test plan

- [ ] Verify anon cannot SELECT from `workspace_preview_stats` directly post-deploy
- [ ] Verify anon CAN SELECT from `workspace_preview_stats_secure` and only sees public workspaces
- [ ] Verify authenticated user sees their own + public workspaces via the wrapper
- [ ] Confirm \`use-user-workspaces.ts\` hook still loads stats correctly in the dashboard
- [ ] Re-run \`get_advisors(security)\` — \`materialized_view_in_api\`: 4 → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bdougie/contributor.info/pull/1792" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
