### PR TITLE
fix(desktop): reliable sign-in, branded callback, live dashboard auth state

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -517,6 +517,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "socket2 0.5.10",
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
@@ -1584,7 +1585,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -2690,7 +2691,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2728,7 +2729,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -3334,6 +3335,16 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
@@ -3933,7 +3944,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.4",
  "windows-sys 0.61.2",
 ]
 

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -21,3 +21,4 @@ tokio = { version = "1", features = ["time"] }
 sha2 = "0.10"
 base64 = "0.22"
 getrandom = "0.2"
+socket2 = "0.5"

--- a/desktop/src-tauri/src/auth.rs
+++ b/desktop/src-tauri/src/auth.rs
@@ -12,7 +12,7 @@
 
 use std::fs;
 use std::io::{Read, Write as IoWrite};
-use std::net::TcpListener;
+use std::net::{SocketAddr, TcpListener};
 use std::path::PathBuf;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -20,6 +20,7 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use socket2::{Domain, Protocol, Socket, Type};
 use tauri::Manager;
 
 pub const CALLBACK_PORT: u16 = 1421;
@@ -84,6 +85,76 @@ fn session_from_response(resp: TokenResponse, fallback_name: Option<String>) -> 
     }
 }
 
+/// Bind the loopback callback listener with `SO_REUSEADDR` so a socket left in
+/// TIME_WAIT by a previous sign-in attempt (the served `/callback` connection
+/// closes server-side) doesn't block a retry with a spurious "address in use".
+fn bind_callback_listener() -> Result<TcpListener, String> {
+    let addr: SocketAddr = ([127, 0, 0, 1], CALLBACK_PORT).into();
+    let socket = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP))
+        .map_err(|e| format!("callback socket setup failed: {e}"))?;
+    socket
+        .set_reuse_address(true)
+        .map_err(|e| format!("callback socket setup failed: {e}"))?;
+    socket
+        .bind(&addr.into())
+        .map_err(|_| format!("port {CALLBACK_PORT} is busy — is a sign-in already running?"))?;
+    socket
+        .listen(1)
+        .map_err(|e| format!("callback listener failed: {e}"))?;
+    Ok(socket.into())
+}
+
+/// Branded browser page shown after the OAuth redirect. Placeholders (`%…%`)
+/// are filled per outcome by `callback_html`; served as UTF-8 so the emoji and
+/// typographic punctuation render.
+const CALLBACK_TEMPLATE: &str = r#"<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>contributor.info</title>
+<style>
+:root{color-scheme:light dark;--bg:#fff;--fg:#1a1a1a;--muted:#6b7280;--border:#e5e7eb}
+@media(prefers-color-scheme:dark){:root{--bg:#111113;--fg:#ededed;--muted:#9ca3af;--border:#27272a}}
+*{box-sizing:border-box;margin:0}html,body{height:100%}
+body{background:var(--bg);color:var(--fg);font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif;display:flex;align-items:center;justify-content:center;padding:24px}
+.card{max-width:420px;width:100%;text-align:center;border:1px solid var(--border);border-radius:16px;padding:40px 32px}
+.mark{width:64px;height:64px;margin:0 auto 20px;border-radius:16px;display:flex;align-items:center;justify-content:center;font-size:30px;background:rgba(%ACCENT%,0.14);border:1px solid rgba(%ACCENT%,0.4)}
+h1{font-size:20px;font-weight:640;margin-bottom:8px;letter-spacing:-0.01em}
+p{font-size:14px;color:var(--muted);line-height:1.5}
+.brand{margin-top:26px;font-size:12px;color:var(--muted)}
+.brand b{color:var(--fg);font-weight:600}
+</style></head>
+<body><main class="card">
+<div class="mark">%EMOJI%</div>
+<h1>%HEADING%</h1>
+<p>%SUB%</p>
+<div class="brand">🌱 <b>contributor.info</b></div>
+</main></body></html>"#;
+
+/// Render the callback page for a success or failure outcome, matching the
+/// app's palette (accent `#10b981`, seedling motif).
+fn callback_html(signed_in: bool) -> String {
+    let (accent, emoji, heading, sub) = if signed_in {
+        (
+            "16,185,129",
+            "\u{1F331}",
+            "You\u{2019}re signed in",
+            "Head back to the contributor.info app \u{2014} you can close this tab.",
+        )
+    } else {
+        (
+            "239,68,68",
+            "\u{26A0}\u{FE0F}",
+            "Sign-in didn\u{2019}t complete",
+            "No authorization code came back. Close this tab and try again from the app.",
+        )
+    };
+    CALLBACK_TEMPLATE
+        .replace("%ACCENT%", accent)
+        .replace("%EMOJI%", emoji)
+        .replace("%HEADING%", heading)
+        .replace("%SUB%", sub)
+}
+
 /// Wait for the OAuth redirect on the loopback listener and pull `code` out
 /// of the request line. Serves a tiny "return to the app" page in response.
 fn wait_for_code(listener: TcpListener) -> Result<String, String> {
@@ -120,20 +191,12 @@ fn wait_for_code(listener: TcpListener) -> Result<String, String> {
                     });
 
                 let (status, body) = match &code {
-                    Some(_) => (
-                        "200 OK",
-                        "<html><body style=\"font-family:sans-serif;text-align:center;padding-top:20vh\">\
-                         <h2>\u{1F331} Signed in</h2><p>You can close this tab and return to the app.</p></body></html>",
-                    ),
-                    None => (
-                        "400 Bad Request",
-                        "<html><body style=\"font-family:sans-serif;text-align:center;padding-top:20vh\">\
-                         <h2>Sign-in failed</h2><p>No authorization code was returned. Close this tab and try again.</p></body></html>",
-                    ),
+                    Some(_) => ("200 OK", callback_html(true)),
+                    None => ("400 Bad Request", callback_html(false)),
                 };
                 let _ = stream.write_all(
                     format!(
-                        "HTTP/1.1 {status}\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                        "HTTP/1.1 {status}\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
                         body.len()
                     )
                     .as_bytes(),
@@ -165,8 +228,7 @@ pub async fn login(
 ) -> Result<Session, String> {
     // One listener per login; a failed bind means another login is pending
     // (or another app owns the port).
-    let listener = TcpListener::bind(("127.0.0.1", CALLBACK_PORT))
-        .map_err(|_| format!("port {CALLBACK_PORT} is busy — is a sign-in already running?"))?;
+    let listener = bind_callback_listener()?;
 
     let mut verifier_bytes = [0u8; 32];
     getrandom::getrandom(&mut verifier_bytes).map_err(|e| format!("rng failure: {e}"))?;

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ mod auth;
 mod settings;
 mod supabase;
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -58,6 +59,22 @@ struct AppState {
     snapshot: Mutex<Snapshot>,
     settings: Mutex<Settings>,
     session: Mutex<Option<Session>>,
+    /// True while an interactive login holds the loopback callback port. Both
+    /// sign-in entry points (tray item and dashboard button) funnel through
+    /// `do_login`, so this keeps them from racing on the same bind.
+    login_in_progress: AtomicBool,
+}
+
+/// Clears `login_in_progress` when a login finishes, whatever the outcome.
+struct LoginGuard(AppHandle);
+
+impl Drop for LoginGuard {
+    fn drop(&mut self) {
+        self.0
+            .state::<AppState>()
+            .login_in_progress
+            .store(false, Ordering::SeqCst);
+    }
 }
 
 fn fmt_trend(v: Option<f64>) -> String {
@@ -107,15 +124,6 @@ fn metric_lines(m: &WorkspaceMetrics) -> Vec<String> {
 
 fn build_menu(app: &AppHandle, snapshot: &Snapshot) -> tauri::Result<Menu<tauri::Wry>> {
     let menu = Menu::new(app)?;
-
-    menu.append(&MenuItem::with_id(
-        app,
-        "open-site",
-        "contributor.info \u{2197}",
-        true,
-        None::<&str>,
-    )?)?;
-    menu.append(&PredefinedMenuItem::separator(app)?)?;
 
     if snapshot.workspaces.is_empty() {
         menu.append(&MenuItem::with_id(
@@ -318,6 +326,18 @@ fn refresh_now(app: AppHandle) {
 }
 
 async fn do_login(app: AppHandle) -> Result<String, String> {
+    // Only one interactive login at a time — a second attempt would collide on
+    // the loopback callback port and surface a confusing "port busy" error.
+    if app
+        .state::<AppState>()
+        .login_in_progress
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return Err("a sign-in is already in progress — finish it in your browser, or wait a moment".into());
+    }
+    let _guard = LoginGuard(app.clone());
+
     let cfg = app.state::<AppState>().settings.lock().unwrap().clone();
     let anon_key = cfg.anon_key();
     if anon_key.is_empty() {
@@ -378,9 +398,6 @@ pub fn run() {
                 .on_menu_event(|app, event| {
                     let id = event.id().as_ref();
                     match id {
-                        "open-site" => {
-                            let _ = app.opener().open_url(SITE, None::<&str>);
-                        }
                         "dashboard" => show_dashboard(app),
                         "refresh" => {
                             tauri::async_runtime::spawn(refresh(app.clone()));

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -75,13 +75,22 @@ export default function App() {
   const [authError, setAuthError] = useState<string | null>(null);
 
   useEffect(() => {
+    const syncSnapshot = () => invoke<Snapshot>('get_snapshot').then(setSnapshot);
     invoke<string[]>('get_workspaces').then(setSlugs);
-    invoke<Snapshot>('get_snapshot').then(setSnapshot);
+    syncSnapshot();
     const unlistenSnapshot = listen<Snapshot>('snapshot', (e) => setSnapshot(e.payload));
     const unlistenLoginError = listen<string>('login-error', (e) => setAuthError(e.payload));
+    // A hidden webview can miss or defer the `snapshot` event, which left the
+    // auth state (the sign-in button) stale after signing in from the tray.
+    // Re-pull the authoritative snapshot whenever the window is shown again.
+    const onVisible = () => document.visibilityState === 'visible' && syncSnapshot();
+    document.addEventListener('visibilitychange', onVisible);
+    window.addEventListener('focus', syncSnapshot);
     return () => {
       unlistenSnapshot.then((fn) => fn());
       unlistenLoginError.then((fn) => fn());
+      document.removeEventListener('visibilitychange', onVisible);
+      window.removeEventListener('focus', syncSnapshot);
     };
   }, []);
 
@@ -90,6 +99,9 @@ export default function App() {
     setAuthError(null);
     try {
       await invoke<string>('login');
+      // `login` resolves only after the backend has refreshed and stored the
+      // new snapshot, so this reflects the signed-in state immediately.
+      setSnapshot(await invoke<Snapshot>('get_snapshot'));
     } catch (e) {
       setAuthError(String(e));
     } finally {
@@ -100,6 +112,9 @@ export default function App() {
   const signOut = async () => {
     setAuthError(null);
     await invoke('logout');
+    // `logout` refreshes in the background; flip the UI now and let the next
+    // `snapshot` event reconcile the rest.
+    setSnapshot((s) => (s ? { ...s, signed_in_as: null } : s));
   };
 
   const save = async (next: string[]) => {
@@ -112,7 +127,10 @@ export default function App() {
     // leading/trailing slashes, and reduce it to the bare slug the API and
     // `/i/{slug}` links expect. A leading slash here previously slipped through
     // and produced `/i//{slug}` links plus failed lookups.
-    const slug = draft.trim().replace(/^.*\/i\//, '').replace(/^\/+|\/+$/g, '');
+    const slug = draft
+      .trim()
+      .replace(/^.*\/i\//, '')
+      .replace(/^\/+|\/+$/g, '');
     if (!slug || slugs.includes(slug)) return;
     setDraft('');
     await save([...slugs, slug]);
@@ -166,7 +184,11 @@ export default function App() {
                 {ws && ws.state !== 'ready' && (
                   <span className="badge warn">{STATE_HINT[ws.state] ?? ws.state}</span>
                 )}
-                <button className="ghost" title="Remove" onClick={() => save(slugs.filter((s) => s !== slug))}>
+                <button
+                  className="ghost"
+                  title="Remove"
+                  onClick={() => save(slugs.filter((s) => s !== slug))}
+                >
                   ✕
                 </button>
               </div>
@@ -174,14 +196,8 @@ export default function App() {
                 <div className="tiles">
                   <Tile label="open PRs" value={String(m.open_prs)} trend={m.prs_trend} />
                   <Tile label="merged" value={String(m.merged_prs)} />
-                  <Tile
-                    label="PRs / day"
-                    value={(m.pr_velocity ?? 0).toFixed(1)}
-                  />
-                  <Tile
-                    label="hrs to merge"
-                    value={(m.avg_pr_merge_time_hours ?? 0).toFixed(0)}
-                  />
+                  <Tile label="PRs / day" value={(m.pr_velocity ?? 0).toFixed(1)} />
+                  <Tile label="hrs to merge" value={(m.avg_pr_merge_time_hours ?? 0).toFixed(0)} />
                   <Tile
                     label="active contribs"
                     value={String(m.active_contributors)}
@@ -202,8 +218,8 @@ export default function App() {
         })}
         {slugs.length === 0 && (
           <p className="empty">
-            Add a workspace above (its slug from contributor.info/i/…) to see its team metrics
-            here and in the tray menu.
+            Add a workspace above (its slug from contributor.info/i/…) to see its team metrics here
+            and in the tray menu.
           </p>
         )}
       </section>


### PR DESCRIPTION
## Problem

Desktop sign-in never completed, so no session ever persisted — the tray and dashboard were stuck on **"Sign in with GitHub"** even after authenticating. Root cause: the loopback OAuth callback listener couldn't rebind port `1421` after a prior attempt (Rust's std `TcpListener` doesn't set `SO_REUSEADDR`, so a socket in `TIME_WAIT` from the served `/callback` blocks the retry → *"port 1421 is busy"*).

## Changes

- **auth (`SO_REUSEADDR`)** — bind the callback listener via `socket2` with address reuse so a lingering `TIME_WAIT` socket no longer blocks a retry. This is the core fix that lets sign-in actually complete and persist a session.
- **auth (branded callback page)** — the browser "return to the app" page is now a palette-matched card (accent `#10b981`, seedling motif, light/dark aware) for both success and failure, served as `text/html; charset=utf-8` (fixes the mojibake 🌱).
- **lib (login guard)** — the two sign-in entry points (tray item + dashboard button) are serialized behind a login-in-progress flag, so a concurrent click gets a clear message instead of a port collision.
- **lib (menu)** — removed the redundant "contributor.info ↗" item from the top of the tray menu.
- **App (dashboard auth state)** — re-sync the snapshot after `login` and whenever the window is re-shown (`visibilitychange`/`focus`); a hidden webview could miss the `snapshot` event and leave the sign-in button stale.

## Testing

- `cargo check` / `cargo test` clean; `tsc --noEmit` clean; release `.app` bundle builds.
- Verified end-to-end locally: GitHub sign-in completes, `session.json` persists (`user_name` populated), tray flips to "Signed in as …", dashboard reflects the account.

## Note

The desktop build requires `VITE_SUPABASE_ANON_KEY` in the env or it bakes to `unconfigured` (documented in `desktop/README.md`). Release CI must set it.