### PR TITLE
fix(webhooks): service-role writes + self-heal missing installation rows

### DIFF
--- a/app/webhooks/installation.ts
+++ b/app/webhooks/installation.ts
@@ -4,7 +4,13 @@ import {
   Installation,
   Repository,
 } from '../types/github';
-import { supabase } from '../../src/lib/supabase';
+import { supabaseAdmin } from '../../src/lib/supabase-admin';
+
+// Installation webhooks run server-side only (Fly webhook server), where there
+// is no user session. Writes to github_app_installations / app_enabled_repositories
+// / repositories are blocked by RLS for the anon role, so use the service-role
+// admin client (RLS bypass). supabaseAdmin is always initialized server-side.
+const supabase = supabaseAdmin!;
 import { inngest } from '../../src/lib/inngest/client';
 import { githubAppAuth } from '../lib/auth';
 import { indexGitHistory } from '../services/git-history';

--- a/app/webhooks/installation.ts
+++ b/app/webhooks/installation.ts
@@ -232,11 +232,42 @@ async function handleRepositoriesAdded(
 ) {
   try {
     // Get the installation record
-    const { data: installationRecord } = await supabase
+    let { data: installationRecord } = await supabase
       .from('github_app_installations')
       .select('id')
       .eq('installation_id', installation.id)
       .maybeSingle();
+
+    // Self-heal: the installation row can be missing if installation.created was
+    // never recorded (e.g. it fired before this webhook handler was deployed).
+    // Recreate it from the installation payload so repository additions aren't
+    // silently dropped for pre-existing installations.
+    if (!installationRecord) {
+      const { data: backfilled, error: backfillError } = await supabase
+        .from('github_app_installations')
+        .upsert({
+          installation_id: installation.id,
+          account_type: installation.account.type.toLowerCase(),
+          account_name: installation.account.login,
+          account_id: installation.account.id,
+          repository_selection: installation.repository_selection,
+          installed_at: new Date().toISOString(),
+          settings: {
+            enabled: true,
+            comment_on_prs: true,
+            include_issue_context: true,
+            comment_style: 'detailed',
+          },
+        })
+        .select('id')
+        .maybeSingle();
+
+      if (backfillError) {
+        console.error('Failed to backfill installation record:', backfillError);
+        return;
+      }
+      installationRecord = backfilled;
+    }
 
     if (!installationRecord) return;
 


### PR DESCRIPTION
## Summary

Follow-up to #1807. With the webhook server finally deploying and routing installation events, two write-side bugs surfaced that blocked private-repo tracking. Both are fixed here and **validated end-to-end in production** (a private repo now tracks successfully via the installation token).

### 1. Handlers wrote as the anon role → RLS blocked every write

The installation handler wrote via the shared anon Supabase client, so inserts into `github_app_installations` / `app_enabled_repositories` / `repositories` were rejected: `new row violates row-level security policy`. The events were received and routed but never persisted. Switched to the existing service-role admin client (`supabaseAdmin`), which runs server-side only. Requires `SUPABASE_SERVICE_ROLE_KEY` on the Fly webhook app (now set).

### 2. Repo-add early-returned when the install row was missing

`handleRepositoriesAdded` bailed if no `github_app_installations` row existed. Installations created before the webhook handler shipped (their `installation.created` was never recorded) therefore never got their repos linked — and a repo re-add couldn't recover them. Now it self-heals: upsert the installation row from the `installation_repositories` payload before linking repos.

## Validation

Redelivered a real `installation_repositories.added` webhook to the deployed server: processed with no RLS error, the install row + repo link were created, and `contributor.info/bdougie/dinnerpeople2` then returned **"Repository tracking initiated!"** instead of 404.

## Note

These fixes also address the `Error storing pull request` RLS failures visible in the webhook logs for the installation path. The PR/issue service-layer writes use their own clients and remain a separate, broader follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)