### PR TITLE
feat(desktop): live workspace metrics via api-workspace-metrics endpoint

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -4,32 +4,28 @@ contributor.info in your system tray / menu bar — a [RepoBar](https://repobar.
 glanceable companion, built with Tauri v2. **Workspaces-first**: the tray is
 organized around your workspaces (teams of repos), not individual repos.
 
-The tray icon is the pixel plant 🌱. Each configured workspace gets a submenu.
-A dashboard window manages workspaces and renders the same numbers as metric
-tiles.
-
-**Status:** workspace identity (name + `contributor.info/i/{slug}` link) is
-live, and signing in unlocks private workspaces. The per-workspace metric tiles
-(open/merged PRs + trend, PR velocity and merge time, active/new contributors,
-open issues, stars) are built but not yet populated — the metrics data source
-needs wiring up (see [Next steps](#next-steps)). Until then, resolved
-workspaces render in a `metrics coming soon` state.
+The tray icon is the pixel plant 🌱. Each configured workspace gets a submenu
+with its headline metrics (open/merged PRs, PR velocity and merge time,
+active/new contributors, open issues, stars). A dashboard window manages
+workspaces and renders the same numbers as metric tiles.
 
 ## Where the data comes from
 
 | Data | Source | Status |
 | --- | --- | --- |
 | Workspace lookup | Supabase REST `workspaces?slug=eq.{slug}` (anon key, or user JWT when signed in) | live |
-| Workspace metrics | none yet — see [Next steps](#next-steps) | pending |
+| Workspace metrics | `GET https://contributor.info/.netlify/functions/api-workspace-metrics?workspace_id={id}&time_range={range}` | live |
 
 RLS lets anonymous clients read **public** workspaces, so workspace identity
 resolves with just the anon key. Signing in widens RLS to the workspaces you
 own or belong to, including private ones.
 
-Workspace metrics have **no live source**: the old `workspace_metrics_cache`
-table was dropped (migration `20260428000007_drop_dead_tables`) and never held
-data. The metric-rendering code is in place and reads through
-`Supabase::metrics` — wiring that to a real endpoint is the top next step.
+Workspace metrics come from the site's public `api-workspace-metrics` endpoint,
+which aggregates them on demand from the source tables (PRs, issues,
+contributors, stars) — the old `workspace_metrics_cache` table was dropped
+(migration `20260428000007_drop_dead_tables`) and never held data. The endpoint
+serves **public** workspaces only; private-workspace metrics (passing the user
+JWT) and period-over-period trends are follow-ups (see [Next steps](#next-steps)).
 
 ## Sign in (private workspaces)
 
@@ -79,13 +75,13 @@ npx tauri icon ../public/plant_pixel_coarse.svg
 
 ## Next steps
 
-- **Workspace metrics endpoint** (unblocks the metric tiles): add a public
-  `api-workspace-metrics` Netlify function on contributor.info that aggregates
-  a workspace's repos server-side (reusing `workspace-aggregation.service.ts`)
-  and returns JSON — mirroring the trending function, so no secret ships in the
-  client. Then repoint `Supabase::metrics` (the seam in `supabase.rs`) at it.
-  The old `workspace_metrics_cache` table is gone, so REST-against-Supabase is
-  a dead end for a client with only the anon key.
+- **Metric trends**: the `api-workspace-metrics` endpoint returns null trend
+  fields (`stars_trend`, `prs_trend`, `contributors_trend`) — the history table
+  they were derived from was dropped. Recompute period-over-period deltas in the
+  endpoint (compare against the previous window) to restore the ▲/▼ arrows.
+- **Private-workspace metrics**: the endpoint serves public workspaces only.
+  Accept the user JWT and verify workspace membership so signed-in users see
+  metrics for their private workspaces.
 - **Notifications**: tauri-plugin-notification on metric transitions (open
   PRs jump, contributors trend down, metrics went stale).
 - **Repo drill-down**: per-workspace repo list with the site's stat-card SVG

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -26,7 +26,13 @@ use auth::Session;
 use settings::Settings;
 use supabase::{Supabase, WorkspaceMetrics};
 
-pub const SITE: &str = "https://contributor.info";
+/// Site base for `/i/{slug}` links and the `api-workspace-metrics` endpoint.
+/// Overridable at build time to aim the app at a local `netlify dev`, a deploy
+/// preview, or staging — set `VITE_CONTRIBUTOR_SITE` when building.
+pub const SITE: &str = match option_env!("VITE_CONTRIBUTOR_SITE") {
+    Some(s) => s,
+    None => "https://contributor.info",
+};
 
 const TRAY_ID: &str = "ci-tray";
 const POLL_INTERVAL: Duration = Duration::from_secs(60);

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1,11 +1,11 @@
 //! contributor.info in the system tray, workspaces-first: each configured
-//! workspace resolves to its public identity, and renders aggregated metrics
-//! (open/merged PRs, velocity, contributors, stars + trends) as soon as a
-//! metrics source is wired up — see README "Next steps".
+//! workspace resolves to its public identity and its aggregated metrics
+//! (open/merged PRs, velocity, contributors, stars).
 //!
 //! Data flow: a 60s poll loop reads Supabase REST (the anon key for public
-//! workspaces, or the user JWT once signed in) for workspace identity, stores
-//! a `Snapshot` in managed state, rebuilds the tray menu from it, and emits a
+//! workspaces, or the user JWT once signed in) for workspace identity and the
+//! site's public `api-workspace-metrics` endpoint for the numbers, stores a
+//! `Snapshot` in managed state, rebuilds the tray menu from it, and emits a
 //! `snapshot` event the dashboard webview listens for. Every fetch failure
 //! degrades to a status string — the tray never errors out.
 
@@ -65,7 +65,7 @@ fn workspace_title(ws: &WorkspaceStatus) -> String {
     match (&ws.metrics, ws.state.as_str()) {
         (Some(m), _) => format!("\u{1F331} {}  ·  {} open PRs", ws.name, m.open_prs),
         (None, "not_found") => format!("\u{26A0}\u{FE0F} {}  ·  not found (private?)", ws.slug),
-        (None, "no_metrics") => format!("\u{23F3} {}  ·  metrics coming soon", ws.name),
+        (None, "no_metrics") => format!("\u{23F3} {}  ·  metrics unavailable", ws.name),
         (None, "unreachable") => format!("\u{26A0}\u{FE0F} {}  ·  offline", ws.slug),
         (None, _) => format!("\u{26A0}\u{FE0F} {}  ·  {}", ws.slug, ws.state),
     }

--- a/desktop/src-tauri/src/supabase.rs
+++ b/desktop/src-tauri/src/supabase.rs
@@ -1,11 +1,10 @@
-//! Minimal Supabase REST reads for workspaces.
+//! Minimal reads for workspaces: identity from Supabase REST, aggregated
+//! metrics from the site's public `api-workspace-metrics` endpoint.
 //!
 //! Anonymous requests use the public anon key — RLS lets them read `public`
-//! workspaces and their `workspace_metrics_cache` rows (one row per
-//! workspace + time_range, refreshed by the site's aggregation cron).
-//! When a user session exists, the user JWT rides in the Authorization
-//! header instead and RLS widens to the workspaces they own or belong to,
-//! including private ones.
+//! workspaces. When a user session exists, the user JWT rides in the
+//! Authorization header instead and RLS widens to the workspaces they own or
+//! belong to, including private ones.
 
 use serde::{Deserialize, Serialize};
 
@@ -35,7 +34,9 @@ pub struct Workspace {
     pub slug: String,
 }
 
-/// The glanceable subset of `workspace_metrics_cache`.
+/// The glanceable subset returned by the `api-workspace-metrics` endpoint.
+/// Every field is `#[serde(default)]` so the endpoint can add fields without
+/// breaking older clients.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkspaceMetrics {
     #[serde(default)]
@@ -117,20 +118,53 @@ impl Supabase {
         Some(rows.into_iter().next())
     }
 
-    /// Aggregated workspace metrics.
+    /// Aggregated workspace metrics from the site's public
+    /// `api-workspace-metrics` endpoint, which computes them on demand from the
+    /// source tables (the old `workspace_metrics_cache` table was dropped).
     ///
-    /// NOTE: `workspace_metrics_cache` was dropped from the database (migration
-    /// `20260428000007_drop_dead_tables`) and never held data, so this currently
-    /// resolves to `None` and workspaces render in the `no_metrics` state. This
-    /// is the seam for the forthcoming metrics endpoint: swap this REST call for
-    /// a request to a public `api-workspace-metrics` function that aggregates
-    /// server-side (see README "Next steps").
+    /// Returns `None` on any non-success response — including the `403` the
+    /// endpoint returns for private workspaces — so the caller falls back to the
+    /// `no_metrics` state. Passing the user JWT for private workspaces is a
+    /// follow-up.
     pub async fn metrics(&self, workspace_id: &str, time_range: &str) -> Option<WorkspaceMetrics> {
-        let rows: Vec<WorkspaceMetrics> = self
-            .rest(&format!(
-                "workspace_metrics_cache?workspace_id=eq.{workspace_id}&time_range=eq.{time_range}&limit=1"
-            ))
-            .await?;
-        rows.into_iter().next()
+        let url = format!(
+            "{}/.netlify/functions/api-workspace-metrics?workspace_id={workspace_id}&time_range={time_range}",
+            crate::SITE
+        );
+        let resp = self.client.get(&url).send().await.ok()?;
+        if !resp.status().is_success() {
+            return None;
+        }
+        resp.json::<WorkspaceMetrics>().await.ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WorkspaceMetrics;
+
+    /// Contract check against a real `api-workspace-metrics` response: the tray
+    /// struct must tolerate fields it doesn't model (`total_issues`,
+    /// `closed_issues`) and `null` trend values, and read the flat shape.
+    #[test]
+    fn deserializes_endpoint_response() {
+        let body = r#"{
+            "time_range":"90d","total_prs":91,"merged_prs":72,"open_prs":5,
+            "draft_prs":0,"avg_pr_merge_time_hours":39.78,"pr_velocity":0.8,
+            "total_issues":3,"closed_issues":2,"open_issues":1,
+            "issue_closure_rate":66.67,"total_contributors":7,
+            "active_contributors":7,"new_contributors":3,"total_stars":581,
+            "stars_trend":null,"prs_trend":null,"contributors_trend":null,
+            "calculated_at":"2026-07-13T03:01:50.264Z","is_stale":false
+        }"#;
+        let m: WorkspaceMetrics = serde_json::from_str(body).expect("valid metrics JSON");
+        assert_eq!(m.time_range, "90d");
+        assert_eq!(m.open_prs, 5);
+        assert_eq!(m.merged_prs, 72);
+        assert_eq!(m.total_stars, 581);
+        assert_eq!(m.new_contributors, 3);
+        assert_eq!(m.pr_velocity, Some(0.8));
+        assert_eq!(m.stars_trend, None);
+        assert!(!m.is_stale);
     }
 }

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -62,7 +62,7 @@ function Tile(props: { label: string; value: string; trend?: number | null }) {
 
 const STATE_HINT: Record<string, string> = {
   not_found: 'not found — sign in if this is a private workspace',
-  no_metrics: 'workspace metrics coming soon',
+  no_metrics: "couldn't load metrics",
   unconfigured: 'Supabase anon key missing — see desktop/README.md',
   unreachable: 'offline',
 };

--- a/netlify/functions/api-workspace-metrics.mts
+++ b/netlify/functions/api-workspace-metrics.mts
@@ -1,0 +1,395 @@
+import type { Handler, HandlerEvent, HandlerContext } from '@netlify/functions';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+// Public, read-only workspace metrics for a single *public* workspace.
+//
+// This replaces the old `workspace_metrics_cache` table (dropped in migration
+// 20260428000007_drop_dead_tables and never populated). Metrics are aggregated
+// on demand from the source tables the site already exposes to anonymous
+// clients — mirroring the logic in `workspace-aggregation.service.ts` but
+// self-contained so it bundles cleanly as a Netlify function.
+//
+// The desktop tray (and any anon client) calls this instead of hitting Supabase
+// REST directly, so the flat shape below matches the tray's `WorkspaceMetrics`
+// struct. Private workspaces are rejected (403); serving them needs an
+// authenticated caller and is a follow-up.
+
+const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || '';
+// Prefer a service-role key server-side (bypasses RLS, reliable). Fall back to
+// the anon key, which can already read the public source tables this endpoint
+// uses — so it also works under `netlify dev` with only VITE_ vars set.
+const supabaseKey =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ||
+  process.env.SUPABASE_TOKEN ||
+  process.env.SUPABASE_ANON_KEY ||
+  process.env.VITE_SUPABASE_ANON_KEY ||
+  '';
+
+let supabase: SupabaseClient | null = null;
+function getSupabase(): SupabaseClient {
+  if (!supabaseUrl || !supabaseKey) {
+    throw new Error('Missing Supabase environment variables (SUPABASE_URL, SUPABASE key)');
+  }
+  if (!supabase) {
+    supabase = createClient(supabaseUrl, supabaseKey, { auth: { persistSession: false } });
+  }
+  return supabase;
+}
+
+const TIME_RANGES = new Set(['7d', '30d', '90d', '1y', 'all']);
+type TimeRange = '7d' | '30d' | '90d' | '1y' | 'all';
+
+const PAGE = 1000;
+// Serve repeated polls (the tray refreshes every 60s) from memory on warm
+// instances, bounding database load. Short enough to stay fresh.
+const CACHE_TTL_MS = 120_000;
+
+// Flat shape consumed by the desktop tray's `WorkspaceMetrics` struct. Trend
+// fields are null in v1 — the history table they were derived from was dropped.
+interface WorkspaceMetricsFlat {
+  time_range: TimeRange;
+  total_prs: number;
+  merged_prs: number;
+  open_prs: number;
+  draft_prs: number;
+  avg_pr_merge_time_hours: number | null;
+  pr_velocity: number | null;
+  total_issues: number;
+  closed_issues: number;
+  open_issues: number;
+  issue_closure_rate: number | null;
+  total_contributors: number;
+  active_contributors: number;
+  new_contributors: number;
+  total_stars: number;
+  stars_trend: number | null;
+  prs_trend: number | null;
+  contributors_trend: number | null;
+  calculated_at: string;
+  is_stale: boolean;
+}
+
+interface PrRow {
+  state: string | null;
+  draft: boolean | null;
+  created_at: string | null;
+  merged_at: string | null;
+  author_id: string | null;
+}
+interface IssueRow {
+  state: string | null;
+  created_at: string | null;
+  closed_at: string | null;
+  author_id: string | null;
+}
+
+const cache = new Map<string, { at: number; body: WorkspaceMetricsFlat }>();
+
+function periodDays(range: TimeRange, now: number): number {
+  switch (range) {
+    case '7d':
+      return 7;
+    case '30d':
+      return 30;
+    case '90d':
+      return 90;
+    case '1y':
+      return 365;
+    case 'all':
+      return Math.max(1, Math.round((now - Date.UTC(2008, 0, 1)) / 86_400_000));
+  }
+}
+
+function periodStart(range: TimeRange, end: Date): Date {
+  const start = new Date(end);
+  switch (range) {
+    case '7d':
+      start.setUTCDate(end.getUTCDate() - 7);
+      break;
+    case '30d':
+      start.setUTCDate(end.getUTCDate() - 30);
+      break;
+    case '90d':
+      start.setUTCDate(end.getUTCDate() - 90);
+      break;
+    case '1y':
+      start.setUTCFullYear(end.getUTCFullYear() - 1);
+      break;
+    case 'all':
+      start.setUTCFullYear(2008, 0, 1);
+      break;
+  }
+  return start;
+}
+
+// Fetch every row of a range-paginated query, following PostgREST's 1000-row cap.
+async function fetchAll<T>(
+  build: (from: number, to: number) => PromiseLike<{ data: T[] | null; error: { message: string } | null }>
+): Promise<T[]> {
+  const rows: T[] = [];
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await build(from, from + PAGE - 1);
+    if (error) throw new Error(error.message);
+    if (!data || data.length === 0) break;
+    rows.push(...data);
+    if (data.length < PAGE) break;
+  }
+  return rows;
+}
+
+function emptyMetrics(range: TimeRange, calculatedAt: string): WorkspaceMetricsFlat {
+  return {
+    time_range: range,
+    total_prs: 0,
+    merged_prs: 0,
+    open_prs: 0,
+    draft_prs: 0,
+    avg_pr_merge_time_hours: null,
+    pr_velocity: null,
+    total_issues: 0,
+    closed_issues: 0,
+    open_issues: 0,
+    issue_closure_rate: null,
+    total_contributors: 0,
+    active_contributors: 0,
+    new_contributors: 0,
+    total_stars: 0,
+    stars_trend: null,
+    prs_trend: null,
+    contributors_trend: null,
+    calculated_at: calculatedAt,
+    is_stale: false,
+  };
+}
+
+async function aggregate(
+  supabase: SupabaseClient,
+  workspaceId: string,
+  range: TimeRange
+): Promise<WorkspaceMetricsFlat> {
+  const now = Date.now();
+  const end = new Date(now);
+  const start = periodStart(range, end);
+  const startIso = start.toISOString();
+  const endIso = end.toISOString();
+  const calculatedAt = end.toISOString();
+
+  // Repositories in the workspace.
+  const repoLinks = await fetchAll<{ repository_id: string }>((from, to) =>
+    supabase
+      .from('workspace_repositories')
+      .select('repository_id')
+      .eq('workspace_id', workspaceId)
+      .range(from, to)
+  );
+  const repoIds = repoLinks.map((r) => r.repository_id).filter(Boolean);
+  if (repoIds.length === 0) {
+    return emptyMetrics(range, calculatedAt);
+  }
+
+  // Stars are an absolute snapshot on the repositories row, not period-scoped.
+  const repos = await fetchAll<{ stargazers_count: number | null }>((from, to) =>
+    supabase.from('repositories').select('stargazers_count').in('id', repoIds).range(from, to)
+  );
+  const totalStars = repos.reduce((sum, r) => sum + (r.stargazers_count || 0), 0);
+
+  // PRs and issues created within the period.
+  const prs = await fetchAll<PrRow>((from, to) =>
+    supabase
+      .from('pull_requests')
+      .select('state, draft, created_at, merged_at, author_id')
+      .in('repository_id', repoIds)
+      .gte('created_at', startIso)
+      .lte('created_at', endIso)
+      .range(from, to)
+  );
+  const issues = await fetchAll<IssueRow>((from, to) =>
+    supabase
+      .from('issues')
+      .select('state, created_at, closed_at, author_id')
+      .in('repository_id', repoIds)
+      .gte('created_at', startIso)
+      .lte('created_at', endIso)
+      .range(from, to)
+  );
+
+  let mergedPrs = 0;
+  let openPrs = 0;
+  let draftPrs = 0;
+  const mergeTimesHours: number[] = [];
+  const activeAuthors = new Set<string>();
+  for (const pr of prs) {
+    if (pr.author_id) activeAuthors.add(pr.author_id);
+    if (pr.state === 'merged' && pr.merged_at && pr.created_at) {
+      mergedPrs++;
+      mergeTimesHours.push(
+        (new Date(pr.merged_at).getTime() - new Date(pr.created_at).getTime()) / 3_600_000
+      );
+    } else if (pr.state === 'open') {
+      openPrs++;
+      if (pr.draft) draftPrs++;
+    }
+  }
+
+  let closedIssues = 0;
+  let openIssues = 0;
+  for (const issue of issues) {
+    if (issue.author_id) activeAuthors.add(issue.author_id);
+    if (issue.state === 'closed' && issue.closed_at) {
+      closedIssues++;
+    } else if (issue.state === 'open') {
+      openIssues++;
+    }
+  }
+
+  const totalPrs = prs.length;
+  const totalIssues = issues.length;
+  const days = periodDays(range, now);
+  const avgMergeHours =
+    mergeTimesHours.length > 0
+      ? mergeTimesHours.reduce((a, b) => a + b, 0) / mergeTimesHours.length
+      : null;
+  const prVelocity = days > 0 ? mergedPrs / days : null;
+  const issueClosureRate = totalIssues > 0 ? (closedIssues / totalIssues) * 100 : null;
+
+  // New contributors = active authors with no contribution before this period.
+  // Bounded to the active author set, and stops early once every active author
+  // is known to be returning, so it stays cheap on busy workspaces.
+  const newContributors = await countNewContributors(supabase, repoIds, activeAuthors, startIso);
+
+  return {
+    time_range: range,
+    total_prs: totalPrs,
+    merged_prs: mergedPrs,
+    open_prs: openPrs,
+    draft_prs: draftPrs,
+    avg_pr_merge_time_hours: avgMergeHours,
+    pr_velocity: prVelocity,
+    total_issues: totalIssues,
+    closed_issues: closedIssues,
+    open_issues: openIssues,
+    issue_closure_rate: issueClosureRate,
+    // Period-scoped for v1; workspace-wide all-time totals are a follow-up and
+    // aren't shown in the tray tiles.
+    total_contributors: activeAuthors.size,
+    active_contributors: activeAuthors.size,
+    new_contributors: newContributors,
+    total_stars: totalStars,
+    stars_trend: null,
+    prs_trend: null,
+    contributors_trend: null,
+    calculated_at: calculatedAt,
+    is_stale: false,
+  };
+}
+
+async function countNewContributors(
+  supabase: SupabaseClient,
+  repoIds: string[],
+  activeAuthors: Set<string>,
+  startIso: string
+): Promise<number> {
+  if (activeAuthors.size === 0) return 0;
+  const authorIds = Array.from(activeAuthors);
+  const returning = new Set<string>();
+
+  const scan = async (table: 'pull_requests' | 'issues') => {
+    for (let from = 0; ; from += PAGE) {
+      if (returning.size === authorIds.length) return; // every active author is returning
+      const { data, error } = await supabase
+        .from(table)
+        .select('author_id')
+        .in('repository_id', repoIds)
+        .in('author_id', authorIds)
+        .lt('created_at', startIso)
+        .range(from, from + PAGE - 1);
+      if (error) throw new Error(error.message);
+      if (!data || data.length === 0) break;
+      for (const row of data as { author_id: string | null }[]) {
+        if (row.author_id) returning.add(row.author_id);
+      }
+      if (data.length < PAGE) break;
+    }
+  };
+
+  await scan('pull_requests');
+  await scan('issues');
+  return authorIds.length - returning.size;
+}
+
+export const handler: Handler = async (event: HandlerEvent, _context: HandlerContext) => {
+  const headers = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Content-Type': 'application/json',
+  };
+
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 200, headers, body: '' };
+  }
+  if (event.httpMethod !== 'GET') {
+    return { statusCode: 405, headers, body: JSON.stringify({ error: 'Method not allowed' }) };
+  }
+
+  try {
+    const params = event.queryStringParameters || {};
+    const workspaceIdParam = (params.workspace_id || '').trim();
+    const slugParam = (params.slug || '').trim();
+    const rangeParam = (params.time_range || '7d').trim();
+    const range: TimeRange = (TIME_RANGES.has(rangeParam) ? rangeParam : '7d') as TimeRange;
+
+    if (!workspaceIdParam && !slugParam) {
+      return {
+        statusCode: 400,
+        headers,
+        body: JSON.stringify({ error: 'Provide workspace_id or slug' }),
+      };
+    }
+
+    const supabase = getSupabase();
+
+    // Resolve the workspace and enforce that it is public. Service-role reads
+    // bypass RLS, so this visibility check is what keeps private workspaces out.
+    const workspaceQuery = supabase
+      .from('workspaces')
+      .select('id, slug, visibility, is_active')
+      .eq('is_active', true)
+      .limit(1);
+    const { data: wsRows, error: wsError } = workspaceIdParam
+      ? await workspaceQuery.eq('id', workspaceIdParam)
+      : await workspaceQuery.eq('slug', slugParam);
+    if (wsError) {
+      throw new Error(wsError.message);
+    }
+    const workspace = wsRows?.[0];
+    if (!workspace) {
+      return { statusCode: 404, headers, body: JSON.stringify({ error: 'Workspace not found' }) };
+    }
+    if (workspace.visibility !== 'public') {
+      return {
+        statusCode: 403,
+        headers,
+        body: JSON.stringify({ error: 'Metrics for private workspaces require authentication' }),
+      };
+    }
+
+    const cacheKey = `${workspace.id}:${range}`;
+    const cached = cache.get(cacheKey);
+    if (cached && Date.now() - cached.at < CACHE_TTL_MS) {
+      return { statusCode: 200, headers: { ...headers, 'X-Cache': 'hit' }, body: JSON.stringify(cached.body) };
+    }
+
+    const metrics = await aggregate(supabase, workspace.id, range);
+    cache.set(cacheKey, { at: Date.now(), body: metrics });
+
+    return { statusCode: 200, headers: { ...headers, 'X-Cache': 'miss' }, body: JSON.stringify(metrics) };
+  } catch (error) {
+    console.error('api-workspace-metrics failed: %s', error instanceof Error ? error.message : error);
+    return {
+      statusCode: 500,
+      headers,
+      body: JSON.stringify({ error: 'Failed to compute workspace metrics' }),
+    };
+  }
+};


### PR DESCRIPTION
Live workspace metrics for the desktop tray. Supersedes #1809, which GitHub auto-closed when its stacked base `feat/desktop-tray` was deleted on merge of #1808 (same commits, retargeted to `main`).

## Web — `netlify/functions/api-workspace-metrics.mts` (new)
Public, read-only endpoint that resolves a **public** workspace (by `workspace_id` or `slug`) and aggregates its metrics on demand from the source tables (`workspace_repositories`, `pull_requests`, `issues`, `repositories`) — the old `workspace_metrics_cache` table was dropped in `20260428000007_drop_dead_tables` and never held data. Self-contained so it bundles under esbuild; enforces `visibility='public'` (403 otherwise); paginates past PostgREST's 1000-row cap; computes new-vs-returning contributors with an early-out; memoizes 120s.

Verified live (`open-source-repos`): 7d → 9 PRs / 4 merged / 32h avg / 3 contributors / 581 stars; 90d → 91 PRs / 72 merged / 3 new contributors.

## Desktop
`Supabase::metrics` GETs the endpoint instead of the dropped table, degrading to `no_metrics` on any non-2xx. Adds `VITE_CONTRIBUTOR_SITE` build override to aim the app at a local server / preview / staging (defaults to production). Docs/labels updated.

## Tests
`cargo test` (5 pass, incl. an endpoint↔struct deserialization contract test); `typecheck:functions` clean for the new file; desktop `npm run build` passes. Exercised end-to-end against a local server — the running tray polled the endpoint and rendered real tiles.

## Follow-ups (in `desktop/README.md`)
Period-over-period **trends** (null today — history table dropped) and **private-workspace** metrics via the user JWT.
