### PR TITLE
fix: keep @ai-sdk/react out of vendor-react-core chunk

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -171,6 +171,12 @@ export default defineConfig(() => ({
             if (id.includes('@sentry')) {
               return; // Return undefined to let Vite handle chunking naturally
             }
+            // AI SDK must also be checked BEFORE react: @ai-sdk/react contains 'react/'
+            // and would otherwise land in vendor-react-core, statically dragging the
+            // whole vendor-ai-sdk chunk into the initial page load.
+            if (id.includes('@ai-sdk') || id.includes('/node_modules/ai/')) {
+              return 'vendor-ai-sdk';
+            }
             // Core React libraries - loaded immediately
             if (id.includes('react/') || id.includes('react-dom/') || id.includes('react-router')) {
               return 'vendor-react-core';


### PR DESCRIPTION
## Summary

One-line-class fix from the performance audit in #1815 (Phase 1, item 1).

The `manualChunks` matcher in `vite.config.ts` checked `id.includes('react/')` before the `@ai-sdk` check. Since `@ai-sdk/react/` contains the substring `react/`, the AI SDK's React bindings were assigned to `vendor-react-core` — which then **statically imported the entire 193 kB `vendor-ai-sdk` chunk into the initial page load on every route**. This is the same substring trap already documented in the config for `@sentry/react` (#1400).

This PR moves the `@ai-sdk` check above the react check (mirroring the existing Sentry precedent), so the AI SDK loads only when the chat panel does.

## Measured impact

Static import graph traced from the built entry chunk (`vite build`, prod config):

| | Before | After |
| --- | --- | --- |
| Initial-load chunks | 6 | 5 |
| Critical-path JS (raw) | 1,076 kB | 883 kB |
| `vendor-ai-sdk` on initial load | yes (193 kB / 49 kB gzip) | no |

~50 kB gzip less JS on every page view. Confirmed against production that `vendor-ai-sdk` currently loads in the first script wave on `/:owner/:repo` (188ms into page load, before any user interaction).

## Testing

- `vite build` succeeds; chunk graph re-traced to confirm `vendor-ai-sdk` is no longer statically imported by the entry or `vendor-react-core`
- TypeScript check passed (pre-commit hook)
- Suggested smoke test before merge: open the chat panel on a repo page and send a message (exercises the now-lazy `@ai-sdk/react` path)

Part of #1815

https://claude.ai/code/session_014rHyvtukqw8HhDfdVzNkdF
