### PR TITLE
fix(ci): pin flyctl setup action to @master (unblock Fly webhook deploy)

### DIFF
--- a/.github/workflows/deploy-github-webhooks.yml
+++ b/.github/workflows/deploy-github-webhooks.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Fly CLI
-        uses: superfly/flyctl-actions/setup-flyctl@v2
+        uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to Fly.io
         run: |


### PR DESCRIPTION
## Summary

The `deploy-github-webhooks.yml` workflow pinned `superfly/flyctl-actions/setup-flyctl@v2`, but that tag does not exist. Every run failed at job setup:

\`\`\`
Unable to resolve action \`superfly/flyctl-actions@v2\`, unable to find version \`v2\`
\`\`\`

This has blocked the Fly webhook deploy since **October 2025** (failures on 2025-10-05, 2025-12-17, 2026-01-03, 2026-04-05, 2026-07-13), leaving the production webhook server running months-old code — which is why installing the app on a private repo currently records nothing.

## Fix

One-liner: pin to `@master`, matching the working pin already used in `deploy-social-cards.yml`.

## After merge

Merging to `main` touches the workflow path and re-triggers the deploy, which should finally ship the `app/webhooks/installation.ts` installation-webhook fix to the Fly server.

Context: https://github.com/bdougie/contributor.info/pull/1805#issuecomment-4953576210

🤖 Generated with [Claude Code](https://claude.com/claude-code)