### PR TITLE
docs(desktop): release CI + changelog + install docs for the menu bar app

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,0 +1,129 @@
+name: Desktop Release
+
+# Builds the Tauri menu-bar app in `desktop/` and publishes unsigned macOS
+# (Apple Silicon) and Linux artifacts to a GitHub Release.
+#
+# Tag namespace is intentionally `desktop-v*`, separate from the web app's
+# semantic-release `v*` tags, so this never fires on a web-app release.
+# Push a `desktop-v<version>` tag to cut a release; use the manual trigger with
+# a blank tag for a build-only dry run (artifacts uploaded to the run, no release).
+# See desktop/RELEASING.md.
+
+on:
+  push:
+    tags:
+      - 'desktop-v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish a release to (e.g. desktop-v0.1.0). Leave blank for a build-only dry run.'
+        required: false
+        default: ''
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.label }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: macOS (Apple Silicon)
+            runner: macos-14
+            target: aarch64-apple-darwin
+            args: '--target aarch64-apple-darwin'
+          - label: Linux (x86_64)
+            runner: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            args: ''
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Linux tray/webkit dependencies
+        if: matrix.runner == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: desktop/package-lock.json
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: desktop/src-tauri
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: desktop
+
+      - name: Resolve release tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "value=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Frontend (`npm run build` -> desktop/dist) runs automatically via the
+      # Tauri config's beforeBuildCommand. The Supabase anon key is public by
+      # design and baked into the binary at compile time; without it the app
+      # ships in an `unconfigured` state.
+      - name: Build and release
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+        with:
+          projectPath: desktop
+          # Empty tagName (blank manual-dispatch input) => build only, no release.
+          tagName: ${{ steps.tag.outputs.value }}
+          releaseName: 'contributor.info desktop ${{ steps.tag.outputs.value }}'
+          releaseBody: |
+            Unsigned builds — no Apple notarization or code signing yet.
+
+            **macOS (Apple Silicon):** download the `.dmg`, open it, drag the app
+            to Applications. On first launch, right-click the app and choose
+            **Open** to get past Gatekeeper (only needed once).
+
+            **Linux (x86_64):** install the `.deb`, or make the `.AppImage`
+            executable and run it.
+
+            Install guide: https://github.com/bdougie/contributor.info/blob/main/docs/user-guide/desktop-app.md
+          releaseDraft: false
+          prerelease: false
+          args: ${{ matrix.args }}
+
+      - name: Upload dry-run artifacts
+        if: steps.tag.outputs.value == ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-${{ matrix.target }}
+          path: |
+            desktop/src-tauri/target/**/release/bundle/**/*.dmg
+            desktop/src-tauri/target/**/release/bundle/**/*.deb
+            desktop/src-tauri/target/**/release/bundle/**/*.AppImage
+          if-no-files-found: warn

