### PR TITLE
perf: Phase 1 LCP quick wins — dedupe repo lookups, defer non-paint calls, preload critical chunks

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+# Skip onnxruntime-node's postinstall download of the CUDA execution provider
+# (~200MB from nuget.org). The CPU runtime is bundled in the npm package and is
+# all we use; the download intermittently times out and fails `npm ci` in CI.
+# See the E2E flake on PR #1816. Override locally with ONNXRUNTIME_NODE_INSTALL=cuda12.
+onnxruntime-node-install=skip

--- a/src/components/features/repository/github-app-install-button.tsx
+++ b/src/components/features/repository/github-app-install-button.tsx
@@ -4,6 +4,7 @@ import { Check, ExternalLink } from '@/components/ui/icon';
 import { toast } from 'sonner';
 import { getSupabase } from '@/lib/supabase-lazy';
 import { useGitHubAuth } from '@/hooks/use-github-auth';
+import { runWhenIdle } from '@/lib/utils/idle-callback';
 
 interface GitHubAppInstallButtonProps {
   owner: string;
@@ -26,10 +27,15 @@ export function GitHubAppInstallButton({
   const { isLoggedIn } = useGitHubAuth();
 
   useEffect(() => {
-    checkInstallationStatus();
-    if (isLoggedIn) {
-      checkUserPermissions();
-    }
+    // Defer these status checks: installation-status takes ~1.8s server-side and
+    // only gates a secondary header button, so keep it off the LCP path (#1815)
+    const cancel = runWhenIdle(() => {
+      checkInstallationStatus();
+      if (isLoggedIn) {
+        checkUserPermissions();
+      }
+    });
+    return cancel;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [owner, repo, isLoggedIn]);
 

--- a/src/hooks/use-monthly-contributor-rankings.ts
+++ b/src/hooks/use-monthly-contributor-rankings.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { getSupabase } from '@/lib/supabase-lazy';
 import { captureException } from '@/lib/sentry-lazy';
 import { trackEvent } from '@/lib/posthog-lazy';
+import { runWhenIdle } from '@/lib/utils/idle-callback';
 
 export interface MonthlyContributorRanking {
   id: string;
@@ -305,9 +306,17 @@ export function useMonthlyContributorRankings(owner: string, repo: string): Mont
       }
     }
 
-    if (owner && repo) {
-      fetchRankings();
+    if (!owner || !repo) {
+      return;
     }
+
+    // Defer the edge-function invoke: the rankings card is below the fold, so
+    // this call shouldn't compete with LCP-critical fetches on mount (#1815).
+    // The skeleton state (loading=true) already covers the idle delay.
+    const cancel = runWhenIdle(() => {
+      fetchRankings();
+    });
+    return cancel;
   }, [owner, repo]);
 
   return { rankings, loading, error, isUsingFallback, displayMonth, displayYear, isCalculating };

--- a/src/hooks/use-repository-metadata.ts
+++ b/src/hooks/use-repository-metadata.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { getSupabase } from '@/lib/supabase-lazy';
+import { getRepositoryByOwnerName } from '@/lib/utils/repository-helpers';
 import { RepositorySize } from '@/lib/validation/database-schemas';
 
 export interface RepositoryMetadata {
@@ -47,22 +48,18 @@ export function useRepositoryMetadata(owner?: string, repo?: string): UseReposit
     setError(null);
 
     try {
-      // First, get the repository ID
-      const supabase = await getSupabase();
-      const { data: repoData, error: repoError } = await supabase
-        .from('repositories')
-        .select('id')
-        .eq('owner', owner)
-        .eq('name', repo)
-        .maybeSingle();
+      // First, get the repository ID (shared deduped lookup, see #1815)
+      const repoData = await getRepositoryByOwnerName(owner, repo).catch(() => null);
 
-      if (repoError || !repoData) {
+      if (!repoData) {
         // Repository not in database yet
         setMetadata({
           dataFreshness: 'old',
         });
         return;
       }
+
+      const supabase = await getSupabase();
 
       // Get tracked repository data with size and metadata
       const { data: trackedData, error: trackedError } = await supabase

--- a/src/hooks/use-repository-tracking.ts
+++ b/src/hooks/use-repository-tracking.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { getSupabase } from '@/lib/supabase-lazy';
 import { useGitHubAuth } from './use-github-auth';
+import { getRepositoryByOwnerName } from '@/lib/utils/repository-helpers';
 import { handleApiResponse } from '@/lib/utils/api-helpers';
 import { NotificationService } from '@/lib/notifications';
 import { trackEvent } from '@/lib/posthog-lazy';
@@ -79,16 +79,11 @@ export function useRepositoryTracking({
         setState((prev) => ({ ...prev, status: 'checking', error: null }));
       }
 
-      // Check if repository exists
-      const supabase = await getSupabase();
-      const { data: repoData, error } = await supabase
-        .from('repositories')
-        .select('id, owner, name')
-        .eq('owner', owner)
-        .eq('name', repo)
-        .maybeSingle();
-
-      if (error) {
+      // Check if repository exists (shared deduped lookup, see #1815)
+      let repoData: Awaited<ReturnType<typeof getRepositoryByOwnerName>> = null;
+      try {
+        repoData = await getRepositoryByOwnerName(owner, repo);
+      } catch (error) {
         console.error('Error checking repository:', error);
         setState({
           status: 'error',
@@ -201,13 +196,12 @@ export function useRepositoryTracking({
         pollCount++;
 
         try {
-          const supabaseClient = await getSupabase();
-          const { data: repoData } = await supabaseClient
-            .from('repositories')
-            .select('id, owner, name')
-            .eq('owner', owner)
-            .eq('name', repo)
-            .maybeSingle();
+          let repoData: Awaited<ReturnType<typeof getRepositoryByOwnerName>> = null;
+          try {
+            repoData = await getRepositoryByOwnerName(owner, repo);
+          } catch {
+            // Treated the same as "not found yet"; the poll will retry
+          }
 
           const hasData = !!repoData;
 

--- a/src/lib/supabase-direct-commits.ts
+++ b/src/lib/supabase-direct-commits.ts
@@ -1,5 +1,5 @@
-import { supabase } from './supabase';
 import { smartCommitAnalyzer } from './progressive-capture/smart-commit-analyzer';
+import { getRepositoryByOwnerName } from './utils/repository-helpers';
 import { trackDatabaseOperation } from './simple-logging';
 // Removed Sentry import - using simple logging instead
 
@@ -34,13 +34,14 @@ export async function fetchDirectCommitsWithDatabaseFallback(
     'fetchDirectCommitsWithDatabaseFallback',
     async () => {
       try {
-        // First, get the repository ID
-        const { data: repoData, error: repoError } = await supabase
-          .from('repositories')
-          .select('id')
-          .eq('owner', owner)
-          .eq('name', repo)
-          .maybeSingle();
+        // First, get the repository ID (shared deduped lookup, see #1815)
+        let repoData: Awaited<ReturnType<typeof getRepositoryByOwnerName>> = null;
+        let repoError: Error | null = null;
+        try {
+          repoData = await getRepositoryByOwnerName(owner, repo);
+        } catch (err) {
+          repoError = err instanceof Error ? err : new Error(String(err));
+        }
 
         if (repoError || !repoData) {
           // Simple breadcrumb logging without analytics

--- a/src/lib/supabase-pr-data-smart.ts
+++ b/src/lib/supabase-pr-data-smart.ts
@@ -11,6 +11,8 @@ import {
 import { sendInngestEvent } from './inngest/client-safe';
 import { toast } from 'sonner';
 import { validateAndTransformPRData } from './validation';
+import { getRepositoryByOwnerName, type RepositoryIdentity } from './utils/repository-helpers';
+import { runWhenIdle } from './utils/idle-callback';
 
 interface FetchOptions {
   timeRange?: string;
@@ -50,15 +52,15 @@ export async function fetchPRDataSmart(
       const since = new Date();
       since.setDate(since.getDate() - days);
 
-      // Check if repository exists
-      const { data: repoData, error: repoError } = await supabase
-        .from('repositories')
-        .select('id, owner, name, last_updated_at')
-        .eq('owner', owner)
-        .eq('name', repo)
-        .maybeSingle();
+      // Check if repository exists (shared deduped lookup, see #1815)
+      let repoData: RepositoryIdentity | null = null;
+      try {
+        repoData = await getRepositoryByOwnerName(owner, repo);
+      } catch {
+        // Lookup failure is handled the same as "not found" below
+      }
 
-      if (repoError || !repoData) {
+      if (!repoData) {
         // Repository not in database - it needs to be tracked first
         if (triggerBackgroundSync) {
           // Add to tracking (handled by useRepositoryDiscovery)
@@ -190,28 +192,31 @@ export async function fetchPRDataSmart(
 
       const isStale = isEmpty || isRepositoryStale;
 
-      // Trigger background sync if needed
+      // Trigger background sync if needed. The queue-event call is fire-and-forget
+      // (its result is never consumed), so defer it until the main thread is idle
+      // instead of blocking the pre-LCP fetch waterfall (#1815).
       if (triggerBackgroundSync && (isEmpty || isStale)) {
-        try {
-          await sendInngestEvent({
-            name: 'capture/repository.sync.graphql',
-            data: {
-              repositoryId: repoData.id,
-              repositoryName: `${repoData.owner}/${repoData.name}`,
-              days: 30,
-              priority: isEmpty ? 'high' : 'medium',
-              reason: isEmpty ? 'smart-fetch-empty-repository' : 'smart-fetch-stale-data',
-            },
+        const syncEvent = {
+          name: 'capture/repository.sync.graphql',
+          data: {
+            repositoryId: repoData.id,
+            repositoryName: `${repoData.owner}/${repoData.name}`,
+            days: 30,
+            priority: isEmpty ? 'high' : 'medium',
+            reason: isEmpty ? 'smart-fetch-empty-repository' : 'smart-fetch-stale-data',
+          },
+        };
+        runWhenIdle(() => {
+          sendInngestEvent(syncEvent).catch((error) => {
+            console.error('Failed to trigger background sync:', error);
           });
+        });
 
-          if (showNotifications && isEmpty) {
-            toast.info(`Getting familiar with ${owner}/${repo}...`, {
-              description: "We're fetching the latest data. Check back in a minute!",
-              duration: 5000,
-            });
-          }
-        } catch (error) {
-          console.error('Failed to trigger background sync:', error);
+        if (showNotifications && isEmpty) {
+          toast.info(`Getting familiar with ${owner}/${repo}...`, {
+            description: "We're fetching the latest data. Check back in a minute!",
+            duration: 5000,
+          });
         }
       }
 
@@ -219,7 +224,7 @@ export async function fetchPRDataSmart(
       if (transformedPRs.length > 0) {
         return createSuccessResult(transformedPRs, {
           isStale,
-          lastUpdate: repoData.last_updated_at,
+          ...(repoData.last_updated_at ? { lastUpdate: repoData.last_updated_at } : {}),
           dataCompleteness: calculateDataCompleteness(transformedPRs),
         });
       }

--- a/src/lib/utils/__tests__/idle-callback.test.ts
+++ b/src/lib/utils/__tests__/idle-callback.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { runWhenIdle } from '../idle-callback';
+
+describe('runWhenIdle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('uses requestIdleCallback with the given timeout when available', () => {
+    const requestIdleCallback = vi.fn().mockReturnValue(42);
+    const cancelIdleCallback = vi.fn();
+    vi.stubGlobal('requestIdleCallback', requestIdleCallback);
+    vi.stubGlobal('cancelIdleCallback', cancelIdleCallback);
+
+    const callback = vi.fn();
+    runWhenIdle(callback, { timeout: 1234 });
+
+    expect(requestIdleCallback).toHaveBeenCalledTimes(1);
+    expect(requestIdleCallback.mock.calls[0][1]).toEqual({ timeout: 1234 });
+
+    // Simulate the browser firing the idle callback
+    requestIdleCallback.mock.calls[0][0]();
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancel unregisters the idle callback', () => {
+    const requestIdleCallback = vi.fn().mockReturnValue(42);
+    const cancelIdleCallback = vi.fn();
+    vi.stubGlobal('requestIdleCallback', requestIdleCallback);
+    vi.stubGlobal('cancelIdleCallback', cancelIdleCallback);
+
+    const cancel = runWhenIdle(vi.fn());
+    cancel();
+
+    expect(cancelIdleCallback).toHaveBeenCalledWith(42);
+  });
+
+  it('falls back to setTimeout when requestIdleCallback is unavailable', () => {
+    const original = (window as { requestIdleCallback?: unknown }).requestIdleCallback;
+    delete (window as { requestIdleCallback?: unknown }).requestIdleCallback;
+
+    try {
+      const callback = vi.fn();
+      runWhenIdle(callback, { fallbackDelay: 100 });
+
+      expect(callback).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(100);
+      expect(callback).toHaveBeenCalledTimes(1);
+    } finally {
+      if (original !== undefined) {
+        (window as { requestIdleCallback?: unknown }).requestIdleCallback = original;
+      }
+    }
+  });
+
+  it('cancel clears the setTimeout fallback', () => {
+    const original = (window as { requestIdleCallback?: unknown }).requestIdleCallback;
+    delete (window as { requestIdleCallback?: unknown }).requestIdleCallback;
+
+    try {
+      const callback = vi.fn();
+      const cancel = runWhenIdle(callback, { fallbackDelay: 100 });
+      cancel();
+
+      vi.advanceTimersByTime(1000);
+      expect(callback).not.toHaveBeenCalled();
+    } finally {
+      if (original !== undefined) {
+        (window as { requestIdleCallback?: unknown }).requestIdleCallback = original;
+      }
+    }
+  });
+});

--- a/src/lib/utils/__tests__/repository-lookup.test.ts
+++ b/src/lib/utils/__tests__/repository-lookup.test.ts
@@ -1,0 +1,96 @@
+/* eslint-disable no-restricted-syntax */
+// Async tests required: the dedup contract is about concurrent promise sharing.
+// All mocks resolve immediately — no real timers, no hangs.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockMaybeSingle } = vi.hoisted(() => {
+  const mockMaybeSingle = vi.fn();
+  return { mockMaybeSingle };
+});
+
+vi.mock('@/lib/supabase-lazy', () => ({
+  getSupabase: vi.fn().mockResolvedValue({
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          eq: () => ({
+            maybeSingle: mockMaybeSingle,
+          }),
+        }),
+      }),
+    }),
+  }),
+}));
+
+import { getRepositoryByOwnerName, clearRepositoryLookupCache } from '../repository-helpers';
+
+const repoRow = {
+  id: 'repo-uuid-1',
+  owner: 'continuedev',
+  name: 'continue',
+  last_updated_at: '2026-07-13T00:00:00Z',
+};
+
+describe('getRepositoryByOwnerName', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearRepositoryLookupCache();
+  });
+
+  it('dedupes concurrent lookups for the same owner/name into one query', async () => {
+    mockMaybeSingle.mockResolvedValue({ data: repoRow, error: null });
+
+    const [a, b, c] = await Promise.all([
+      getRepositoryByOwnerName('continuedev', 'continue'),
+      getRepositoryByOwnerName('continuedev', 'continue'),
+      getRepositoryByOwnerName('continuedev', 'continue'),
+    ]);
+
+    expect(mockMaybeSingle).toHaveBeenCalledTimes(1);
+    expect(a).toEqual(repoRow);
+    expect(b).toEqual(repoRow);
+    expect(c).toEqual(repoRow);
+  });
+
+  it('serves sequential lookups for a found repository from cache', async () => {
+    mockMaybeSingle.mockResolvedValue({ data: repoRow, error: null });
+
+    await getRepositoryByOwnerName('continuedev', 'continue');
+    const second = await getRepositoryByOwnerName('continuedev', 'continue');
+
+    expect(mockMaybeSingle).toHaveBeenCalledTimes(1);
+    expect(second).toEqual(repoRow);
+  });
+
+  it('does not cache misses so pollers can see a repo appear', async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: null, error: null });
+    mockMaybeSingle.mockResolvedValueOnce({ data: repoRow, error: null });
+
+    const miss = await getRepositoryByOwnerName('new', 'repo');
+    const hit = await getRepositoryByOwnerName('new', 'repo');
+
+    expect(miss).toBeNull();
+    expect(hit).toEqual(repoRow);
+    expect(mockMaybeSingle).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws on query error and does not cache the failure', async () => {
+    mockMaybeSingle.mockResolvedValueOnce({ data: null, error: { message: 'boom' } });
+    mockMaybeSingle.mockResolvedValueOnce({ data: repoRow, error: null });
+
+    await expect(getRepositoryByOwnerName('a', 'b')).rejects.toBeTruthy();
+    const retry = await getRepositoryByOwnerName('a', 'b');
+
+    expect(retry).toEqual(repoRow);
+    expect(mockMaybeSingle).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not share cache entries across different repositories', async () => {
+    mockMaybeSingle.mockResolvedValue({ data: repoRow, error: null });
+
+    await getRepositoryByOwnerName('owner-a', 'repo');
+    await getRepositoryByOwnerName('owner-b', 'repo');
+
+    expect(mockMaybeSingle).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/utils/idle-callback.ts
+++ b/src/lib/utils/idle-callback.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared idle-deferral helper.
+ *
+ * Defers work that doesn't affect first paint (background sync triggers,
+ * secondary status checks) until the main thread is idle, keeping it off the
+ * LCP critical path. See https://github.com/bdougie/contributor.info/issues/1815
+ *
+ * Follows the same requestIdleCallback + setTimeout fallback pattern used in
+ * route-prefetch.ts and query-client.ts (Safari has no requestIdleCallback).
+ */
+
+/** Cancels a pending idle callback scheduled by {@link runWhenIdle}. */
+export type CancelIdleCallback = () => void;
+
+interface RunWhenIdleOptions {
+  /** Max time to wait for an idle period before forcing the callback. */
+  timeout?: number;
+  /** Delay used by the setTimeout fallback when requestIdleCallback is unavailable. */
+  fallbackDelay?: number;
+}
+
+export function runWhenIdle(
+  callback: () => void,
+  { timeout = 2000, fallbackDelay = 100 }: RunWhenIdleOptions = {}
+): CancelIdleCallback {
+  if (typeof window !== 'undefined' && 'requestIdleCallback' in window) {
+    const id = window.requestIdleCallback(() => callback(), { timeout });
+    return () => window.cancelIdleCallback(id);
+  }
+
+  const id = setTimeout(callback, fallbackDelay);
+  return () => clearTimeout(id);
+}

--- a/src/lib/utils/repository-helpers.ts
+++ b/src/lib/utils/repository-helpers.ts
@@ -1,6 +1,83 @@
 import { getSupabase } from '@/lib/supabase-lazy';
 import type { GitHubRepository } from '@/lib/github';
 
+/** Row returned by {@link getRepositoryByOwnerName} — the superset of columns
+ * every repo-view consumer needs, so one query serves all of them. */
+export interface RepositoryIdentity {
+  id: string;
+  owner: string;
+  name: string;
+  last_updated_at: string | null;
+}
+
+// Promise-level dedup + short TTL cache for the owner/name → repository row
+// lookup. Before this, every repo-view hook resolved the id independently,
+// firing 4-6 identical queries per page view (#1815).
+//
+// Cache semantics matter here:
+// - Concurrent callers share the in-flight promise (dedup).
+// - Found rows are cached for the TTL (matches query-client staleTime).
+// - Misses (null) and errors are NOT cached — tracking flows poll for a repo
+//   to appear right after it's created, and a cached miss would break them.
+const REPOSITORY_LOOKUP_TTL_MS = 5 * 60 * 1000;
+
+interface RepositoryLookupEntry {
+  promise: Promise<RepositoryIdentity | null>;
+  timestamp: number;
+}
+
+const repositoryLookupCache = new Map<string, RepositoryLookupEntry>();
+
+/**
+ * Resolve a repository row by owner/name with request dedup and caching.
+ *
+ * Returns null when the repository isn't in the database; throws on query
+ * errors so callers can distinguish "not tracked" from "lookup failed".
+ */
+export function getRepositoryByOwnerName(
+  owner: string,
+  name: string
+): Promise<RepositoryIdentity | null> {
+  const key = `${owner}/${name}`;
+  const cached = repositoryLookupCache.get(key);
+  if (cached && Date.now() - cached.timestamp < REPOSITORY_LOOKUP_TTL_MS) {
+    return cached.promise;
+  }
+
+  const promise = (async (): Promise<RepositoryIdentity | null> => {
+    const supabase = await getSupabase();
+    const { data, error } = await supabase
+      .from('repositories')
+      .select('id, owner, name, last_updated_at')
+      .eq('owner', owner)
+      .eq('name', name)
+      .maybeSingle();
+
+    if (error) {
+      throw error;
+    }
+    return (data as RepositoryIdentity | null) ?? null;
+  })();
+
+  repositoryLookupCache.set(key, { promise, timestamp: Date.now() });
+  promise
+    .then((result) => {
+      if (result === null) {
+        repositoryLookupCache.delete(key);
+      }
+    })
+    .catch(() => {
+      repositoryLookupCache.delete(key);
+    });
+
+  return promise;
+}
+
+/** Test-only escape hatch to reset the lookup cache between cases. */
+export function clearRepositoryLookupCache(): void {
+  repositoryLookupCache.clear();
+}
+
 // Extended repository properties that may be available from GitHub API
 export interface ExtendedGitHubRepository extends GitHubRepository {
   watchers_count?: number;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -197,10 +197,6 @@ export default defineConfig(() => ({
             if (id.includes('uplot')) {
               return 'vendor-uplot';
             }
-            // AI SDK - lazy loaded via chat panel
-            if (id.includes('@ai-sdk') || id.includes('/node_modules/ai/')) {
-              return 'vendor-ai-sdk';
-            }
             // Supabase SDK
             if (id.includes('@supabase')) {
               return 'vendor-supabase';
@@ -266,13 +262,17 @@ export default defineConfig(() => ({
           if (b.includes('vendor-utils')) return 1;
           return 0;
         });
-        // CRITICAL: Only preload chunks needed for initial H1 render (LCP element)
-        // UI components (Radix), charts, markdown, and analytics load on-demand
-        // This reduces initial preload from ~10 chunks to 3, improving LCP by 200-300ms
+        // Preload the chunks the entry statically imports anyway. vendor-supabase and
+        // vendor-ui are on every route's critical path; without a preload hint the
+        // browser only discovers them after parsing the entry chunk, costing a
+        // round-trip before first data fetch / render (#1815). Charts, markdown, and
+        // analytics stay on-demand.
         return sorted.filter(
           (dep) =>
             dep.includes('vendor-react-core') ||
             dep.includes('vendor-utils') ||
+            dep.includes('vendor-supabase') ||
+            dep.includes('vendor-ui') ||
             // Match index- followed by hash, but exclude other prefixed chunks
             (dep.includes('index-') && !dep.includes('nivo-') && !dep.includes('charts-'))
         );


### PR DESCRIPTION
## Summary

Completes Phase 1 of the performance audit in #1815 (items 2–4; item 1 shipped in #1816), plus a CI flake fix.

### 1. Shared repository-id lookup (audit item 2)

Every repo-view data hook resolved `owner/name → repository id` with its own identical `repositories` query — 4–6 duplicate queries per page view, serialized into the LCP waterfall.

New `getRepositoryByOwnerName()` in `repository-helpers.ts` provides promise-level dedup + a 5-minute TTL cache (matching the query-client `staleTime`), selecting the superset of columns (`id, owner, name, last_updated_at`) so one query serves all consumers. Wired through:

- `use-repository-tracking.ts` (mount check + tracking poll)
- `use-repository-metadata.ts`
- `supabase-pr-data-smart.ts`
- `supabase-direct-commits.ts`

Cache semantics: concurrent callers share the in-flight promise; found rows cache for the TTL; **misses and errors are never cached** so tracking pollers still see newly-created repos appear.

Note: the audit suggested a TanStack Query hook. A lib-level deduped function covers both the React hooks *and* the plain async fetchers (`supabase-pr-data-smart`, `supabase-direct-commits`) with one mechanism, so no separate hook was needed — the dedup effect is the same and there's no unused abstraction.

### 2. Defer non-paint calls on repo view (audit item 3)

New shared `runWhenIdle()` util (`requestIdleCallback` + `setTimeout` fallback — the pattern already inlined in route-prefetch.ts, query-client.ts, sentry-lazy.ts). Applied to the three pre-LCP calls that don't affect first paint:

- `installation-status` (~1.8s server-side, gates a secondary header button) — deferred in `github-app-install-button.tsx`
- `queue-event` background-sync trigger — fire-and-forget, no longer awaited inside `fetchPRDataSmart`'s critical path
- `calculate-monthly-rankings` edge invoke — below-the-fold card, deferred in `use-monthly-contributor-rankings.ts`

### 3. Preload critical chunks (audit item 4)

`vendor-supabase` (168 kB) and `vendor-ui` (132 kB) are statically imported by the entry on every route but weren't in `modulePreload.resolveDependencies`, so the browser discovered them a round-trip late. Both now emit `<link rel="modulepreload">` in the HTML shell (verified in the built `dist/index.html`). Also removed a dead duplicate `@ai-sdk` check in `manualChunks` left behind by #1816.

### 4. CI flake fix

`onnxruntime-node`'s postinstall downloads the CUDA execution provider from nuget.org on every `npm ci`; the download intermittently times out and failed the E2E job on #1816. CI runners have no GPU and the CPU runtime is bundled in the package, so a repo `.npmrc` sets the package's documented `onnxruntime-node-install=skip` flag for all workflows and dev machines.

## Testing

- New unit tests: `repository-lookup.test.ts` (5 tests — concurrent dedup, TTL cache, miss/error non-caching, per-repo isolation) and `idle-callback.test.ts` (4 tests — rIC path, fallback, cancellation)
- Full unit suite passes (1902 passed; the one prior local failure was the missing onnxruntime install, fixed by the `.npmrc` change)
- `npm run build` (typecheck + prod build) passes; `dist/index.html` confirmed to modulepreload vendor-supabase + vendor-ui
- With the skip flag: fresh install completes with no nuget.org download, `@huggingface/transformers` loads, and `issue-similarity.test.ts` (18 tests) passes

Part of #1815

https://claude.ai/code/session_014rHyvtukqw8HhDfdVzNkdF