### PR TITLE
fix: move http extension out of public schema

### DIFF
--- a/supabase/migrations/20260428000006_move_http_extension_out_of_public.sql
+++ b/supabase/migrations/20260428000006_move_http_extension_out_of_public.sql
@@ -1,0 +1,31 @@
+-- Fix: move `http` extension out of `public` schema (advisor: extension_in_public)
+--
+-- The advisor flags two extensions in `public`: `http` and `vector`.
+--
+-- Verified via pg_depend: nothing in this project's user-defined functions,
+-- views, or triggers calls http_get / http_post / etc. Only the extension's
+-- own types and functions depend on it. Safe to move.
+--
+-- The `vector` extension is intentionally NOT moved here. Eight tables have
+-- `vector(384)` columns (issues, pull_requests, discussions,
+-- similarity_cache, file_embeddings, contributor_analytics, repositories,
+-- plus replicas/backups). Moving the extension requalifies the type to
+-- `extensions.vector(384)`, which is technically transparent but exposes
+-- regression risk in RPC signatures, view definitions, and migration
+-- replay paths. The security upside is marginal (the vector type itself
+-- is harmless). Skipping; advisor will continue to flag it (1 finding).
+
+-- The http extension does not support ALTER EXTENSION ... SET SCHEMA, so we
+-- must DROP and re-CREATE in the target schema. This is safe here because
+-- pg_depend confirms only the extension's own objects depend on it — no
+-- user functions, triggers, or views reference http_* functions.
+
+BEGIN;
+
+CREATE SCHEMA IF NOT EXISTS extensions;
+GRANT USAGE ON SCHEMA extensions TO postgres, anon, authenticated, service_role;
+
+DROP EXTENSION IF EXISTS http;
+CREATE EXTENSION http SCHEMA extensions;
+
+COMMIT;


### PR DESCRIPTION
## Summary

The Supabase advisor flagged `http` and `vector` as `extension_in_public`. This PR moves `http`. `vector` is intentionally left where it is.

### `http` — moved to `extensions` schema

- pg_depend confirms no user-defined functions, views, or triggers call \`http_*\` — only the extension's own objects depend on it.
- The extension doesn't support \`ALTER EXTENSION ... SET SCHEMA\`, so the migration drops and recreates it in \`extensions\`.
- With no user-code dependencies, the drop has no fallout.

### `vector` — left in `public` (deliberate)

Eight tables have \`vector(384)\` columns: \`issues\`, \`pull_requests\`, \`discussions\`, \`similarity_cache\`, \`file_embeddings\`, \`contributor_analytics\`, \`repositories\`, plus replicas/backups. Relocating requalifies the type to \`extensions.vector(384)\`, which is technically transparent but exposes regression risk in RPC signatures, view definitions, and migration replay paths. The advisor will continue to flag it (1 finding) — accepting that for now in exchange for stability.

## Test plan

- [ ] Verify \`http\` shows \`schema = extensions\` after deploy
- [ ] Re-run \`get_advisors(security)\` — \`extension_in_public\`: 2 → 1

## What this PR does NOT do

- **Postgres upgrade** (\`vulnerable_postgres_version\` advisor): requires Supabase Dashboard → Settings → Infrastructure → Upgrade. Not migration-runnable.
- **Move \`vector\`**: skipped per above.
- **Leaked password protection** (\`auth_leaked_password_protection\`): requires Dashboard → Authentication → Sign In / Up → Password Strength. Not migration-runnable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/bdougie/contributor.info/pull/1794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