--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ Display repository statistics directly in your README with our embeddable widget
 
 Visit [contributor.info/widgets](https://contributor.info/widgets) to generate custom widgets for your repository!
 
+## 🖥️ Desktop App
+
+A menu bar / system tray companion (built with Tauri v2) keeps your workspaces glanceable — headline PR, contributor, and issue metrics without opening a browser.
+
+- **Install & use:** [User guide](./docs/user-guide/desktop-app.md)
+- **Download:** [Releases](https://github.com/bdougie/contributor.info/releases?q=desktop-v) (macOS Apple Silicon, Linux)
+- **Develop:** [`desktop/README.md`](./desktop/README.md)
+
 ## 🛠️ For Contributors
 
 Want to contribute to the project? We'd love your help!

--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable changes to the contributor.info desktop app are documented in this
+file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This app is versioned and released independently of the web app: its tags use a
+`desktop-v*` prefix (e.g. `desktop-v0.1.0`) and this changelog is maintained by
+hand. See [RELEASING.md](./RELEASING.md).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-07-12
+
+First public release — contributor.info in your system tray / menu bar.
+
+### 🚀 Features
+
+- **Workspaces-first system tray app** (Tauri v2). Each configured workspace
+  gets a submenu with its headline metrics — open/merged PRs, PR velocity and
+  average merge time, active/new contributors, open issues, and stars. A
+  dashboard window (hidden on close, not quit) manages workspaces and renders
+  the same numbers as metric tiles. A Rust core polls every 60s, rebuilds the
+  tray menu, and emits a snapshot to the dashboard; every fetch failure degrades
+  to a status badge rather than an error.
+- **GitHub sign-in for private workspaces** via Supabase's OAuth PKCE flow with
+  a one-shot loopback listener on `127.0.0.1:1421`. The user JWT replaces the
+  anonymous key on reads, widening access to private workspaces; sessions
+  persist to `session.json` (mode 0600) with automatic refresh-token rotation
+  and clean fallback to anonymous.
+- **Live workspace metrics** sourced from the site's public
+  `api-workspace-metrics` endpoint, aggregated on demand from the source tables.
+
+### 🐛 Bug Fixes
+
+- Normalize workspace input: accept a bare slug, a `/i/{slug}` URL, or a value
+  with stray slashes, reducing it to the slug the API and deep links expect
+  (previously a leading slash produced broken `/i//{slug}` links and failed
+  lookups). Period-over-period trend arrows are marked deferred until the
+  endpoint recomputes them.
+
+### ♻️ Code Refactoring
+
+- Drop the trending-repositories view from the tray — the app is organized
+  around workspaces (teams of repos) only.
+
+[Unreleased]: https://github.com/bdougie/contributor.info/compare/desktop-v0.1.0...HEAD
+[0.1.0]: https://github.com/bdougie/contributor.info/releases/tag/desktop-v0.1.0

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -9,6 +9,23 @@ with its headline metrics (open/merged PRs, PR velocity and merge time,
 active/new contributors, open issues, stars). A dashboard window manages
 workspaces and renders the same numbers as metric tiles.
 
+## Install
+
+Grab the latest build from the
+[GitHub Releases](https://github.com/bdougie/contributor.info/releases?q=desktop-v)
+page (filter for `desktop-v*`). Builds are **unsigned** for now.
+
+- **macOS (Apple Silicon):** download the `.dmg`, open it, and drag the app to
+  Applications. On first launch, right-click the app and choose **Open** to get
+  past Gatekeeper (only needed once, because the build isn't notarized).
+- **Linux (x86_64):** install the `.deb` (`sudo dpkg -i contributor.info_*.deb`),
+  or `chmod +x` the `.AppImage` and run it.
+
+Once running, click the tray icon → **Dashboard…**, add a workspace by its slug
+or `/i/…` URL, and (for private workspaces) **Sign in with GitHub**. The
+end-user walkthrough lives in
+[docs/user-guide/desktop-app.md](../docs/user-guide/desktop-app.md).
+
 ## Where the data comes from
 
 | Data | Source | Status |
@@ -72,6 +89,15 @@ Icons are generated from `public/plant_pixel_coarse.svg`:
 ```bash
 npx tauri icon ../public/plant_pixel_coarse.svg
 ```
+
+## Releasing
+
+Releases are cut independently of the web app, on `desktop-v*` tags. Pushing a
+`desktop-v<version>` tag runs the
+[Desktop Release workflow](../.github/workflows/desktop-release.yml), which
+builds unsigned macOS + Linux artifacts and publishes them to a GitHub Release.
+See [RELEASING.md](./RELEASING.md) for the full runbook and
+[CHANGELOG.md](./CHANGELOG.md) for the release history.
 
 ## Next steps
 

--- a/desktop/RELEASING.md
+++ b/desktop/RELEASING.md
@@ -1,0 +1,88 @@
+# Releasing the desktop app
+
+The desktop app is released **independently of the web app**. It uses its own
+`desktop-v*` git tags and its own version number (currently `0.1.0`), and the
+web app's semantic-release automation on `v*` tags never touches it.
+
+Pushing a `desktop-v<version>` tag triggers
+[`.github/workflows/desktop-release.yml`](../.github/workflows/desktop-release.yml),
+which builds unsigned macOS (Apple Silicon) and Linux artifacts and publishes
+them to a GitHub Release. Distribution is GitHub Releases only.
+
+## Prerequisites
+
+- Push access to the repo (to push the tag).
+- For a local build: Rust stable, Node 20+, and on Linux the Tauri system deps
+  `libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev`.
+- CI needs the repo secrets `VITE_SUPABASE_ANON_KEY` and `VITE_SUPABASE_URL`
+  (already configured — the anon key is public-by-design and gets baked into the
+  binary at build time so the shipped app is configured out of the box).
+
+## Steps
+
+1. **Bump the version in lockstep** in both files (they must match):
+   - `desktop/package.json` — `"version"`
+   - `desktop/src-tauri/tauri.conf.json` — `"version"`
+
+2. **Update the changelog.** In [`CHANGELOG.md`](./CHANGELOG.md), move the
+   entries under `## [Unreleased]` into a new `## [<version>] - <YYYY-MM-DD>`
+   section and refresh the compare/tag links at the bottom.
+
+3. **Commit** the version bump and changelog:
+
+   ```bash
+   git add desktop/package.json desktop/src-tauri/tauri.conf.json desktop/CHANGELOG.md
+   git commit -m "chore(desktop): release v<version>"
+   ```
+
+4. **Tag and push.** The tag is what triggers the release build:
+
+   ```bash
+   git tag desktop-v<version>
+   git push origin desktop-v<version>
+   ```
+
+5. **Watch the build.** In the Actions tab, the "Desktop Release" workflow runs
+   the macOS and Linux jobs and creates the GitHub Release with artifacts
+   attached.
+
+6. **Verify** the release has all three bundles:
+
+   ```bash
+   gh release view desktop-v<version>
+   ```
+
+   Expect a macOS `.dmg`, a Linux `.deb`, and a Linux `.AppImage`.
+
+## Dry run before the real tag
+
+To exercise the build without publishing a release, trigger the workflow
+manually with a **blank** tag input (Actions → Desktop Release → Run workflow).
+It builds both platforms and uploads the bundles as workflow artifacts instead
+of creating a release. To rehearse the publish path, push a throwaway prerelease
+tag such as `desktop-v<version>-rc.1`, confirm the release, then delete the tag
+and release.
+
+## Local build (fallback / smoke test)
+
+```bash
+cd desktop
+npm ci
+VITE_SUPABASE_ANON_KEY=… VITE_SUPABASE_URL=… npm run tauri build
+```
+
+Artifacts land in `desktop/src-tauri/target/release/bundle/` (`.app` + `.dmg` on
+macOS, `.deb` + `.AppImage` on Linux). The frontend build (`npm run build` →
+`desktop/dist`) runs automatically via the Tauri config's `beforeBuildCommand`.
+
+## Notes
+
+- **Unsigned artifacts.** There is no Apple code signing / notarization and no
+  Windows signing. On macOS, first launch requires right-click → **Open** to get
+  past Gatekeeper. This is called out in the release notes and the
+  [install guide](../docs/user-guide/desktop-app.md).
+- **No auto-updater.** The app ships without the Tauri updater, so no signing key
+  is required and updates are manual downloads from GitHub Releases.
+- **Targets.** The workflow builds macOS Apple Silicon (arm64) and Linux
+  (x86_64) only. Intel-mac and Windows builds are intentionally out of scope for
+  now; add matrix entries in the workflow if that changes.

--- a/docs/features/desktop-tray-app.md
+++ b/docs/features/desktop-tray-app.md
@@ -78,14 +78,18 @@ run), `unconfigured` (no anon key), `unreachable` (offline).
 | Data | Source |
 | --- | --- |
 | Workspace lookup | Supabase REST `workspaces?slug=eq.{slug}` |
-| Workspace metrics | Supabase REST `workspace_metrics_cache?workspace_id=eq.{id}&time_range=eq.{7d\|30d\|…}` |
+| Workspace metrics | Site endpoint `GET /.netlify/functions/api-workspace-metrics?workspace_id={id}&time_range={7d\|30d\|…}` |
 
-RLS permits anonymous reads of public workspaces and their metrics cache
-(policies in `supabase/migrations/20250827000000_workspace_metrics_cache.sql`),
-so the app works without login for public workspaces; signing in extends
-reads to private workspaces via the same queries. Note that
-`workspace_repositories` requires a logged-in user even for public
-workspaces, so per-repo drill-down is only possible once signed in.
+RLS permits anonymous reads of public workspaces, so workspace identity resolves
+with just the anon key; signing in extends reads to the private workspaces the
+user owns or belongs to. Metrics no longer come from a cache table — the
+`workspace_metrics_cache` table was dropped (migration
+`20260428000007_drop_dead_tables`) and the `api-workspace-metrics` endpoint now
+aggregates the numbers on demand from the source tables (PRs, issues,
+contributors, stars). The endpoint currently serves **public** workspaces only;
+private-workspace metrics and period-over-period trends are follow-ups. Note that
+`workspace_repositories` requires a logged-in user even for public workspaces, so
+per-repo drill-down is only possible once signed in.
 
 ### Keys
 
@@ -105,6 +109,13 @@ npm install
 VITE_SUPABASE_ANON_KEY=… npm run tauri dev
 VITE_SUPABASE_ANON_KEY=… npm run tauri build   # .app/.dmg on macOS, .deb/.AppImage on Linux
 ```
+
+## Releases
+
+Releases are cut independently of the web app on `desktop-v*` tags. Pushing such
+a tag runs `.github/workflows/desktop-release.yml`, which builds unsigned macOS
+(Apple Silicon) and Linux artifacts and publishes them to a GitHub Release. See
+`desktop/RELEASING.md` for the runbook and `desktop/CHANGELOG.md` for history.
 
 ## Future Work
 

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -7,6 +7,7 @@ This folder contains end-user documentation for using the contributor.info appli
 ### Getting Started
 
 - **[new-repository-setup.md](./new-repository-setup.md)** - Guide for setting up and tracking new repositories
+- **[desktop-app.md](./desktop-app.md)** - Install and use the menu bar / system tray desktop app
 
 ## Purpose
 

--- a/docs/user-guide/desktop-app.md
+++ b/docs/user-guide/desktop-app.md
@@ -1,0 +1,81 @@
+# Desktop App (Menu Bar / System Tray)
+
+Keep an eye on your workspaces without opening a browser. The contributor.info
+desktop app lives in your macOS menu bar or Linux system tray and shows each
+workspace's headline metrics — open and merged PRs, PR velocity and merge time,
+active and new contributors, open issues, and stars — right from the tray menu.
+
+It's **workspaces-first**: you add the workspaces (teams of repos) you care
+about, and each one gets its own submenu. A small dashboard window lets you
+manage your workspaces and see the same numbers as tiles.
+
+## Download
+
+Get the latest build from the
+[Releases page](https://github.com/bdougie/contributor.info/releases?q=desktop-v)
+and pick the file for your platform:
+
+| Platform | File | Notes |
+| --- | --- | --- |
+| macOS (Apple Silicon, M1 and newer) | `.dmg` | Unsigned — see first-run step below |
+| Linux (x86_64) | `.deb` or `.AppImage` | `.deb` for Debian/Ubuntu; `.AppImage` runs anywhere |
+
+> The builds are **unsigned** right now, so your OS will warn you the first time
+> you open the app. That's expected — the steps below get you through it.
+
+## Install and first run
+
+### macOS
+
+1. Open the downloaded `.dmg` and drag **contributor.info** to Applications.
+2. The first time you launch it, macOS blocks unsigned apps. **Right-click** (or
+   Control-click) the app in Applications and choose **Open**, then confirm.
+   You only have to do this once.
+3. The pixel-plant icon (🌱) appears in your menu bar. Click it to open the menu.
+
+### Linux
+
+- **`.deb`:** `sudo dpkg -i contributor.info_*.deb` (or open it with your
+  software installer). You may need the tray dependency
+  `libayatana-appindicator3-1` if it isn't already installed.
+- **`.AppImage`:** make it executable and run it —
+  `chmod +x contributor.info_*.AppImage && ./contributor.info_*.AppImage`.
+
+The tray icon appears in your system tray; click it for the menu.
+
+## Add a workspace
+
+1. Click the tray icon → **Dashboard…**.
+2. In the box at the top, paste a workspace slug or its `/i/…` URL from
+   contributor.info (for example `my-team` or
+   `https://contributor.info/i/my-team`) and click **Add**.
+3. Its metrics show up as tiles in the dashboard and as a submenu in the tray.
+
+The app refreshes every 60 seconds. Use **Refresh now** (tray) or the
+**Refresh** button (dashboard) to update immediately.
+
+## Sign in for private workspaces
+
+Public workspaces work without signing in. To see your **private** workspaces:
+
+1. Click **Sign in with GitHub** (in the tray menu or the dashboard header).
+2. Your browser opens to authorize; approve it, then return to the app.
+3. The tray now shows the private workspaces you own or belong to. Your session
+   is saved securely and refreshes automatically; **Sign out** clears it.
+
+## Troubleshooting
+
+| What you see | What it means | What to do |
+| --- | --- | --- |
+| **"unconfigured"** | The app was built without its access key | Download an official release from the Releases page (dev builds may omit the key) |
+| **"not found (private?)"** | The workspace slug didn't resolve | Check the slug; if it's a private workspace, sign in with GitHub |
+| **"metrics unavailable"** | Metrics haven't been computed yet | Try again shortly, or open the workspace on the site to warm it up |
+| **"offline"** | The app couldn't reach contributor.info | Check your internet connection |
+| macOS won't open the app | It's unsigned | Right-click the app → **Open** (see first-run step above) |
+| No tray icon on Linux | Missing tray support | Install `libayatana-appindicator3-1` and relaunch |
+
+## Related
+
+- Feature overview: [Desktop Tray App](../features/desktop-tray-app.md)
+- For developers: [`desktop/README.md`](../../desktop/README.md) and
+  [`desktop/RELEASING.md`](../../desktop/RELEASING.md)

--- a/mintlify-docs/docs.json
+++ b/mintlify-docs/docs.json
@@ -46,7 +46,8 @@
           "features/distribution-charts",
           "features/repository-health",
           "features/repository-search",
-          "features/github-app-setup"
+          "features/github-app-setup",
+          "features/desktop-app"
         ]
       },
       {

--- a/mintlify-docs/features/desktop-app.mdx
+++ b/mintlify-docs/features/desktop-app.mdx
@@ -1,0 +1,58 @@
+---
+title: Desktop App
+description: Keep your workspaces in your macOS menu bar or Linux system tray. Glanceable PR, contributor, and issue metrics without opening a browser.
+---
+
+The contributor.info desktop app lives in your macOS menu bar or Linux system tray and surfaces each workspace's headline metrics at a glance — open and merged PRs, PR velocity and merge time, active and new contributors, open issues, and stars. It's **workspaces-first**: add the workspaces you care about and each gets its own tray submenu, plus a small dashboard window to manage them.
+
+## Download
+
+Grab the latest build from the [Releases page](https://github.com/bdougie/contributor.info/releases?q=desktop-v) (filter for `desktop-v*`) and pick the file for your platform.
+
+| Platform | File | Notes |
+|---|---|---|
+| macOS (Apple Silicon, M1 and newer) | `.dmg` | Unsigned — see first-run step below |
+| Linux (x86_64) | `.deb` or `.AppImage` | `.deb` for Debian/Ubuntu; `.AppImage` runs anywhere |
+
+<Note>
+The builds are currently **unsigned**, so your operating system warns you the first time you open the app. That's expected — the steps below get you through it.
+</Note>
+
+## Install and first run
+
+<Tabs>
+  <Tab title="macOS">
+    1. Open the `.dmg` and drag **contributor.info** to Applications.
+    2. On first launch, macOS blocks unsigned apps. **Right-click** (or Control-click) the app in Applications and choose **Open**, then confirm. You only do this once.
+    3. The pixel-plant icon appears in your menu bar. Click it to open the menu.
+  </Tab>
+  <Tab title="Linux">
+    - **`.deb`:** `sudo dpkg -i contributor.info_*.deb`. Install `libayatana-appindicator3-1` if the tray icon doesn't appear.
+    - **`.AppImage`:** `chmod +x contributor.info_*.AppImage && ./contributor.info_*.AppImage`.
+
+    The tray icon appears in your system tray; click it for the menu.
+  </Tab>
+</Tabs>
+
+## Add a workspace
+
+1. Click the tray icon, then **Dashboard…**.
+2. Paste a workspace slug or its `/i/…` URL (for example `my-team` or `https://contributor.info/i/my-team`) and click **Add**.
+3. Its metrics show up as tiles in the dashboard and as a submenu in the tray.
+
+The app refreshes every 60 seconds; use **Refresh now** to update immediately.
+
+## Sign in for private workspaces
+
+Public workspaces work without an account. To see your private workspaces, click **Sign in with GitHub** in the tray menu or dashboard header, authorize in your browser, and return to the app. Your session is saved securely and refreshes automatically. See [Authentication](/features/authentication) for the scopes requested.
+
+## Troubleshooting
+
+| What you see | What it means | What to do |
+|---|---|---|
+| **unconfigured** | Built without its access key | Download an official release from the Releases page |
+| **not found (private?)** | The slug didn't resolve | Check the slug; sign in if it's private |
+| **metrics unavailable** | Metrics aren't computed yet | Try again shortly, or open the workspace on the site |
+| **offline** | Couldn't reach contributor.info | Check your internet connection |
+| macOS won't open the app | It's unsigned | Right-click the app → **Open** |
+| No tray icon on Linux | Missing tray support | Install `libayatana-appindicator3-1` and relaunch |


### PR DESCRIPTION
## What

Stands up a **GitHub-Releases-only, unsigned** release for the Tauri v2 menu bar app in `desktop/` (v0.1.0, never formally released) and documents it end to end.

## Release CI

- **`.github/workflows/desktop-release.yml`** — builds **macOS (Apple Silicon)** and **Linux (x86_64)** artifacts via `tauri-apps/tauri-action` and publishes them to a GitHub Release.
  - Triggers on **`desktop-v*`** tags — intentionally decoupled from the web app's semantic-release `v*` tags so it never fires on a web release.
  - A manual `workflow_dispatch` with a blank tag does a **build-only dry run** (artifacts uploaded to the run, no release).
  - Bakes the existing `VITE_SUPABASE_ANON_KEY` / `VITE_SUPABASE_URL` secrets (anon key is public-by-design). No signing/notarization and no updater key required.

## Docs

- **`desktop/CHANGELOG.md`** — Keep a Changelog, `[0.1.0]`, assembled from the desktop commit history (hand-maintained; desktop is not on semantic-release).
- **`desktop/RELEASING.md`** — release runbook (lockstep version bump, tag, verify, dry run, local fallback, unsigned/Gatekeeper notes).
- **`desktop/README.md`** — new **Install** and **Releasing** sections.
- **`docs/features/desktop-tray-app.md`** — fixes stale metrics source (`workspace_metrics_cache` → `api-workspace-metrics` endpoint; the table was dropped in `20260428000007_drop_dead_tables`).
- **End-user install guides** — `docs/user-guide/desktop-app.md` (+ index link) and `mintlify-docs/features/desktop-app.mdx` (+ `docs.json` nav), plus a **Desktop App** section in the root README (was previously undiscoverable).

## Scope decisions

- Targets: **macOS Apple Silicon + Linux** only (no Intel-mac, no Windows).
- **Unsigned** distribution via **GitHub Releases** only.

## Verification

- Workflow YAML parses (2 matrix entries); `docs.json` valid with the new nav entry; all relative markdown links resolve.
- Not yet done (release-gated, needs a maintainer): local `tauri build` smoke test, CI dry run, and the real `desktop-v0.1.0` tag push that publishes artifacts.