### PR TITLE
fix: unblock workspace delete and repository add/remove for owners

### DIFF
--- a/src/components/features/workspace/AddToWorkspaceModal.tsx
+++ b/src/components/features/workspace/AddToWorkspaceModal.tsx
@@ -21,6 +21,7 @@ import { Crown, LogIn, Plus, Loader2, AlertCircle } from '@/components/ui/icon';
 import { getWorkspaceRoute } from '@/lib/utils/workspace-routes';
 import { toast } from 'sonner';
 import { getSupabase } from '@/lib/supabase-lazy';
+import { getAppUserId } from '@/lib/auth-helpers';
 import { WorkspaceService } from '@/services/workspace.service';
 import { useUserWorkspaces } from '@/hooks/use-user-workspaces';
 import { useSubscriptionLimits } from '@/hooks/use-subscription-limits';
@@ -146,10 +147,21 @@ export function AddToWorkspaceModal({ open, onOpenChange, owner, repo }: AddToWo
 
     setIsSubmitting(true);
     try {
-      const result = await WorkspaceService.addRepositoryToWorkspace(selectedWorkspaceId, user.id, {
-        repository_id: repoId,
-        is_pinned: false,
-      });
+      // Workspace tables reference app_users.id, not auth.users.id
+      const appUserId = await getAppUserId();
+      if (!appUserId) {
+        toast.error('Could not resolve your account. Please log in again.');
+        return;
+      }
+
+      const result = await WorkspaceService.addRepositoryToWorkspace(
+        selectedWorkspaceId,
+        appUserId,
+        {
+          repository_id: repoId,
+          is_pinned: false,
+        }
+      );
 
       if (result.success) {
         toast.success(`Added ${owner}/${repo} to workspace successfully!`);

--- a/src/components/features/workspace/settings/WorkspaceSettings.tsx
+++ b/src/components/features/workspace/settings/WorkspaceSettings.tsx
@@ -202,12 +202,18 @@ export function WorkspaceSettings({
     setIsLoading(true);
     try {
       const supabase = await getSupabase();
-      const { error } = await supabase
+      const { data: deleted, error } = await supabase
         .from('workspaces')
         .update({ is_active: false })
-        .eq('id', workspace.id);
+        .eq('id', workspace.id)
+        .select('id');
 
       if (error) throw error;
+
+      // RLS blocks manifest as 0 affected rows with no error — don't report success
+      if (!deleted || deleted.length === 0) {
+        throw new Error('No workspace was deleted — you may not have permission');
+      }
 
       toast({
         title: 'Workspace Deleted',

--- a/src/services/__tests__/workspace.service.test.ts
+++ b/src/services/__tests__/workspace.service.test.ts
@@ -658,6 +658,20 @@ describe('WorkspaceService', () => {
     });
 
     it('should reject update without proper permissions', async () => {
+      // Mock owner check - user does not own the workspace
+      vi.mocked(supabase.from).mockReturnValueOnce({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: null,
+                error: null,
+              }),
+            }),
+          }),
+        }),
+      } as MockSupabaseResponse);
+
       // Mock permission check - viewer role
       vi.mocked(supabase.from).mockReturnValueOnce({
         select: vi.fn().mockReturnValue({
@@ -987,19 +1001,49 @@ describe('WorkspaceService', () => {
       expect(result.role).toBe('owner');
     });
 
-    it('should return hasPermission: true when user has admin role', async () => {
-      vi.mocked(supabase.from).mockReturnValue({
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnValue({
-            eq: vi.fn().mockReturnValue({
-              maybeSingle: vi.fn().mockResolvedValue({
-                data: { role: 'admin' },
-                error: null,
+    it('should grant owner permission via workspaces.owner_id when no member row exists', async () => {
+      vi.mocked(supabase.from).mockImplementation(
+        (table: string) =>
+          ({
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockReturnValue({
+                  maybeSingle: vi.fn().mockResolvedValue({
+                    data: table === 'workspaces' ? { owner_id: mockUserId } : null,
+                    error: null,
+                  }),
+                }),
               }),
             }),
-          }),
-        }),
-      } as unknown as MockQueryBuilder);
+          }) as unknown as MockQueryBuilder
+      );
+
+      const result = await WorkspaceService.checkPermission(mockWorkspaceId, mockUserId, [
+        'owner',
+        'maintainer',
+      ]);
+
+      expect(result.hasPermission).toBe(true);
+      expect(result.role).toBe('owner');
+    });
+
+    it('should return hasPermission: true when user has admin role', async () => {
+      // Table-aware: owner check finds nothing, member row has admin role
+      vi.mocked(supabase.from).mockImplementation(
+        (table: string) =>
+          ({
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockReturnValue({
+                  maybeSingle: vi.fn().mockResolvedValue({
+                    data: table === 'workspaces' ? null : { role: 'admin' },
+                    error: null,
+                  }),
+                }),
+              }),
+            }),
+          }) as unknown as MockQueryBuilder
+      );
 
       const result = await WorkspaceService.checkPermission(mockWorkspaceId, mockUserId, [
         'owner',
@@ -1012,18 +1056,22 @@ describe('WorkspaceService', () => {
     });
 
     it('should return hasPermission: true when user has maintainer role', async () => {
-      vi.mocked(supabase.from).mockReturnValue({
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnValue({
-            eq: vi.fn().mockReturnValue({
-              maybeSingle: vi.fn().mockResolvedValue({
-                data: { role: 'maintainer' },
-                error: null,
+      // Table-aware: owner check finds nothing, member row has maintainer role
+      vi.mocked(supabase.from).mockImplementation(
+        (table: string) =>
+          ({
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockReturnValue({
+                  maybeSingle: vi.fn().mockResolvedValue({
+                    data: table === 'workspaces' ? null : { role: 'maintainer' },
+                    error: null,
+                  }),
+                }),
               }),
             }),
-          }),
-        }),
-      } as unknown as MockQueryBuilder);
+          }) as unknown as MockQueryBuilder
+      );
 
       const result = await WorkspaceService.checkPermission(mockWorkspaceId, mockUserId, [
         'owner',
@@ -1036,18 +1084,22 @@ describe('WorkspaceService', () => {
     });
 
     it('should return hasPermission: false when user has contributor role but needs admin', async () => {
-      vi.mocked(supabase.from).mockReturnValue({
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnValue({
-            eq: vi.fn().mockReturnValue({
-              maybeSingle: vi.fn().mockResolvedValue({
-                data: { role: 'contributor' },
-                error: null,
+      // Table-aware: owner check finds nothing, member row has contributor role
+      vi.mocked(supabase.from).mockImplementation(
+        (table: string) =>
+          ({
+            select: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                eq: vi.fn().mockReturnValue({
+                  maybeSingle: vi.fn().mockResolvedValue({
+                    data: table === 'workspaces' ? null : { role: 'contributor' },
+                    error: null,
+                  }),
+                }),
               }),
             }),
-          }),
-        }),
-      } as unknown as MockQueryBuilder);
+          }) as unknown as MockQueryBuilder
+      );
 
       const result = await WorkspaceService.checkPermission(mockWorkspaceId, mockUserId, [
         'owner',
@@ -1122,6 +1174,20 @@ describe('WorkspaceService', () => {
     };
 
     it('should fail with 403 when user has contributor role', async () => {
+      // Mock owner check - user does not own the workspace
+      vi.mocked(supabase.from).mockReturnValueOnce({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: null,
+                error: null,
+              }),
+            }),
+          }),
+        }),
+      } as unknown as MockQueryBuilder);
+
       // Mock permission check - user is contributor (insufficient permissions)
       vi.mocked(supabase.from).mockReturnValueOnce({
         select: vi.fn().mockReturnValue({

--- a/src/services/workspace.service.ts
+++ b/src/services/workspace.service.ts
@@ -250,15 +250,9 @@ export class WorkspaceService {
         };
       }
 
-      // Check permissions
-      const { data: member } = await supabase
-        .from('workspace_members')
-        .select('role')
-        .eq('workspace_id', workspaceId)
-        .eq('user_id', userId)
-        .maybeSingle();
-
-      if (!member || !['owner', 'maintainer'].includes(member.role)) {
+      // Check permissions (owner via workspaces.owner_id, or owner/maintainer member row)
+      const permission = await this.checkPermission(workspaceId, userId, ['owner', 'maintainer']);
+      if (!permission.hasPermission) {
         return {
           success: false,
           error: 'Insufficient permissions to update workspace',
@@ -580,6 +574,22 @@ export class WorkspaceService {
         userId,
         requiredRoles,
       });
+
+      // The workspace owner may not have a workspace_members row (legacy data,
+      // or the owner-member trigger failed silently) — check owner_id first.
+      const { data: ownedWorkspace } = await supabase
+        .from('workspaces')
+        .select('owner_id')
+        .eq('id', workspaceId)
+        .eq('owner_id', userId)
+        .maybeSingle();
+
+      if (ownedWorkspace) {
+        return {
+          hasPermission: requiredRoles.includes('owner'),
+          role: 'owner',
+        };
+      }
 
       const { data: member, error: queryError } = await supabase
         .from('workspace_members')

--- a/supabase/migrations/20260711120000_fix_workspace_write_triggers.sql
+++ b/supabase/migrations/20260711120000_fix_workspace_write_triggers.sql
@@ -1,0 +1,121 @@
+-- Fix: All workspace write operations blocked by broken triggers
+--
+-- Symptoms (all confirmed in production on 2026-07-11):
+--   1. Workspace soft-delete (UPDATE workspaces SET is_active = false) fails with
+--      42703 'record "new" has no field "workspace_id"'. The shared trigger function
+--      trigger_workspace_stats_refresh() reads NEW.workspace_id, which exists on
+--      workspace_repositories/workspace_members but NOT on workspaces (its PK is "id").
+--      The trigger fires exactly WHEN (OLD.is_active IS DISTINCT FROM NEW.is_active),
+--      i.e. only on soft-delete — so owners can never delete a workspace.
+--   2. Adding/removing repositories fails with 42P01 'relation "workspace_metrics_cache"
+--      does not exist'. trigger_invalidate_cache_on_repo_change calls
+--      mark_workspace_cache_stale(), which UPDATEs workspace_metrics_cache — a table
+--      dropped by 20260428000007_drop_dead_tables.sql.
+--   3. Even where NEW.workspace_id is valid, trigger_workspace_stats_refresh() runs
+--      REFRESH MATERIALIZED VIEW CONCURRENTLY, which cannot execute inside a trigger's
+--      transaction (0A000) — breaking workspace_members INSERTs (owner auto-membership,
+--      invitation acceptance) and workspace_repositories writes.
+--
+-- The materialized view workspace_preview_stats is already refreshed every 5 minutes by
+-- the pg_cron job 'refresh-workspace-preview-stats', so the row-level refresh triggers
+-- are redundant. Drop them.
+
+BEGIN;
+
+-- =====================================================
+-- 1. Drop broken stats-refresh triggers (matview is cron-refreshed)
+-- =====================================================
+
+DROP TRIGGER IF EXISTS trigger_refresh_stats_on_workspace_change ON public.workspaces;
+DROP TRIGGER IF EXISTS trigger_refresh_stats_on_repo_change ON public.workspace_repositories;
+DROP TRIGGER IF EXISTS trigger_refresh_stats_on_member_change ON public.workspace_members;
+DROP FUNCTION IF EXISTS public.trigger_workspace_stats_refresh();
+
+-- =====================================================
+-- 2. Drop cache-invalidation trigger for the dropped workspace_metrics_cache table
+-- =====================================================
+
+DROP TRIGGER IF EXISTS trigger_invalidate_cache_on_repo_change ON public.workspace_repositories;
+DROP FUNCTION IF EXISTS public.invalidate_workspace_cache_on_repo_change();
+
+-- The web client still calls this via supabase.rpc() in invalidateWorkspaceMetrics().
+-- Keep the signature but make it a no-op until the in-memory/DB cache strategy is rebuilt.
+CREATE OR REPLACE FUNCTION public.mark_workspace_cache_stale(p_workspace_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+    -- No-op: workspace_metrics_cache was dropped in 20260428000007_drop_dead_tables.
+    NULL;
+END;
+$$;
+
+-- =====================================================
+-- 3. Align workspace_repositories INSERT policy with DELETE/UPDATE
+--    (old policy allowed retired roles 'editor'/'admin', omitted 'maintainer',
+--     and had no workspaces.owner_id fallback)
+-- =====================================================
+
+DROP POLICY IF EXISTS "Editors can add repositories to workspaces" ON public.workspace_repositories;
+DROP POLICY IF EXISTS "Owners and maintainers can add repositories" ON public.workspace_repositories;
+
+CREATE POLICY "Owners and maintainers can add repositories"
+    ON public.workspace_repositories FOR INSERT
+    WITH CHECK (
+        added_by = public.rls_current_app_user_id()
+        AND (
+            public.rls_workspace_owner_id(workspace_id) = public.rls_current_app_user_id()
+            OR public.rls_user_workspace_role(workspace_id, public.rls_current_app_user_id())
+                IN ('owner', 'maintainer')
+        )
+    );
+
+COMMENT ON POLICY "Owners and maintainers can add repositories" ON public.workspace_repositories IS
+'Owner (workspaces.owner_id) or accepted owner/maintainer member may add repositories. Uses rls_* SECURITY DEFINER helpers from 20260319000000.';
+
+-- =====================================================
+-- 4. Members/owners can view repositories of their private workspaces
+--    (previously only "View public workspace repositories" existed)
+-- =====================================================
+
+DROP POLICY IF EXISTS "Members can view their workspace repositories" ON public.workspace_repositories;
+
+CREATE POLICY "Members can view their workspace repositories"
+    ON public.workspace_repositories FOR SELECT
+    USING (
+        public.rls_workspace_owner_id(workspace_id) = public.rls_current_app_user_id()
+        OR public.rls_user_workspace_role(workspace_id, public.rls_current_app_user_id()) IS NOT NULL
+    );
+
+-- =====================================================
+-- 5. Owners must be able to see their own INACTIVE workspaces,
+--    or soft-delete is impossible.
+--
+--    PostgreSQL enforces SELECT policies against the NEW row of an UPDATE
+--    (when the statement reads the table, which it always does via WHERE).
+--    Both SELECT policies required is_active = true, so
+--    UPDATE workspaces SET is_active = false was rejected with
+--    42501 'new row violates row-level security policy' for every owner.
+--    Confirmed in production: the update succeeds the moment a SELECT
+--    policy matches the post-update row.
+-- =====================================================
+
+DROP POLICY IF EXISTS "rls_ws_select_member" ON public.workspaces;
+
+CREATE POLICY "rls_ws_select_member"
+    ON public.workspaces FOR SELECT
+    USING (
+        -- Owners can always see their workspaces, including soft-deleted ones
+        owner_id = public.rls_current_app_user_id()
+        -- Members only see active workspaces
+        OR (
+            is_active = true
+            AND public.rls_user_workspace_role(id, public.rls_current_app_user_id()) IS NOT NULL
+        )
+    );
+
+COMMENT ON POLICY "rls_ws_select_member" ON public.workspaces IS
+'Owner sees all their workspaces (incl. inactive, required for soft-delete WITH CHECK); accepted members see active ones. App queries filter is_active=true explicitly.';
+
+COMMIT;


### PR DESCRIPTION
## Summary

Workspace owners could not delete workspaces or add/remove repositories. An audit found **three stacked production database bugs** (all confirmed live, all fixed and verified) plus app-layer permission gaps.

### Database — `supabase/migrations/20260711120000_fix_workspace_write_triggers.sql`

> ⚠️ Already applied to production via the management API and recorded in `supabase_migrations.schema_migrations`. The file keeps the repo in sync; it is idempotent.

1. **Every workspace soft-delete crashed (42703).** `trigger_workspace_stats_refresh()` reads `NEW.workspace_id`, but was also attached to `workspaces` (whose PK is `id`), firing exactly `WHEN (OLD.is_active IS DISTINCT FROM NEW.is_active)`.
2. **Every repo add/remove crashed since 2026-04-28 (42P01).** `trigger_invalidate_cache_on_repo_change` updates `workspace_metrics_cache`, which `20260428000007_drop_dead_tables.sql` dropped. Kept the `mark_workspace_cache_stale()` RPC as a no-op since the client still calls it.
3. **Member inserts crashed too (0A000).** The stats-refresh trigger runs `REFRESH MATERIALIZED VIEW CONCURRENTLY`, which cannot execute inside a trigger transaction. All `trigger_refresh_stats_*` triggers are dropped — the `refresh-workspace-preview-stats` pg_cron job already refreshes the matview every 5 minutes.
4. **Soft-delete was still RLS-blocked after the trigger fix (42501).** Postgres enforces SELECT policies against the NEW row of an UPDATE; both SELECT policies required `is_active = true`, so flipping it to false made the row invisible mid-statement. `rls_ws_select_member` now lets owners see their own inactive workspaces.
5. **Policy alignment.** The `workspace_repositories` INSERT policy allowed retired roles (`editor`/`admin`), omitted `maintainer`, and had no `owner_id` fallback — now matches the DELETE/UPDATE policies. Also added a SELECT policy so members can see private-workspace repositories (previously only public workspaces were readable).

### App

- **`AddToWorkspaceModal`** passed the *auth* user id into `checkPermission`, which compares against `workspace_members.user_id` (an `app_users.id`) — a guaranteed mismatch, 403 for everyone on the repo-page "Add to workspace" flow. Now resolves via `getAppUserId()`.
- **`WorkspaceService.checkPermission`** was the only permission path with no `workspaces.owner_id` fallback — owners without a member row were denied. `updateWorkspace` now routes through it as well.
- **`WorkspaceSettings` delete handler** showed "Workspace Deleted" even when RLS blocked the update (0 rows, no error). It now verifies the affected row count.

## Verification

- Ran the exact app statements as the real owner (`SET LOCAL role authenticated` + JWT claims, rolled back): repo INSERT, repo DELETE, and workspace soft-delete all succeed; all failed before.
- `npx vitest run src/services/__tests__ src/components/features/workspace/__tests__` — 150/150 pass (updated mocks for the owner precheck, added a test for the `owner_id` fallback).
- `npm run typecheck` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)