### PR TITLE
fix: drop SELECT policies that allow listing public storage buckets

### DIFF
--- a/supabase/migrations/20260428000005_restrict_public_bucket_listing.sql
+++ b/supabase/migrations/20260428000005_restrict_public_bucket_listing.sql
@@ -1,0 +1,28 @@
+-- Fix: 2 public storage buckets allow listing (advisor: public_bucket_allows_listing)
+--
+-- Public buckets serve files via direct URL — no SELECT policy on
+-- storage.objects is required for URL-based access. The broad SELECT
+-- policies on these buckets currently allow any client with the
+-- publishable key to enumerate every file in the bucket via .list(),
+-- exposing more data than intended.
+--
+-- Buckets: chart-screenshots, social-cards (both public).
+--
+-- Caller impact:
+--   - chart-screenshots: no callers found.
+--   - social-cards: one .list() call in
+--     src/components/performance-monitoring-dashboard.tsx (loadCDNMetrics).
+--     This is an admin diagnostic that counts files for CDN metrics
+--     (which the same file describes as "mock CDN performance data").
+--     The dashboard handles errors gracefully — it will report 0 files
+--     until the metric is moved to a server-side Netlify endpoint that
+--     uses SUPABASE_SERVICE_ROLE_KEY.
+--
+-- URL-based image access (the actual product feature) is unaffected.
+
+BEGIN;
+
+DROP POLICY IF EXISTS "Public read access for chart screenshots" ON storage.objects;
+DROP POLICY IF EXISTS "Public read access for social cards"      ON storage.objects;
+
+COMMIT;


### PR DESCRIPTION
## Summary

The Supabase advisor flagged `chart-screenshots` and `social-cards` as `public_bucket_allows_listing`. Public buckets serve files via direct URL — they don't need a SELECT policy on `storage.objects` for URL access. The existing broad SELECT policies let any client with the publishable key enumerate every file in the bucket via `.list()`.

URL-based image access (the actual product feature: meta-tag previews, chart embeds) is **unaffected**.

## Caller impact

| Bucket | `.list()` callers |
|---|---|
| chart-screenshots | none |
| social-cards | 1 — \`src/components/performance-monitoring-dashboard.tsx:127\` (admin CDN diagnostic counting files; the same file describes its own metrics as "mock CDN performance data"; handles errors gracefully and will report 0 files until moved server-side) |

## Test plan

- [ ] Verify anon cannot \`.list()\` either bucket post-deploy
- [ ] Verify direct URL access to social card images and chart screenshots still works (load any repo page → meta tag image renders)
- [ ] Re-run \`get_advisors(security)\` — \`public_bucket_allows_listing\`: 2 → 0

## Follow-up

Move \`performance-monitoring-dashboard.tsx\` CDN metrics to a Netlify endpoint that uses \`SUPABASE_SERVICE_ROLE_KEY\`, or replace the metric entirely (it's mock data anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bdougie/contributor.info/pull/1793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
