### PR TITLE
feat: opt in private repositories via the GitHub App

### DIFF
--- a/app/webhooks/installation.ts
+++ b/app/webhooks/installation.ts
@@ -130,6 +130,35 @@ async function handleInstallationDeleted(event: InstallationEvent) {
       })
       .eq('installation_id', event.installation.id);
 
+    // Private repos covered by this installation lose their only sync
+    // token — stop tracking them
+    const { data: installationRecord } = await supabase
+      .from('github_app_installations')
+      .select('id')
+      .eq('installation_id', event.installation.id)
+      .maybeSingle();
+
+    if (installationRecord) {
+      const { data: enabledRepos } = await supabase
+        .from('app_enabled_repositories')
+        .select('repository_id, repositories!inner(id, is_private)')
+        .eq('installation_id', installationRecord.id);
+
+      const privateRepoIds = (enabledRepos || [])
+        .filter((row) => {
+          const repo = Array.isArray(row.repositories) ? row.repositories[0] : row.repositories;
+          return repo?.is_private;
+        })
+        .map((row) => row.repository_id);
+
+      if (privateRepoIds.length > 0) {
+        await supabase
+          .from('tracked_repositories')
+          .update({ tracking_enabled: false, updated_at: new Date().toISOString() })
+          .in('repository_id', privateRepoIds);
+      }
+    }
+
     // Track uninstall metrics
     await trackInstallationMetrics('installation_deleted', {
       account_type: event.installation.account.type,
@@ -218,17 +247,22 @@ async function handleRepositoriesAdded(
 
       if (!existingRepo) {
         // Create the repository if it doesn't exist
-        const { data: newRepo } = await supabase
+        const { data: newRepo, error: repoInsertError } = await supabase
           .from('repositories')
           .insert({
             github_id: repo.id,
             name: repo.name,
             full_name: repo.full_name,
-            private: repo.private,
+            owner: repo.owner?.login || repo.full_name.split('/')[0],
+            is_private: repo.private,
             // We'll need to fetch more details later
           })
           .select('id')
           .maybeSingle();
+
+        if (repoInsertError) {
+          console.error(`Failed to insert repository ${repo.full_name}:`, repoInsertError);
+        }
 
         repoId = newRepo?.id;
       }
@@ -346,7 +380,7 @@ async function handleRepositoriesRemoved(
     for (const repo of repositories) {
       const { data: repoRecord } = await supabase
         .from('repositories')
-        .select('id')
+        .select('id, is_private')
         .eq('github_id', repo.id)
         .maybeSingle();
 
@@ -366,6 +400,15 @@ async function handleRepositoriesRemoved(
             last_webhook_event_at: null,
           })
           .eq('id', repoRecord.id);
+
+        // Private repos are only accessible through the installation —
+        // once it's gone, sync has no token, so stop tracking them
+        if (repoRecord.is_private || repo.private) {
+          await supabase
+            .from('tracked_repositories')
+            .update({ tracking_enabled: false, updated_at: new Date().toISOString() })
+            .eq('repository_id', repoRecord.id);
+        }
       }
     }
   } catch (error) {

--- a/docs/product-requirements/prd-private-repo-opt-in.md
+++ b/docs/product-requirements/prd-private-repo-opt-in.md
@@ -1,0 +1,125 @@
+# PRD: Private Repository Opt-In via GitHub App
+
+**Status:** Implemented (v1) · **Date:** 2026-07-13
+
+> Implementation notes: phases 1–4 below are built. Sync uses installation
+> tokens on the Inngest/Node path (GraphQL sync, PR details/reviews/comments,
+> issues, commits). RLS migration: `20260713000000_private_repo_read_protection.sql`.
+> Still open: Deno edge functions (`github-sync`, `repository-sync-graphql`)
+> remain PAT-only; billing/tier gating (`allows_private_repos`) is NOT enforced
+> yet — any user can opt in a repo the app is installed on; Netlify env needs
+> `CONTRIBUTOR_APP_ID`/`CONTRIBUTOR_APP_KEY` for installation-token sync.
+
+## Summary
+
+Allow paying users to track private repositories. Authorization and data access ride on the
+existing **contributor.info GitHub App installation token** — not on expanding OAuth scopes.
+The user proves access by installing the app on the repo; billing entitlement
+(`tier_limits.allows_private_repos`) gates who may do it.
+
+## Why the GitHub App (not OAuth `repo` scope)
+
+- Login OAuth is deliberately public-only (`public_repo read:user user:email`,
+  `src/hooks/use-github-auth.ts:158`; documented promise in
+  `mintlify-docs/features/authentication.mdx:38`). Adding `repo` scope would grant
+  contributor.info write access to *all* of a user's private repos and break that promise.
+- The app already has what's needed: `contents: read`, `metadata: read`, installation
+  webhooks, and per-repo "selected repositories" installs (`app/config/app.ts`).
+- Installation tokens are org-scoped, revocable per-repo by the customer, and survive
+  the user's session — the right primitive for background sync.
+- Install plumbing already exists end-to-end: install button
+  (`src/components/features/repository/github-app-install-button.tsx`), installation webhook
+  handlers that store private repos (`app/webhooks/installation.ts:222-261`), and tables
+  `github_app_installations` + `app_enabled_repositories`
+  (`supabase/migrations/20250114000001_github_app_schema.sql`).
+
+## Current blockers (what actually prevents private repos today)
+
+1. **Hard 403** on tracking any private repo:
+   `netlify/functions/api-track-repository.mts:338-357`.
+2. **All sync uses a shared PAT** (`GITHUB_TOKEN`) or the user's public-scoped
+   `provider_token` — never the app installation token:
+   - `supabase/functions/github-sync/index.ts:40`
+   - `supabase/functions/repository-sync-graphql/index.ts:244`
+   - Inngest jobs in `src/lib/inngest/functions/*`
+3. **Installation-status endpoint is stubbed**:
+   `netlify/functions/github-app-installation-status.mts:51-53` hard-codes
+   bdougie/contributor.info.
+4. **Feature flag off**: `app/config/app.ts:118` `FEATURES.private_repos = false`.
+5. **Public-only assumptions** downstream: metrics cron filters `.eq('is_private', false)`
+   (`src/lib/inngest/functions/capture-repository-metrics-cron.ts:66,360`), repo view assumes
+   public (`src/components/features/repository/repo-view.tsx:172`), RLS/visibility rules never
+   restrict who can *view* a synced private repo.
+
+## Design
+
+### Opt-in flow
+
+1. User (on a tier with `allows_private_repos`) adds a private repo to a workspace.
+2. `api-track-repository` sees `private: true` → instead of 403:
+   - check entitlement (`subscriptions`/`tier_limits.allows_private_repos`);
+   - check `app_enabled_repositories` for an active installation covering the repo;
+   - if no installation → return `409 installation_required` with the app install URL
+     (`https://github.com/apps/contributor-info/installations/new`); frontend shows the
+     existing install button flow.
+3. `installation_repositories` webhook (already handled) records the repo; tracking is
+   confirmed either by the webhook completing the pending track request or by the user
+   retrying (now passing the check).
+4. Sync jobs resolve a token per repo: **installation token if the repo is private**
+   (via `app_enabled_repositories → github_app_installations.installation_id` →
+   `githubAppAuth.getInstallationOctokit()` from `app/lib/auth.ts`), else existing
+   PAT path. Centralize this in one `getTokenForRepo(repoId)` helper shared by the
+   Supabase edge functions and Inngest jobs.
+
+### Access control for viewing synced private data (critical, net-new)
+
+Syncing is only half the problem — a synced private repo must not be publicly visible:
+
+- Add RLS policies so `repositories` with `is_private = true` (and all child rows:
+  PRs, contributors-in-repo, issues, embeddings) are readable only by members of a
+  workspace containing that repo.
+- Private repos must be excluded from: trending/search/discovery endpoints, sitemaps,
+  social cards, public widgets/badges, `not-found.tsx` suggestions, and any
+  logged-out API surface.
+- Embeddings/similarity services must not leak private issue/PR content across repos
+  (`cross_repo_insights` stays off for private repos).
+
+### Revocation
+
+- `installation_repositories.removed` / `installation.deleted` webhooks (already handled in
+  `app/webhooks/installation.ts`) must also: disable tracking, and either delete or
+  quarantine already-synced private data per the data-retention policy.
+- Subscription downgrade (Polar webhook) → private repos become read-disabled, then purged
+  after grace period.
+
+### Entitlement mapping
+
+`tier_limits.allows_private_repos` already exists (enterprise = TRUE; free/pro = FALSE,
+`supabase/migrations/20250824000001_subscription_system.sql:226-228`). Decide whether the
+$99 Team tier (docs/pricing-structure.md says "Private & Public") should map to TRUE — the
+seed data and the pricing doc currently disagree.
+
+## Implementation phases
+
+1. **Foundations** — real installation-status lookup (replace the stub with a query on
+   `app_enabled_repositories`/`github_app_installations`); `getTokenForRepo()` helper;
+   RLS policies for private repos.
+2. **Opt-in path** — replace the 403 with entitlement + installation checks and the
+   `installation_required` response; frontend wiring in `AddRepositoryModal` /
+   `repository-tracking-card` to the existing install button.
+3. **Sync via installation tokens** — thread `getTokenForRepo` through
+   `github-sync`, `repository-sync-graphql`, and the Inngest capture jobs; remove
+   `.eq('is_private', false)` filters where private repos should now participate.
+4. **Leak-proofing & lifecycle** — audit public surfaces (widgets, social cards,
+   sitemap, trending, search); revocation + downgrade handling; docs update
+   (authentication.mdx keeps its "OAuth never sees private repos" promise; the private-repo
+   story is explicitly the App).
+5. **Flip `FEATURES.private_repos`** for entitled tiers.
+
+## Open questions
+
+- Team vs enterprise tier mapping for `allows_private_repos` (pricing doc vs seed data).
+- Rate limits: installation tokens get 5k req/hr *per installation* — likely an improvement
+  over the shared PAT, but large-org syncs should be tested.
+- Should private repos be workspace-only (no standalone `/owner/repo` page)? Simplest safe
+  answer: yes — private repos exist only inside workspaces, which already have membership.

--- a/fly-social-cards/src/chart-data-fetchers.js
+++ b/fly-social-cards/src/chart-data-fetchers.js
@@ -70,6 +70,7 @@ export async function fetchLotteryFactorData(supabase, owner, repo, timeRange = 
       .select('id')
       .eq('owner', owner)
       .eq('name', repo)
+      .eq('is_private', false)
       .single();
 
     if (repoError || !repoData) {
@@ -195,6 +196,7 @@ export async function fetchHealthFactorsData(supabase, owner, repo, timeRange = 
       .select('id')
       .eq('owner', owner)
       .eq('name', repo)
+      .eq('is_private', false)
       .single();
 
     if (repoError || !repoData) {
@@ -323,6 +325,7 @@ export async function fetchDistributionData(
       .select('id')
       .eq('owner', owner)
       .eq('name', repo)
+      .eq('is_private', false)
       .single();
 
     if (repoError || !repoData) {

--- a/fly-social-cards/src/server.js
+++ b/fly-social-cards/src/server.js
@@ -273,6 +273,7 @@ app.get('/social-cards/:type?', rateLimit, async (req, res) => {
             )
             .eq('owner', owner)
             .eq('name', repo)
+            .eq('is_private', false)
             .single();
 
           if (!error && repoData) {

--- a/netlify/functions/api-repository-status.mts
+++ b/netlify/functions/api-repository-status.mts
@@ -113,8 +113,19 @@ export default async (req: Request, _context: Context) => {
 
     const supabase = createClient(supabaseUrl, supabaseKey);
 
+    // Look up the repository with an RLS-scoped client so private repos are
+    // only visible to callers whose JWT grants workspace access — the
+    // service-role client would leak private repo existence and sync status
+    const anonKey = process.env.SUPABASE_ANON_KEY || process.env.VITE_SUPABASE_ANON_KEY;
+    const authHeader = req.headers.get('authorization') || req.headers.get('Authorization');
+    const rlsClient = anonKey
+      ? createClient(supabaseUrl, anonKey, {
+          global: authHeader ? { headers: { Authorization: authHeader } } : undefined,
+        })
+      : supabase;
+
     // Step 1: Check if repository exists
-    const { data: repoData, error: repoError } = await supabase
+    const { data: repoData, error: repoError } = await rlsClient
       .from('repositories')
       .select('id, owner, name, first_tracked_at, last_updated_at, is_active')
       .eq('owner', owner)

--- a/netlify/functions/api-track-repository.mts
+++ b/netlify/functions/api-track-repository.mts
@@ -7,6 +7,72 @@ import { RateLimiter, getRateLimitKey, applyRateLimitHeaders } from './lib/rate-
  * Blocked owner names that are app routes, not GitHub organizations
  * These should never be treated as repository identifiers
  */
+const GITHUB_APP_INSTALL_URL = 'https://github.com/apps/contributor-info/installations/new';
+
+/**
+ * Check whether the contributor.info GitHub App covers a repository.
+ * Private repositories can only be tracked through an app installation:
+ * the installation webhook creates the repositories row and the
+ * app_enabled_repositories link, and sync uses the installation token.
+ */
+async function checkAppInstallation(
+  supabaseUrl: string | undefined,
+  supabaseKey: string | undefined,
+  owner: string,
+  repo: string
+): Promise<{ installed: boolean; installationId?: number }> {
+  if (!supabaseUrl || !supabaseKey) {
+    return { installed: false };
+  }
+
+  try {
+    const supabase = createClient(supabaseUrl, supabaseKey);
+
+    const { data: repoData } = await supabase
+      .from('repositories')
+      .select('id')
+      .eq('owner', owner)
+      .eq('name', repo)
+      .maybeSingle();
+
+    if (repoData) {
+      const { data: enabledRepo } = await supabase
+        .from('app_enabled_repositories')
+        .select('github_app_installations!inner(installation_id, deleted_at, suspended_at)')
+        .eq('repository_id', repoData.id)
+        .is('github_app_installations.deleted_at', null)
+        .is('github_app_installations.suspended_at', null)
+        .maybeSingle();
+
+      const installation = Array.isArray(enabledRepo?.github_app_installations)
+        ? enabledRepo?.github_app_installations[0]
+        : enabledRepo?.github_app_installations;
+
+      if (installation) {
+        return { installed: true, installationId: installation.installation_id };
+      }
+    }
+
+    // Owner-wide installation covering all repositories
+    const { data: ownerInstall } = await supabase
+      .from('github_app_installations')
+      .select('installation_id')
+      .eq('account_name', owner)
+      .eq('repository_selection', 'all')
+      .is('deleted_at', null)
+      .is('suspended_at', null)
+      .maybeSingle();
+
+    if (ownerInstall) {
+      return { installed: true, installationId: ownerInstall.installation_id };
+    }
+  } catch (error) {
+    console.error('Failed to check app installation:', error);
+  }
+
+  return { installed: false };
+}
+
 const BLOCKED_OWNERS = new Set([
   'social-cards',
   'api',
@@ -268,6 +334,8 @@ export default async (req: Request, context: Context) => {
 
     // First, verify the repository exists on GitHub
     let githubData: GitHubRepository | null = null;
+    // Set when a private repository is covered by a GitHub App installation
+    let viaAppInstallation = false;
     try {
       // In production, we need a GitHub token to avoid rate limits
       const githubToken = process.env.GITHUB_TOKEN;
@@ -310,50 +378,71 @@ export default async (req: Request, context: Context) => {
       });
 
       if (githubResponse.status === 404) {
-        return withHeaders(
-          new Response(
-            JSON.stringify({
-              success: false,
-              error: 'Repository not found',
-              message: `Repository ${owner}/${repo} not found on GitHub`,
-            }),
-            {
-              status: 404,
-              headers: {
-                ...corsHeaders,
-                'Content-Type': 'application/json',
-              },
-            }
-          ),
-          rateLimitResult
-        );
-      }
+        // A 404 also happens for private repos our shared token can't see.
+        // If the GitHub App is installed on the repo, the installation webhook
+        // has already registered it — allow tracking to proceed from our DB.
+        const installation = await checkAppInstallation(supabaseUrl, supabaseKey, owner, repo);
 
-      if (!githubResponse.ok) {
-        throw new Error(`GitHub API error: ${githubResponse.status}`);
-      }
+        if (installation.installed) {
+          viaAppInstallation = true;
+        } else {
+          return withHeaders(
+            new Response(
+              JSON.stringify({
+                success: false,
+                error: 'Repository not found',
+                message: `Repository ${owner}/${repo} not found on GitHub. If this is a private repository, install the contributor.info GitHub App to track it.`,
+                code: 'repository_not_found',
+                installUrl: GITHUB_APP_INSTALL_URL,
+              }),
+              {
+                status: 404,
+                headers: {
+                  ...corsHeaders,
+                  'Content-Type': 'application/json',
+                },
+              }
+            ),
+            rateLimitResult
+          );
+        }
+      } else {
+        if (!githubResponse.ok) {
+          throw new Error(`GitHub API error: ${githubResponse.status}`);
+        }
 
-      githubData = await githubResponse.json();
+        githubData = await githubResponse.json();
 
-      // Check if it's a private repository
-      if (githubData.private) {
-        return withHeaders(
-          new Response(
-            JSON.stringify({
-              success: false,
-              error: 'Private repository',
-              message: 'Cannot track private repositories',
-            }),
-            {
-              status: 403,
-              headers: {
-                ...corsHeaders,
-                'Content-Type': 'application/json',
-              },
-            }
-          ),
-          rateLimitResult
-        );
+        // Private repositories require the GitHub App installation —
+        // that is the opt-in and what gives sync a token that can read them
+        if (githubData?.private) {
+          const installation = await checkAppInstallation(supabaseUrl, supabaseKey, owner, repo);
+
+          if (installation.installed) {
+            viaAppInstallation = true;
+          } else {
+            return withHeaders(
+              new Response(
+                JSON.stringify({
+                  success: false,
+                  error: 'Private repository',
+                  message:
+                    'Private repositories require the contributor.info GitHub App. Install it on this repository to opt in.',
+                  code: 'app_installation_required',
+                  installUrl: GITHUB_APP_INSTALL_URL,
+                }),
+                {
+                  status: 403,
+                  headers: {
+                    ...corsHeaders,
+                    'Content-Type': 'application/json',
+                  },
+                }
+              ),
+              rateLimitResult
+            );
+          }
+        }
       }
     } catch (githubError) {
       // Log the actual error for debugging
@@ -458,7 +547,7 @@ export default async (req: Request, context: Context) => {
       // Step 1: Check if repository already exists in database
       const { data: existingRepos, error: checkError } = await supabase
         .from('repositories')
-        .select('id, owner, name, github_id')
+        .select('id, owner, name, github_id, is_private')
         .eq('owner', owner)
         .eq('name', repo);
 
@@ -470,6 +559,33 @@ export default async (req: Request, context: Context) => {
       if (existingRepos && existingRepos.length > 0) {
         // Repository already exists
         const existingRepo = existingRepos[0];
+
+        // Private repositories stay opted-in only while the app is installed
+        if (existingRepo.is_private && !viaAppInstallation) {
+          const installation = await checkAppInstallation(supabaseUrl, supabaseKey, owner, repo);
+          if (!installation.installed) {
+            return withHeaders(
+              new Response(
+                JSON.stringify({
+                  success: false,
+                  error: 'Private repository',
+                  message:
+                    'Private repositories require the contributor.info GitHub App. Install it on this repository to opt in.',
+                  code: 'app_installation_required',
+                  installUrl: GITHUB_APP_INSTALL_URL,
+                }),
+                {
+                  status: 403,
+                  headers: {
+                    ...corsHeaders,
+                    'Content-Type': 'application/json',
+                  },
+                }
+              ),
+              rateLimitResult
+            );
+          }
+        }
 
         // Update repository with latest GitHub data
         interface RepositoryUpdateData {
@@ -545,6 +661,24 @@ export default async (req: Request, context: Context) => {
 
         if (updateError) {
           console.error('Failed to update repository with GitHub data:', updateError);
+        }
+
+        // Ensure the repository is in tracked_repositories — rows created by the
+        // GitHub App installation webhook (e.g. private repos) exist in
+        // repositories without ever having been tracked
+        const { error: existingTrackError } = await supabase.from('tracked_repositories').insert({
+          repository_id: existingRepo.id,
+          organization_name: owner,
+          repository_name: repo,
+          tracking_enabled: true,
+          priority: 'high',
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        });
+
+        if (existingTrackError && existingTrackError.code !== '23505') {
+          // Ignore duplicate key errors
+          console.error('Failed to track existing repository:', existingTrackError);
         }
 
         // Send sync event for existing repository
@@ -658,6 +792,30 @@ export default async (req: Request, context: Context) => {
       // Step 2: Create repository record directly
       // At this point we MUST have githubData since we return early on GitHub API failures
       if (!githubData) {
+        if (viaAppInstallation) {
+          // Private repo covered by an app installation, but the installation
+          // webhook hasn't registered the repository row yet — ask for a retry
+          return withHeaders(
+            new Response(
+              JSON.stringify({
+                success: false,
+                error: 'Installation pending',
+                message:
+                  'The GitHub App is installed, but repository data has not arrived yet. Please try again in a moment.',
+                code: 'installation_pending',
+              }),
+              {
+                status: 202,
+                headers: {
+                  ...corsHeaders,
+                  'Content-Type': 'application/json',
+                },
+              }
+            ),
+            rateLimitResult
+          );
+        }
+
         console.error('Critical error: githubData is null but we should have returned earlier');
         return withHeaders(
           new Response(

--- a/netlify/functions/github-app-installation-status.mts
+++ b/netlify/functions/github-app-installation-status.mts
@@ -3,7 +3,82 @@ import { createClient } from '@supabase/supabase-js';
 
 // Use SUPABASE_URL (server-side) first, fall back to VITE_ prefix for local dev
 const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || '';
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY || process.env.VITE_SUPABASE_ANON_KEY || '';
+// Installation tables are RLS-restricted to authenticated users, so this
+// server-side check needs the service role key (anon fallback for local dev)
+const supabaseKey =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ||
+  process.env.SUPABASE_ANON_KEY ||
+  process.env.VITE_SUPABASE_ANON_KEY ||
+  '';
+
+interface InstallationStatus {
+  installed: boolean;
+  installationId?: number;
+  installedAt?: string;
+}
+
+/**
+ * Check whether the contributor.info GitHub App is installed on a repository.
+ *
+ * A repo is considered covered when either:
+ * 1. It is linked in app_enabled_repositories to a live installation, or
+ * 2. Its owner has a live installation with repository_selection = 'all'
+ *    (repos created after install never fire installation_repositories events)
+ */
+async function getInstallationStatus(owner: string, repo: string): Promise<InstallationStatus> {
+  const supabase = createClient(supabaseUrl, supabaseKey);
+
+  const { data: repoData } = await supabase
+    .from('repositories')
+    .select('id')
+    .eq('owner', owner)
+    .eq('name', repo)
+    .maybeSingle();
+
+  if (repoData) {
+    const { data: enabledRepo } = await supabase
+      .from('app_enabled_repositories')
+      .select(
+        'enabled_at, github_app_installations!inner(installation_id, deleted_at, suspended_at)'
+      )
+      .eq('repository_id', repoData.id)
+      .is('github_app_installations.deleted_at', null)
+      .is('github_app_installations.suspended_at', null)
+      .maybeSingle();
+
+    const installation = Array.isArray(enabledRepo?.github_app_installations)
+      ? enabledRepo?.github_app_installations[0]
+      : enabledRepo?.github_app_installations;
+
+    if (installation) {
+      return {
+        installed: true,
+        installationId: installation.installation_id,
+        installedAt: enabledRepo?.enabled_at ?? undefined,
+      };
+    }
+  }
+
+  // Owner-wide installation covering all repositories
+  const { data: ownerInstall } = await supabase
+    .from('github_app_installations')
+    .select('installation_id, installed_at')
+    .eq('account_name', owner)
+    .eq('repository_selection', 'all')
+    .is('deleted_at', null)
+    .is('suspended_at', null)
+    .maybeSingle();
+
+  if (ownerInstall) {
+    return {
+      installed: true,
+      installationId: ownerInstall.installation_id,
+      installedAt: ownerInstall.installed_at ?? undefined,
+    };
+  }
+
+  return { installed: false };
+}
 
 export default async (req: Request, _context: Context) => {
   // CORS headers
@@ -48,39 +123,22 @@ export default async (req: Request, _context: Context) => {
   }
 
   try {
-    // For now, hard-code that the app is installed on bdougie/contributor.info
-    // In production, this would check the actual GitHub App installations in the database
-    const isInstalled = owner === 'bdougie' && repo === 'contributor.info';
-
-    if (isInstalled) {
-      return new Response(
-        JSON.stringify({
-          installed: true,
-          installationId: 123456789, // Placeholder
-          installedAt: '2024-01-01T00:00:00Z',
-        }),
-        {
-          status: 200,
-          headers: {
-            ...corsHeaders,
-            'Content-Type': 'application/json',
-            'Cache-Control': 'max-age=60', // Cache for 1 minute
-          },
-        }
-      );
+    if (!supabaseUrl || !supabaseKey) {
+      throw new Error('Supabase configuration missing');
     }
 
-    // Return not installed for other repositories
-    return new Response(JSON.stringify({ installed: false }), {
+    const status = await getInstallationStatus(owner, repo);
+
+    return new Response(JSON.stringify(status), {
       status: 200,
       headers: {
         ...corsHeaders,
         'Content-Type': 'application/json',
-        'Cache-Control': 'max-age=60',
+        'Cache-Control': 'max-age=60', // Cache for 1 minute
       },
     });
   } catch (error) {
-    // Return error response without logging
+    console.error('Failed to check installation status:', error);
     return new Response(
       JSON.stringify({
         error: 'Internal server error',

--- a/netlify/functions/widget-badge.mjs
+++ b/netlify/functions/widget-badge.mjs
@@ -142,11 +142,13 @@ async function fetchRepoStats(owner, repo) {
 
   try {
     // Get repository ID
+    // Widgets are public embeds — never serve private repository data
     const { data: repoData, error: repoError } = await supabase
       .from('repositories')
       .select('id')
       .eq('owner', owner)
       .eq('name', repo)
+      .eq('is_private', false)
       .single();
 
     if (repoError || !repoData) {

--- a/netlify/functions/widget-stat-card.mjs
+++ b/netlify/functions/widget-stat-card.mjs
@@ -47,11 +47,13 @@ async function fetchRepoStats(owner, repo) {
 
   try {
     // Get repository data
+    // Widgets are public embeds — never serve private repository data
     const { data: repoData, error: repoError } = await supabase
       .from('repositories')
       .select('id, description, language')
       .eq('owner', owner)
       .eq('name', repo)
+      .eq('is_private', false)
       .single();
 
     if (repoError || !repoData) {

--- a/scripts/sitemap/generate-sitemap.js
+++ b/scripts/sitemap/generate-sitemap.js
@@ -115,6 +115,7 @@ async function fetchRepositories() {
         last_updated_at
       `
       )
+      .eq('is_private', false)
       .order('stargazers_count', { ascending: false });
 
     if (error) {

--- a/src/components/features/workspace/AddRepositoryModal.tsx
+++ b/src/components/features/workspace/AddRepositoryModal.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Separator } from '@/components/ui/separator';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -16,7 +17,15 @@ import { GitHubSearchInput } from '@/components/ui/github-search-input';
 import { WorkspaceService as DefaultWorkspaceService } from '@/services/workspace.service';
 import { getSupabase } from '@/lib/supabase-lazy';
 import { toast } from 'sonner';
-import { Package, X, AlertCircle, CheckCircle2, Loader2, Star } from '@/components/ui/icon';
+import {
+  Package,
+  X,
+  AlertCircle,
+  CheckCircle2,
+  ExternalLink,
+  Loader2,
+  Star,
+} from '@/components/ui/icon';
 import type { Workspace } from '@/types/workspace';
 import type { GitHubRepository } from '@/lib/github';
 import { z } from 'zod';
@@ -50,6 +59,24 @@ const TIER_LIMITS = {
   pro: 10,
   enterprise: 100,
 } as const;
+
+const GITHUB_APP_INSTALL_URL = 'https://github.com/apps/contributor-info/installations/new';
+
+/**
+ * Tracking failure that carries the structured error code from the
+ * track-repository API (e.g. app_installation_required for private repos)
+ */
+class TrackingError extends Error {
+  code?: string;
+  installUrl?: string;
+
+  constructor(message: string, code?: string, installUrl?: string) {
+    super(message);
+    this.name = 'TrackingError';
+    this.code = code;
+    this.installUrl = installUrl;
+  }
+}
 
 interface StagedRepository extends GitHubRepository {
   notes?: string;
@@ -93,6 +120,9 @@ export function AddRepositoryModal({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [removingRepoId, setRemovingRepoId] = useState<string | null>(null);
+  // Private repos that need the GitHub App installed before they can be added
+  const [installNeeded, setInstallNeeded] = useState<{ repos: string[]; url: string } | null>(null);
+  const [privateRepoInput, setPrivateRepoInput] = useState('');
 
   // Calculate limits
   const isFreeTier = workspace?.tier === 'free';
@@ -249,6 +279,31 @@ export function AddRepositoryModal({
     [stagedRepos, existingRepoIds, canAddMore, maxRepos, workspace?.tier]
   );
 
+  const handleAddPrivateRepo = useCallback(() => {
+    const match = privateRepoInput.trim().match(/^([a-zA-Z0-9_.-]+)\/([a-zA-Z0-9_.-]+)$/);
+    if (!match) {
+      setError('Enter the repository as owner/name, e.g. acme/internal-tools');
+      setTimeout(() => setError(null), 3000);
+      return;
+    }
+    const [, owner, name] = match;
+
+    // Private repos can't be found via GitHub search with our public-only
+    // OAuth scope, so stage them from the typed owner/name — the tracking
+    // API verifies access via the GitHub App installation
+    handleSelectRepository({
+      id: 0,
+      name,
+      full_name: `${owner}/${name}`,
+      owner: { login: owner, avatar_url: `https://github.com/${owner}.png` },
+      description: null,
+      stargazers_count: 0,
+      forks_count: 0,
+      private: true,
+    });
+    setPrivateRepoInput('');
+  }, [privateRepoInput, handleSelectRepository]);
+
   const handleRemoveFromStaging = useCallback(
     (fullName: string) => {
       setStagedRepos(stagedRepos.filter((r) => r.full_name !== fullName));
@@ -336,7 +391,19 @@ export function AddRepositoryModal({
         .maybeSingle();
 
       if (existingRepo) {
-        return existingRepo.id;
+        // Repos registered by the GitHub App installation webhook (e.g. private
+        // repos) exist here without being tracked — only short-circuit when
+        // tracking is actually set up, otherwise go through the track API
+        const { data: trackedRepo } = await supabase
+          .from('tracked_repositories')
+          .select('id')
+          .eq('repository_id', existingRepo.id)
+          .eq('tracking_enabled', true)
+          .maybeSingle();
+
+        if (trackedRepo) {
+          return existingRepo.id;
+        }
       }
 
       // Repository not tracked yet — start tracking via API
@@ -361,15 +428,22 @@ export function AddRepositoryModal({
 
       // Handle API-level errors with user-friendly messages
       if (!trackResponse.ok) {
+        if (trackResult.code === 'app_installation_required') {
+          throw new TrackingError(
+            `${repo.full_name} is private. Install the contributor.info GitHub App on it to opt in.`,
+            trackResult.code,
+            trackResult.installUrl || GITHUB_APP_INSTALL_URL
+          );
+        }
         if (trackResponse.status === 404) {
-          throw new Error(`${repo.full_name} was not found on GitHub.`);
+          throw new TrackingError(
+            `${repo.full_name} was not found on GitHub. If it's a private repository, install the contributor.info GitHub App on it first.`,
+            trackResult.code,
+            trackResult.installUrl || GITHUB_APP_INSTALL_URL
+          );
         }
         if (trackResponse.status === 403) {
-          throw new Error(
-            trackResult.error === 'Private repository'
-              ? `${repo.full_name} is private and cannot be tracked.`
-              : `You don't have permission to track ${repo.full_name}.`
-          );
+          throw new Error(`You don't have permission to track ${repo.full_name}.`);
         }
         if (trackResponse.status === 429) {
           throw new Error('Rate limit reached. Please wait a moment and try again.');
@@ -378,6 +452,12 @@ export function AddRepositoryModal({
           throw new Error('The tracking service is temporarily unavailable. Please try again.');
         }
         throw new Error(trackResult.message || `Unable to track ${repo.full_name}.`);
+      }
+
+      if (trackResult.code === 'installation_pending') {
+        // App installed but the webhook hasn't registered the repo yet —
+        // wait for the repository row to appear
+        return await waitForRepository(owner, name);
       }
 
       if (trackResult.success && trackResult.repositoryId) {
@@ -408,6 +488,7 @@ export function AddRepositoryModal({
 
     setSubmitting(true);
     setError(null);
+    setInstallNeeded(null);
 
     try {
       const supabase = await getSupabaseClient();
@@ -417,7 +498,12 @@ export function AddRepositoryModal({
         stagedRepos.map(
           async (
             repo
-          ): Promise<{ id: string | null; error: string | null; repo: StagedRepository }> => {
+          ): Promise<{
+            id: string | null;
+            error: string | null;
+            trackingError?: unknown;
+            repo: StagedRepository;
+          }> => {
             try {
               const id = await trackAndResolveRepository(supabase, repo);
               return { id, error: null, repo };
@@ -425,7 +511,7 @@ export function AddRepositoryModal({
               const message =
                 err instanceof Error ? err.message : `Failed to set up ${repo.full_name}`;
               console.error('Error tracking repository %s:', repo.full_name, err);
-              return { id: null, error: message, repo };
+              return { id: null, error: message, trackingError: err, repo };
             }
           }
         )
@@ -436,9 +522,25 @@ export function AddRepositoryModal({
       );
       const failed = repoResults.filter((r) => r.id === null);
 
+      // Surface private repos that need the GitHub App with a dedicated
+      // install prompt instead of a plain error message
+      const installFailures = failed.filter(
+        (r) => r.trackingError instanceof TrackingError && r.trackingError.installUrl
+      );
+      if (installFailures.length > 0) {
+        setInstallNeeded({
+          repos: installFailures.map((r) => r.repo.full_name),
+          url:
+            (installFailures[0].trackingError as TrackingError).installUrl ||
+            GITHUB_APP_INSTALL_URL,
+        });
+      }
+
       // Add resolved repositories to the workspace
       let successCount = 0;
-      const errors: string[] = failed.map((r) => r.error!);
+      const errors: string[] = failed
+        .filter((r) => !installFailures.includes(r))
+        .map((r) => r.error!);
 
       for (const { id: repoId, repo: stagedRepo } of resolved) {
         const response = await WorkspaceService.addRepositoryToWorkspace(workspaceId, appUserId, {
@@ -488,6 +590,7 @@ export function AddRepositoryModal({
   const handleCancel = useCallback(() => {
     if (!submitting) {
       setError(null);
+      setInstallNeeded(null);
       setStagedRepos([]);
       onOpenChange(false);
     }
@@ -539,6 +642,32 @@ export function AddRepositoryModal({
             onSelect={handleSelectRepository}
             showButton={false}
           />
+          <div className="flex gap-2">
+            <Input
+              value={privateRepoInput}
+              onChange={(e) => setPrivateRepoInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  handleAddPrivateRepo();
+                }
+              }}
+              placeholder="owner/repo"
+              aria-label="Add a private repository by owner/name"
+            />
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleAddPrivateRepo}
+              disabled={!privateRepoInput.trim()}
+            >
+              Add private repo
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Private repositories don't appear in search. Enter owner/name directly — tracking them
+            requires installing the contributor.info GitHub App.
+          </p>
         </div>
 
         {/* Existing Repositories Section */}
@@ -676,6 +805,34 @@ export function AddRepositoryModal({
             </ScrollArea>
           )}
         </div>
+
+        {/* GitHub App install prompt for private repositories */}
+        {installNeeded && (
+          <Alert>
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription className="flex flex-col gap-2">
+              <span>
+                {installNeeded.repos.join(', ')}{' '}
+                {installNeeded.repos.length === 1
+                  ? 'is a private repository'
+                  : 'are private repositories'}
+                . Install the contributor.info GitHub App on{' '}
+                {installNeeded.repos.length === 1 ? 'it' : 'them'} to opt in, then add{' '}
+                {installNeeded.repos.length === 1 ? 'it' : 'them'} again.
+              </span>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="w-fit gap-1"
+                onClick={() => window.open(installNeeded.url, '_blank', 'noopener,noreferrer')}
+              >
+                Install GitHub App
+                <ExternalLink className="h-3 w-3" />
+              </Button>
+            </AlertDescription>
+          </Alert>
+        )}
 
         {/* Error Alert */}
         {error && (

--- a/src/lib/github-app/installation-token.ts
+++ b/src/lib/github-app/installation-token.ts
@@ -1,0 +1,167 @@
+/**
+ * GitHub App installation tokens for server-side sync of private repositories.
+ *
+ * The shared GITHUB_TOKEN PAT can only see public repositories. Private repos
+ * are opted in by installing the contributor.info GitHub App, and sync must
+ * authenticate with that installation's token instead. This module is
+ * server-only (Inngest/Netlify functions) — it uses node:crypto to sign the
+ * app JWT so it adds no dependencies.
+ */
+import { createSign } from 'node:crypto';
+import { supabaseAdmin } from '../supabase-admin';
+
+function base64url(input: Buffer | string): string {
+  return (typeof input === 'string' ? Buffer.from(input) : input)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+function getAppCredentials(): { appId: string; privateKey: string } | null {
+  const appId = process.env.CONTRIBUTOR_APP_ID || process.env.GITHUB_APP_ID || '';
+
+  let privateKey = process.env.CONTRIBUTOR_APP_KEY || '';
+  if (!privateKey && process.env.GITHUB_APP_PRIVATE_KEY_ENCODED) {
+    privateKey = Buffer.from(process.env.GITHUB_APP_PRIVATE_KEY_ENCODED, 'base64').toString();
+  }
+  if (!privateKey && process.env.GITHUB_APP_PRIVATE_KEY) {
+    privateKey = Buffer.from(process.env.GITHUB_APP_PRIVATE_KEY, 'base64').toString();
+  }
+
+  if (!appId || !privateKey) {
+    return null;
+  }
+  return { appId, privateKey };
+}
+
+function generateAppJWT(appId: string, privateKey: string): string {
+  const now = Math.floor(Date.now() / 1000);
+  const header = base64url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
+  // iat backdated 60s to allow for clock drift, 10 minute expiry (GitHub max)
+  const payload = base64url(JSON.stringify({ iat: now - 60, exp: now + 600, iss: appId }));
+  const signature = base64url(
+    createSign('RSA-SHA256').update(`${header}.${payload}`).sign(privateKey)
+  );
+  return `${header}.${payload}.${signature}`;
+}
+
+// Installation tokens are valid for 1 hour; cache with a safety margin
+const tokenCache = new Map<number, { token: string; expiresAt: number }>();
+
+export async function getInstallationToken(installationId: number): Promise<string> {
+  const cached = tokenCache.get(installationId);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.token;
+  }
+
+  const credentials = getAppCredentials();
+  if (!credentials) {
+    throw new Error(
+      'GitHub App credentials not configured (CONTRIBUTOR_APP_ID / CONTRIBUTOR_APP_KEY)'
+    );
+  }
+
+  const jwt = generateAppJWT(credentials.appId, credentials.privateKey);
+  const response = await fetch(
+    `https://api.github.com/app/installations/${installationId}/access_tokens`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: 'application/vnd.github.v3+json',
+        'User-Agent': 'contributor-info',
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `Failed to create installation token for installation ${installationId}: ${response.status} ${body}`
+    );
+  }
+
+  const data = (await response.json()) as { token: string; expires_at: string };
+  tokenCache.set(installationId, {
+    token: data.token,
+    // Refresh 5 minutes before GitHub's expiry
+    expiresAt: new Date(data.expires_at).getTime() - 5 * 60 * 1000,
+  });
+
+  return data.token;
+}
+
+/**
+ * Find the GitHub App installation covering a repository (by database id).
+ * Checks the explicit app_enabled_repositories link first, then falls back
+ * to an owner-wide installation with repository_selection = 'all'.
+ */
+export async function getInstallationIdForRepo(repositoryId: string): Promise<number | null> {
+  if (!supabaseAdmin) {
+    throw new Error('Supabase admin client not available');
+  }
+
+  const { data: enabledRepo } = await supabaseAdmin
+    .from('app_enabled_repositories')
+    .select('github_app_installations!inner(installation_id, deleted_at, suspended_at)')
+    .eq('repository_id', repositoryId)
+    .is('github_app_installations.deleted_at', null)
+    .is('github_app_installations.suspended_at', null)
+    .maybeSingle();
+
+  const installation = Array.isArray(enabledRepo?.github_app_installations)
+    ? enabledRepo?.github_app_installations[0]
+    : enabledRepo?.github_app_installations;
+
+  if (installation?.installation_id) {
+    return installation.installation_id;
+  }
+
+  const { data: repo } = await supabaseAdmin
+    .from('repositories')
+    .select('owner')
+    .eq('id', repositoryId)
+    .maybeSingle();
+
+  if (repo?.owner) {
+    const { data: ownerInstall } = await supabaseAdmin
+      .from('github_app_installations')
+      .select('installation_id')
+      .eq('account_name', repo.owner)
+      .eq('repository_selection', 'all')
+      .is('deleted_at', null)
+      .is('suspended_at', null)
+      .maybeSingle();
+
+    if (ownerInstall?.installation_id) {
+      return ownerInstall.installation_id;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolve the GitHub token to use for syncing a repository.
+ * Public repos return undefined so callers keep using the shared PAT;
+ * private repos get an installation token (or an error if the app was
+ * uninstalled — the shared PAT cannot see them, so there is no fallback).
+ */
+export async function getTokenForRepo(repository: {
+  id: string;
+  is_private?: boolean | null;
+}): Promise<string | undefined> {
+  if (!repository.is_private) {
+    return undefined;
+  }
+
+  const installationId = await getInstallationIdForRepo(repository.id);
+  if (!installationId) {
+    throw new Error(
+      `Private repository ${repository.id} has no active GitHub App installation — install the contributor.info app to sync it`
+    );
+  }
+
+  return getInstallationToken(installationId);
+}

--- a/src/lib/github-app/installation-token.ts
+++ b/src/lib/github-app/installation-token.ts
@@ -3,19 +3,43 @@
  *
  * The shared GITHUB_TOKEN PAT can only see public repositories. Private repos
  * are opted in by installing the contributor.info GitHub App, and sync must
- * authenticate with that installation's token instead. This module is
- * server-only (Inngest/Netlify functions) — it uses node:crypto to sign the
- * app JWT so it adds no dependencies.
+ * authenticate with that installation's token instead.
+ *
+ * Uses Web Crypto (crypto.subtle) rather than node:crypto so this module is
+ * safe in every bundle we produce (Vite client build, Netlify functions,
+ * Deno edge functions) — in the browser the token paths are never executed
+ * because supabase-admin resolves to null there.
  */
-import { createSign } from 'node:crypto';
 import { supabaseAdmin } from '../supabase-admin';
 
-function base64url(input: Buffer | string): string {
-  return (typeof input === 'string' ? Buffer.from(input) : input)
-    .toString('base64')
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/, '');
+function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64.replace(/\s/g, ''));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function bytesToBase64url(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function stringToBase64url(input: string): string {
+  return bytesToBase64url(new TextEncoder().encode(input));
+}
+
+function decodeBase64Env(value: string): string {
+  try {
+    return atob(value.replace(/\s/g, ''));
+  } catch {
+    // Value wasn't base64 — assume it's the raw PEM
+    return value;
+  }
 }
 
 function getAppCredentials(): { appId: string; privateKey: string } | null {
@@ -23,10 +47,10 @@ function getAppCredentials(): { appId: string; privateKey: string } | null {
 
   let privateKey = process.env.CONTRIBUTOR_APP_KEY || '';
   if (!privateKey && process.env.GITHUB_APP_PRIVATE_KEY_ENCODED) {
-    privateKey = Buffer.from(process.env.GITHUB_APP_PRIVATE_KEY_ENCODED, 'base64').toString();
+    privateKey = decodeBase64Env(process.env.GITHUB_APP_PRIVATE_KEY_ENCODED);
   }
   if (!privateKey && process.env.GITHUB_APP_PRIVATE_KEY) {
-    privateKey = Buffer.from(process.env.GITHUB_APP_PRIVATE_KEY, 'base64').toString();
+    privateKey = decodeBase64Env(process.env.GITHUB_APP_PRIVATE_KEY);
   }
 
   if (!appId || !privateKey) {
@@ -35,15 +59,73 @@ function getAppCredentials(): { appId: string; privateKey: string } | null {
   return { appId, privateKey };
 }
 
-function generateAppJWT(appId: string, privateKey: string): string {
-  const now = Math.floor(Date.now() / 1000);
-  const header = base64url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
-  // iat backdated 60s to allow for clock drift, 10 minute expiry (GitHub max)
-  const payload = base64url(JSON.stringify({ iat: now - 60, exp: now + 600, iss: appId }));
-  const signature = base64url(
-    createSign('RSA-SHA256').update(`${header}.${payload}`).sign(privateKey)
+/** Minimal DER length encoding for the PKCS#8 wrapper below */
+function derLength(length: number): number[] {
+  if (length < 0x80) {
+    return [length];
+  }
+  const bytes: number[] = [];
+  let n = length;
+  while (n > 0) {
+    bytes.unshift(n & 0xff);
+    n >>= 8;
+  }
+  return [0x80 | bytes.length, ...bytes];
+}
+
+/**
+ * Wrap a PKCS#1 RSA private key (GitHub's PEM format, "BEGIN RSA PRIVATE
+ * KEY") in a PKCS#8 envelope, which is the only format crypto.subtle can
+ * import: SEQUENCE { INTEGER 0, SEQUENCE { rsaEncryption OID, NULL },
+ * OCTET STRING { pkcs1 } }
+ */
+function pkcs1ToPkcs8(pkcs1: Uint8Array): Uint8Array {
+  const version = [0x02, 0x01, 0x00];
+  const rsaAlgorithmId = [
+    0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01, 0x05, 0x00,
+  ];
+  const octetStringHeader = [0x04, ...derLength(pkcs1.length)];
+  const contentLength =
+    version.length + rsaAlgorithmId.length + octetStringHeader.length + pkcs1.length;
+
+  return new Uint8Array([
+    0x30,
+    ...derLength(contentLength),
+    ...version,
+    ...rsaAlgorithmId,
+    ...octetStringHeader,
+    ...pkcs1,
+  ]);
+}
+
+async function importPrivateKey(pem: string): Promise<CryptoKey> {
+  const isPkcs1 = pem.includes('BEGIN RSA PRIVATE KEY');
+  const der = base64ToBytes(pem.replace(/-----[^-]+-----/g, ''));
+  const pkcs8 = isPkcs1 ? pkcs1ToPkcs8(der) : der;
+
+  return crypto.subtle.importKey(
+    'pkcs8',
+    pkcs8.buffer as ArrayBuffer,
+    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+    false,
+    ['sign']
   );
-  return `${header}.${payload}.${signature}`;
+}
+
+async function generateAppJWT(appId: string, privateKeyPem: string): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const header = stringToBase64url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
+  // iat backdated 60s to allow for clock drift, 10 minute expiry (GitHub max)
+  const payload = stringToBase64url(JSON.stringify({ iat: now - 60, exp: now + 600, iss: appId }));
+
+  const key = await importPrivateKey(privateKeyPem);
+  const signature = await crypto.subtle.sign(
+    'RSASSA-PKCS1-v1_5',
+    key,
+    new TextEncoder().encode(`${header}.${payload}`)
+  );
+
+  return `${header}.${payload}.${bytesToBase64url(new Uint8Array(signature))}`;
 }
 
 // Installation tokens are valid for 1 hour; cache with a safety margin
@@ -62,7 +144,7 @@ export async function getInstallationToken(installationId: number): Promise<stri
     );
   }
 
-  const jwt = generateAppJWT(credentials.appId, credentials.privateKey);
+  const jwt = await generateAppJWT(credentials.appId, credentials.privateKey);
   const response = await fetch(
     `https://api.github.com/app/installations/${installationId}/access_tokens`,
     {

--- a/src/lib/inngest/functions/capture-issue-comments.ts
+++ b/src/lib/inngest/functions/capture-issue-comments.ts
@@ -1,6 +1,6 @@
 import { inngest } from '../client';
 import { supabase } from '../supabase-server';
-import { getOctokit } from '../github-client';
+import { getOctokitForRepo } from '../github-client';
 import type { DatabaseComment } from '../types';
 import { SyncLogger } from '../sync-logger';
 import { NonRetriableError } from 'inngest';
@@ -84,7 +84,7 @@ export const captureIssueComments = inngest.createFunction(
 
     // Step 2: Fetch issue comments
     const commentsData = await step.run('fetch-comments', async () => {
-      const octokit = getOctokit();
+      const octokit = await getOctokitForRepo(repositoryId);
 
       try {
         console.log(

--- a/src/lib/inngest/functions/capture-pr-comments.ts
+++ b/src/lib/inngest/functions/capture-pr-comments.ts
@@ -1,6 +1,6 @@
 import { inngest } from '../client';
 import { supabase } from '../supabase-server';
-import { getOctokit } from '../github-client';
+import { getOctokitForRepo } from '../github-client';
 import type { DatabaseComment } from '../types';
 import { SyncLogger } from '../sync-logger';
 import { NonRetriableError } from 'inngest';
@@ -99,7 +99,7 @@ export const capturePrComments = inngest.createFunction(
 
       // Step 2: Fetch both PR comments and issue comments
       const commentsData = await step.run('fetch-comments', async () => {
-        const octokit = getOctokit();
+        const octokit = await getOctokitForRepo(repositoryId);
 
         try {
           console.log(

--- a/src/lib/inngest/functions/capture-pr-details.ts
+++ b/src/lib/inngest/functions/capture-pr-details.ts
@@ -1,6 +1,6 @@
 import { inngest } from '../client';
 import { supabase } from '../supabase-server';
-import { makeGitHubRequest } from '../github-client';
+import { makeGitHubRequest, getTokenForRepoId } from '../github-client';
 import type { GitHubPullRequest } from '../types';
 import { SyncLogger } from '../sync-logger';
 import { NonRetriableError } from 'inngest';
@@ -64,8 +64,11 @@ export const capturePrDetails = inngest.createFunction(
         });
 
         apiCallsUsed++;
-        const apiPromise = makeGitHubRequest(
-          `/repos/${repository.owner}/${repository.name}/pulls/${prNumber}`
+        const apiPromise = getTokenForRepoId(repositoryId).then((token) =>
+          makeGitHubRequest(
+            `/repos/${repository.owner}/${repository.name}/pulls/${prNumber}`,
+            token
+          )
         );
 
         const pr = await Promise.race([apiPromise, timeoutPromise]);

--- a/src/lib/inngest/functions/capture-pr-reviews.ts
+++ b/src/lib/inngest/functions/capture-pr-reviews.ts
@@ -1,6 +1,6 @@
 import { inngest } from '../client';
 import { supabase } from '../supabase-server';
-import { getOctokit } from '../github-client';
+import { getOctokitForRepo } from '../github-client';
 import type { DatabaseReview } from '../types';
 import { SyncLogger } from '../sync-logger';
 import { NonRetriableError } from 'inngest';
@@ -95,7 +95,7 @@ export const capturePrReviews = inngest.createFunction(
 
     // Step 2: Fetch reviews from GitHub
     const reviews = await step.run('fetch-reviews', async () => {
-      const octokit = getOctokit();
+      const octokit = await getOctokitForRepo(repositoryId);
 
       try {
         console.log(

--- a/src/lib/inngest/functions/capture-repository-issues.ts
+++ b/src/lib/inngest/functions/capture-repository-issues.ts
@@ -1,6 +1,6 @@
 import { inngest } from '../client';
 import { supabase } from '../supabase-server';
-import { getOctokit } from '../github-client';
+import { getOctokitForRepo } from '../github-client';
 import { SyncLogger } from '../sync-logger';
 import { NonRetriableError } from 'inngest';
 import { detectBot } from '../../utils/bot-detection';
@@ -76,7 +76,7 @@ export const captureRepositoryIssues = inngest.createFunction(
 
     // Step 2: Fetch issues with comments
     const issuesData = await step.run('fetch-issues', async () => {
-      const octokit = getOctokit();
+      const octokit = await getOctokitForRepo(repositoryId);
       const issues: GitHubIssue[] = [];
       let page = 1;
       let hasMore = true;

--- a/src/lib/inngest/functions/capture-repository-sync-graphql.ts
+++ b/src/lib/inngest/functions/capture-repository-sync-graphql.ts
@@ -5,6 +5,7 @@ import type { NonRetriableError } from 'inngest';
 import { getThrottleHours, QUEUE_CONFIG } from '../../progressive-capture/throttle-config';
 import { getPRState } from '../../utils/state-mapping';
 import { updateJobStatus } from '../helpers/job-status-updater';
+import { getTokenForRepo } from '../../github-app/installation-token';
 
 // Rate limiting constants for GraphQL (more generous)
 const MAX_PRS_PER_SYNC = QUEUE_CONFIG.maxPrsPerSync || 150; // Higher than REST due to efficiency
@@ -14,7 +15,12 @@ const DEFAULT_DAYS_LIMIT = 30;
 // GraphQL client instance - lazy initialization to avoid module load failures
 let graphqlClient: GraphQLClient | null = null;
 
-function getGraphQLClient(): GraphQLClient {
+function getGraphQLClient(token?: string): GraphQLClient {
+  if (token) {
+    // Private repos authenticate with a short-lived installation token —
+    // don't reuse the shared-PAT singleton for them
+    return new GraphQLClient(token);
+  }
   if (!graphqlClient) {
     graphqlClient = new GraphQLClient();
   }
@@ -136,7 +142,7 @@ export const captureRepositorySyncGraphQL = inngest.createFunction(
       const repository = await step.run('get-repository', async () => {
         const { data, error } = await supabase
           .from('repositories')
-          .select('owner, name, last_updated_at')
+          .select('id, owner, name, last_updated_at, is_private')
           .eq('id', repositoryId)
           .maybeSingle();
 
@@ -240,7 +246,11 @@ export const captureRepositorySyncGraphQL = inngest.createFunction(
         const since = new Date(Date.now() - effectiveDays * 24 * 60 * 60 * 1000).toISOString();
 
         try {
-          const client = getGraphQLClient();
+          // Private repos need the GitHub App installation token — the
+          // shared PAT cannot see them. Resolved inside the step so the
+          // token never lands in Inngest step state.
+          const installationToken = await getTokenForRepo(repository);
+          const client = getGraphQLClient(installationToken);
           const prs = await client.getRecentPRs(
             repository.owner,
             repository.name,

--- a/src/lib/inngest/github-client.ts
+++ b/src/lib/inngest/github-client.ts
@@ -18,10 +18,16 @@ const SERVER_GITHUB_TOKEN = (() => {
   return process.env.GITHUB_TOKEN || '';
 })();
 
-export async function getGitHubHeaders(): Promise<Record<string, string>> {
+export async function getGitHubHeaders(tokenOverride?: string): Promise<Record<string, string>> {
   const headers: Record<string, string> = {
     Accept: 'application/vnd.github.v3+json',
   };
+
+  // Explicit token (e.g. GitHub App installation token for private repos)
+  if (tokenOverride) {
+    headers['Authorization'] = `token ${tokenOverride}`;
+    return headers;
+  }
 
   // For server-side operations (like Inngest), use the server token
   if (SERVER_GITHUB_TOKEN) {
@@ -53,8 +59,11 @@ export async function getGitHubHeaders(): Promise<Record<string, string>> {
   return headers;
 }
 
-export async function makeGitHubRequest<T = unknown>(endpoint: string): Promise<T> {
-  const headers = await getGitHubHeaders();
+export async function makeGitHubRequest<T = unknown>(
+  endpoint: string,
+  tokenOverride?: string
+): Promise<T> {
+  const headers = await getGitHubHeaders(tokenOverride);
 
   // Add delay to prevent rate limiting (respectful API usage)
   await new Promise((resolve) => setTimeout(resolve, 100)); // 100ms delay between requests
@@ -83,25 +92,28 @@ export async function makeGitHubRequest<T = unknown>(endpoint: string): Promise<
 }
 
 // Export a compatibility function for getOctokit
-export function getOctokit() {
+export function getOctokit(tokenOverride?: string) {
   return {
     rest: {
       pulls: {
         get: async (params: { owner: string; repo: string; pull_number: number }) => {
           const data = await makeGitHubRequest(
-            `/repos/${params.owner}/${params.repo}/pulls/${params.pull_number}`
+            `/repos/${params.owner}/${params.repo}/pulls/${params.pull_number}`,
+            tokenOverride
           );
           return { data };
         },
         listReviews: async (params: { owner: string; repo: string; pull_number: number }) => {
           const data = await makeGitHubRequest(
-            `/repos/${params.owner}/${params.repo}/pulls/${params.pull_number}/reviews`
+            `/repos/${params.owner}/${params.repo}/pulls/${params.pull_number}/reviews`,
+            tokenOverride
           );
           return { data };
         },
         listComments: async (params: { owner: string; repo: string; pull_number: number }) => {
           const data = await makeGitHubRequest(
-            `/repos/${params.owner}/${params.repo}/pulls/${params.pull_number}/comments`
+            `/repos/${params.owner}/${params.repo}/pulls/${params.pull_number}/comments`,
+            tokenOverride
           );
           return { data };
         },
@@ -109,7 +121,8 @@ export function getOctokit() {
       issues: {
         listComments: async (params: { owner: string; repo: string; issue_number: number }) => {
           const data = await makeGitHubRequest(
-            `/repos/${params.owner}/${params.repo}/issues/${params.issue_number}/comments`
+            `/repos/${params.owner}/${params.repo}/issues/${params.issue_number}/comments`,
+            tokenOverride
           );
           return { data };
         },
@@ -133,11 +146,45 @@ export function getOctokit() {
 
           const query = queryParams.toString();
           const data = await makeGitHubRequest(
-            `/repos/${params.owner}/${params.repo}/issues${query ? `?${query}` : ''}`
+            `/repos/${params.owner}/${params.repo}/issues${query ? `?${query}` : ''}`,
+            tokenOverride
           );
           return { data };
         },
       },
     },
   };
+}
+
+/**
+ * Resolve the token override for a repository by database id.
+ * Private repositories require their GitHub App installation token (the
+ * shared server PAT cannot see them); public repositories return undefined
+ * so callers keep using the default token chain.
+ */
+export async function getTokenForRepoId(repositoryId: string): Promise<string | undefined> {
+  const { supabaseAdmin } = await import('../supabase-admin');
+  if (!supabaseAdmin) {
+    return undefined;
+  }
+
+  const { data: repo } = await supabaseAdmin
+    .from('repositories')
+    .select('id, is_private')
+    .eq('id', repositoryId)
+    .maybeSingle();
+
+  if (!repo?.is_private) {
+    return undefined;
+  }
+
+  const { getTokenForRepo } = await import('../github-app/installation-token');
+  return getTokenForRepo(repo);
+}
+
+/**
+ * Get an octokit-compatible client authenticated for a specific repository.
+ */
+export async function getOctokitForRepo(repositoryId: string) {
+  return getOctokit(await getTokenForRepoId(repositoryId));
 }

--- a/src/lib/inngest/graphql-client.ts
+++ b/src/lib/inngest/graphql-client.ts
@@ -370,8 +370,9 @@ export class GraphQLClient {
     timestamp: number;
   }>;
 
-  constructor() {
-    if (!GITHUB_TOKEN) {
+  constructor(token?: string) {
+    const authToken = token || GITHUB_TOKEN;
+    if (!authToken) {
       const env = process.env.NODE_ENV || 'unknown';
       const hasGithubToken = !!process.env.GITHUB_TOKEN;
       const hasViteGithubToken = !!process.env.VITE_GITHUB_TOKEN;
@@ -382,7 +383,7 @@ export class GraphQLClient {
 
     this.client = graphql.defaults({
       headers: {
-        authorization: `token ${GITHUB_TOKEN}`,
+        authorization: `token ${authToken}`,
       },
     });
 

--- a/src/lib/progressive-capture/commit-processor.ts
+++ b/src/lib/progressive-capture/commit-processor.ts
@@ -33,7 +33,7 @@ export class CommitProcessor {
       // Get repository info
       const { data: repo, error: repoError } = await supabase
         .from('repositories')
-        .select('owner, name, last_commit_capture_at')
+        .select('owner, name, last_commit_capture_at, is_private')
         .eq('id', repositoryId)
         .maybeSingle();
 
@@ -62,10 +62,19 @@ export class CommitProcessor {
         daysToCapture
       );
 
+      // Private repos need their GitHub App installation token — the
+      // default token chain can only see public repositories
+      let installationToken: string | undefined;
+      if (repo.is_private) {
+        const { getTokenForRepoId } = await import('../inngest/github-client');
+        installationToken = await getTokenForRepoId(repositoryId);
+      }
+
       // Use the existing captureCommits function
       const result = await captureCommits(repo.owner, repo.name, since, {
         batchSize: config.batchSize,
         maxPages: Math.min(config.maxPages, Math.ceil(config.maxPerRun / config.batchSize)),
+        githubToken: installationToken,
       });
 
       if (!result.success) {

--- a/supabase/migrations/20260713000000_private_repo_read_protection.sql
+++ b/supabase/migrations/20260713000000_private_repo_read_protection.sql
@@ -1,0 +1,144 @@
+-- Private Repository Read Protection
+--
+-- Private repositories are opted in via the contributor.info GitHub App and
+-- synced with installation tokens. Until now every content table was
+-- publicly readable (USING (true)). This migration restricts reads so rows
+-- belonging to a private repository are only visible to members (or owners)
+-- of a workspace containing that repository.
+--
+-- Notes:
+-- - The service role bypasses RLS, so sync/backend paths are unaffected.
+-- - Helper functions are SECURITY DEFINER: the privacy check itself must see
+--   repositories/workspace tables without the caller's RLS applied,
+--   otherwise a row the caller cannot see would read as "not private".
+
+-- =====================================================
+-- HELPER FUNCTIONS
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION public.can_view_private_repository(repo_id UUID)
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM workspace_repositories wr
+    JOIN workspaces w ON w.id = wr.workspace_id
+    WHERE wr.repository_id = repo_id
+      AND (
+        w.owner_id = (SELECT id FROM app_users WHERE auth_user_id = auth.uid())
+        OR EXISTS (
+          SELECT 1
+          FROM workspace_members wm
+          WHERE wm.workspace_id = w.id
+            AND wm.user_id = (SELECT id FROM app_users WHERE auth_user_id = auth.uid())
+            AND wm.accepted_at IS NOT NULL
+        )
+      )
+  );
+$$;
+
+COMMENT ON FUNCTION public.can_view_private_repository(UUID) IS
+  'True when the current user owns or is an accepted member of a workspace containing the repository';
+
+CREATE OR REPLACE FUNCTION public.repository_is_readable(repo_id UUID)
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM repositories r
+    WHERE r.id = repo_id
+      AND (
+        r.is_private IS DISTINCT FROM TRUE
+        OR public.can_view_private_repository(repo_id)
+      )
+  );
+$$;
+
+COMMENT ON FUNCTION public.repository_is_readable(UUID) IS
+  'True when the repository is public, or private and readable by the current user';
+
+GRANT EXECUTE ON FUNCTION public.can_view_private_repository(UUID) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.repository_is_readable(UUID) TO anon, authenticated;
+
+-- =====================================================
+-- REPLACE SELECT POLICIES ON REPOSITORY-SCOPED TABLES
+-- =====================================================
+
+-- Drop every existing SELECT policy on the content tables (their names have
+-- drifted across migrations: public_read_*, consolidated_read_*,
+-- public_read_only, ...) and install one canonical privacy-aware policy per
+-- table.
+DO $$
+DECLARE
+  t TEXT;
+  pol RECORD;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'repositories',
+    'pull_requests',
+    'reviews',
+    'comments',
+    'commits',
+    'issues',
+    'github_issues',
+    'discussions'
+  ]
+  LOOP
+    IF to_regclass('public.' || t) IS NULL THEN
+      CONTINUE;
+    END IF;
+
+    FOR pol IN
+      SELECT policyname
+      FROM pg_policies
+      WHERE schemaname = 'public' AND tablename = t AND cmd = 'SELECT'
+    LOOP
+      EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', pol.policyname, t);
+    END LOOP;
+  END LOOP;
+END $$;
+
+-- Repositories: public rows for everyone, private rows for workspace members
+CREATE POLICY "read_repositories_respect_privacy" ON public.repositories
+  FOR SELECT
+  USING (
+    is_private IS DISTINCT FROM TRUE
+    OR public.can_view_private_repository(id)
+  );
+
+-- Child tables: gate on the owning repository's visibility.
+-- Legacy rows with NULL repository_id predate private repo support and are
+-- treated as public.
+DO $$
+DECLARE
+  t TEXT;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'pull_requests',
+    'reviews',
+    'comments',
+    'commits',
+    'issues',
+    'github_issues',
+    'discussions'
+  ]
+  LOOP
+    IF to_regclass('public.' || t) IS NULL THEN
+      CONTINUE;
+    END IF;
+
+    EXECUTE format(
+      'CREATE POLICY %I ON public.%I FOR SELECT USING (repository_id IS NULL OR public.repository_is_readable(repository_id))',
+      'read_' || t || '_respect_privacy',
+      t
+    );
+  END LOOP;
+END $$;


### PR DESCRIPTION
## Summary

Private repositories can now be added to workspaces. The opt-in is **installing the contributor.info GitHub App** on the repo — the installation both authorizes access and provides the sync token, so login OAuth stays public-only (`public_repo`), keeping the documented privacy promise.

**User flow:** workspace → Add repositories → enter `owner/repo` in the private-repo field (private repos can't appear in public search) → if the app isn't installed, an "Install GitHub App" prompt appears → install on GitHub → the installation webhook registers the repo → retry the add → sync runs on the installation token → data is visible only to that workspace's members.

## Changes

### Opt-in path
- **`api-track-repository`**: the hard 403 on private repos is now an installation check. Covered → tracking proceeds from the webhook-registered DB row; not covered → structured `app_installation_required` response with install URL. Also adds the previously missing `tracked_repositories` insert for repos that already exist in `repositories` (webhook-created rows were never tracked), and an `installation_pending` retry response for webhook lag.
- **`github-app-installation-status`**: replaces the hard-coded stub (bdougie/contributor.info only) with real lookups against `app_enabled_repositories` / `github_app_installations`, including owner-wide `repository_selection = 'all'` coverage.
- **Installation webhook** (`app/webhooks/installation.ts`): fixes the repositories insert that used a nonexistent `private` column and omitted the NOT NULL `owner` — private repo registration was silently failing, which broke the entire flow. Uninstall / repo-removal now disables tracking for private repos (their only sync token is gone).
- **`AddRepositoryModal`**: direct `owner/repo` entry for private repos plus an Install GitHub App alert driven by the structured API error; the repo-exists short-circuit now also verifies a `tracked_repositories` row so webhook-created repos actually get synced.

### Sync via installation tokens
- New **`src/lib/github-app/installation-token.ts`**: mints app JWTs with `node:crypto` (zero new dependencies), caches hourly installation tokens, resolves repo → installation. Public repos keep the shared-PAT path untouched.
- Wired into GraphQL repository sync, PR details/reviews/comments, issue capture, and commit capture.

### Leak-proofing
- `is_private = false` filters on public widgets (badge, stat card), social cards (fly server + chart fetchers), and the sitemap generator; trending already filtered in SQL.
- `api-repository-status` resolves repos through an RLS-scoped client (caller's JWT) instead of service role, so it no longer leaks private repo existence/sync status.
- **RLS migration `20260713000000`**: replaces the accumulated `USING (true)` read policies on `repositories`, `pull_requests`, `reviews`, `comments`, `commits`, `issues`, `github_issues`, `discussions` with privacy-aware policies — private repo rows readable only by owners/accepted members of a workspace containing the repo (SECURITY DEFINER helpers map `auth.uid()` → `app_users`). Service role (sync) bypasses RLS.

## Deployment notes
- Netlify needs `CONTRIBUTOR_APP_ID` + `CONTRIBUTOR_APP_KEY` env vars for installation-token sync (currently only set on the Fly webhooks server).
- **Not yet enforced:** billing gating — `tier_limits.allows_private_repos` exists but the pricing doc (Team includes private) and seed data (enterprise-only) disagree; needs a product decision before wiring into the track gate.
- Follow-up: Deno edge functions (`github-sync`, `repository-sync-graphql`) remain PAT-only.

PRD with full design rationale: `docs/product-requirements/prd-private-repo-opt-in.md`.

## Test plan
- [x] `tsc -b --noEmit` clean
- [x] eslint clean on touched files (pre-commit hooks passed)
- [x] `capture-pr-reviews` unit tests (6) pass
- [x] `AddRepositoryModal` unit tests (3) pass
- [ ] Manual: install app on a private repo, add it to a workspace, verify sync + that logged-out users can't see it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LWXEcBoC5LK5eQa8JxbtPV