### PR TITLE
perf: prefetch repository row from ssr-repo edge function

### DIFF
--- a/netlify/edge-functions/_shared/html-template.ts
+++ b/netlify/edge-functions/_shared/html-template.ts
@@ -313,13 +313,16 @@ const THEME_SCRIPT = `
  * @param ssrData - Data to be hydrated on the client
  * @param url - Current page URL
  * @param assets - Asset references from the built index.html
+ * @param extraHeadScript - Optional pre-serialized script tag injected before the first
+ *   script/preload in <head> (e.g. route-specific prefetch data). Must already be safe HTML.
  */
 export function renderHTML(
   content: string | SafeHTML,
   meta: MetaTags,
   ssrData: SSRData,
   url: string,
-  assets: AssetReferences
+  assets: AssetReferences,
+  extraHeadScript?: SafeHTML
 ): string {
   // Generate modulepreload links
   const modulePreloads = assets.modulePreloads.map(
@@ -378,6 +381,9 @@ export function renderHTML(
         <!-- Performance -->
         <link rel="dns-prefetch" href="https://avatars.githubusercontent.com" />
         <link rel="dns-prefetch" href="https://egcxzonpmmcirmgqdrla.supabase.co" />
+
+        <!-- Route-specific prefetch data (injected before any other script/preload) -->
+        ${extraHeadScript ?? ''}
 
         <!-- Theme detection - prevent FOUC -->
         <script>

--- a/netlify/edge-functions/_shared/supabase.ts
+++ b/netlify/edge-functions/_shared/supabase.ts
@@ -51,6 +51,8 @@ export interface RepoData {
   contributor_count?: number;
   pr_count?: number;
   updated_at: string;
+  /** Data freshness timestamp, used by the client to skip its own repo lookup */
+  last_updated_at?: string | null;
 }
 
 /**
@@ -81,7 +83,8 @@ export async function fetchRepository(owner: string, repo: string): Promise<Repo
       forks_count,
       language,
       topics,
-      updated_at
+      updated_at,
+      last_updated_at
     `
     )
     .eq('owner', owner)

--- a/netlify/edge-functions/ssr-repo.ts
+++ b/netlify/edge-functions/ssr-repo.ts
@@ -14,6 +14,7 @@ import {
   renderHeader,
   renderFooter,
   html,
+  unsafe,
   type SafeHTML,
   type MetaTags,
   type RepoPageData,
@@ -43,6 +44,44 @@ const LANGUAGE_COLORS: Record<string, string> = {
   Dart: '#00B4AB',
   Shell: '#89e051',
 };
+
+/**
+ * Build the `window.__REPO_SSR__` prefetch script.
+ *
+ * Inlines the minimal repository row so client hooks can resolve owner/name -> id
+ * without waiting for the SPA to boot and issue its own Supabase query.
+ *
+ * Serialization safety: the payload is JSON.stringified, `<` is escaped to the
+ * unicode escape sequence backslash-u003c (preventing `</script>` breakout from
+ * repo-controlled strings), and the result is
+ * stringified again so it is emitted as a JS string literal passed to JSON.parse.
+ * This mirrors the hardened `__SSR_DATA__` serialization in html-template.ts.
+ *
+ * Never throws: returns undefined on any failure so the page render is unaffected.
+ */
+function buildRepoPrefetchScript(repoData: RepoData): SafeHTML | undefined {
+  try {
+    const payload = {
+      id: String(repoData.id),
+      owner: repoData.owner,
+      name: repoData.name,
+      last_updated_at: repoData.last_updated_at ?? null,
+    };
+
+    // 1. Stringify the payload
+    // 2. Escape < to the backslash-u003c escape sequence to prevent </script> injection
+    // 3. Double-stringify to emit a JS string literal for JSON.parse("...")
+    const safeJson = JSON.stringify(payload).replace(/</g, '\\u003c');
+    const quotedSafeJson = JSON.stringify(safeJson);
+
+    return html`<script>
+      window.__REPO_SSR__ = JSON.parse(${unsafe(quotedSafeJson)});
+    </script>`;
+  } catch (error) {
+    console.warn('[ssr-repo] Failed to build repo prefetch script: %o', error);
+    return undefined;
+  }
+}
 
 /**
  * Render contributor avatars
@@ -500,7 +539,11 @@ async function handler(request: Request, context: Context) {
       timestamp: Date.now(),
     };
 
-    const html = renderHTML(content, meta, ssrData, request.url, assets);
+    // Prefetch: inline the repository row so client hooks skip the owner/name -> id
+    // round trip. Optional — never blocks or fails the page render.
+    const repoPrefetchScript = buildRepoPrefetchScript(repoData);
+
+    const html = renderHTML(content, meta, ssrData, request.url, assets, repoPrefetchScript);
     const headers = getSSRHeaders(300, 3600); // 5 min cache, 1 hour stale-while-revalidate
 
     return new Response(html, { headers });

--- a/src/lib/utils/__tests__/repository-lookup.test.ts
+++ b/src/lib/utils/__tests__/repository-lookup.test.ts
@@ -1,28 +1,33 @@
 /* eslint-disable no-restricted-syntax */
 // Async tests required: the dedup contract is about concurrent promise sharing.
 // All mocks resolve immediately — no real timers, no hangs.
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-const { mockMaybeSingle } = vi.hoisted(() => {
+const { mockMaybeSingle, mockFrom } = vi.hoisted(() => {
   const mockMaybeSingle = vi.fn();
-  return { mockMaybeSingle };
+  const mockFrom = vi.fn(() => ({
+    select: () => ({
+      eq: () => ({
+        eq: () => ({
+          maybeSingle: mockMaybeSingle,
+        }),
+      }),
+    }),
+  }));
+  return { mockMaybeSingle, mockFrom };
 });
 
 vi.mock('@/lib/supabase-lazy', () => ({
   getSupabase: vi.fn().mockResolvedValue({
-    from: () => ({
-      select: () => ({
-        eq: () => ({
-          eq: () => ({
-            maybeSingle: mockMaybeSingle,
-          }),
-        }),
-      }),
-    }),
+    from: mockFrom,
   }),
 }));
 
-import { getRepositoryByOwnerName, clearRepositoryLookupCache } from '../repository-helpers';
+import {
+  getRepositoryByOwnerName,
+  clearRepositoryLookupCache,
+  type RepositoryIdentity,
+} from '../repository-helpers';
 
 const repoRow = {
   id: 'repo-uuid-1',
@@ -31,10 +36,21 @@ const repoRow = {
   last_updated_at: '2026-07-13T00:00:00Z',
 };
 
+const ssrRow: RepositoryIdentity = {
+  id: 'ssr-uuid-1',
+  owner: 'continuedev',
+  name: 'continue',
+  last_updated_at: '2026-07-12T00:00:00Z',
+};
+
 describe('getRepositoryByOwnerName', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     clearRepositoryLookupCache();
+  });
+
+  afterEach(() => {
+    delete window.__REPO_SSR__;
   });
 
   it('dedupes concurrent lookups for the same owner/name into one query', async () => {
@@ -92,5 +108,62 @@ describe('getRepositoryByOwnerName', () => {
     await getRepositoryByOwnerName('owner-b', 'repo');
 
     expect(mockMaybeSingle).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses a matching SSR payload without querying supabase', async () => {
+    window.__REPO_SSR__ = ssrRow;
+
+    const result = await getRepositoryByOwnerName('continuedev', 'continue');
+
+    expect(result).toEqual(ssrRow);
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it('matches the SSR payload case-insensitively', async () => {
+    window.__REPO_SSR__ = { ...ssrRow, owner: 'ContinueDev', name: 'Continue' };
+
+    const result = await getRepositoryByOwnerName('continuedev', 'continue');
+
+    expect(result?.id).toBe('ssr-uuid-1');
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it('ignores a mismatched SSR payload and queries normally', async () => {
+    window.__REPO_SSR__ = { ...ssrRow, owner: 'someone-else', name: 'other-repo' };
+    mockMaybeSingle.mockResolvedValue({ data: repoRow, error: null });
+
+    const result = await getRepositoryByOwnerName('continuedev', 'continue');
+
+    expect(result).toEqual(repoRow);
+    expect(mockFrom).toHaveBeenCalledTimes(1);
+    // Mismatched payload is left in place for the repository it belongs to
+    expect(window.__REPO_SSR__).toBeDefined();
+  });
+
+  it('ignores a malformed SSR payload and queries normally', async () => {
+    window.__REPO_SSR__ = { id: 123, owner: 'continuedev' } as unknown as RepositoryIdentity;
+    mockMaybeSingle.mockResolvedValue({ data: repoRow, error: null });
+
+    const result = await getRepositoryByOwnerName('continuedev', 'continue');
+
+    expect(result).toEqual(repoRow);
+    expect(mockFrom).toHaveBeenCalledTimes(1);
+  });
+
+  it('consumes the SSR payload one-shot', async () => {
+    window.__REPO_SSR__ = ssrRow;
+
+    const first = await getRepositoryByOwnerName('continuedev', 'continue');
+    expect(first).toEqual(ssrRow);
+    expect(window.__REPO_SSR__).toBeUndefined();
+
+    // A fresh lookup after the cache is cleared (e.g. TTL expiry) must hit the
+    // network, not stale SSR data
+    clearRepositoryLookupCache();
+    mockMaybeSingle.mockResolvedValue({ data: repoRow, error: null });
+
+    const second = await getRepositoryByOwnerName('continuedev', 'continue');
+    expect(second).toEqual(repoRow);
+    expect(mockFrom).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/utils/repository-helpers.ts
+++ b/src/lib/utils/repository-helpers.ts
@@ -10,6 +10,55 @@ export interface RepositoryIdentity {
   last_updated_at: string | null;
 }
 
+declare global {
+  interface Window {
+    /**
+     * Repository row prefetched by the ssr-repo edge function and inlined into
+     * the HTML shell. Consumed one-shot by getRepositoryByOwnerName() so client
+     * hooks skip the owner/name → id round trip on first load (#1815).
+     */
+    __REPO_SSR__?: RepositoryIdentity;
+  }
+}
+
+/** Runtime validation for the SSR-injected payload (it crosses an HTML boundary). */
+function isRepositoryIdentity(value: unknown): value is RepositoryIdentity {
+  if (!value || typeof value !== 'object') return false;
+  const row = value as Record<string, unknown>;
+  return (
+    typeof row.id === 'string' &&
+    typeof row.name === 'string' &&
+    typeof row.owner === 'string' &&
+    (row.last_updated_at === null || typeof row.last_updated_at === 'string')
+  );
+}
+
+/**
+ * Consume the SSR-prefetched repository row if it matches the requested
+ * owner/name. GitHub names are case-insensitive, so the comparison is too.
+ * One-shot: the global is deleted on first use so client-side navigation to
+ * other repositories never reuses stale data.
+ */
+function consumeSSRRepository(owner: string, name: string): RepositoryIdentity | null {
+  if (typeof window === 'undefined') return null;
+
+  const payload = window.__REPO_SSR__;
+  if (!isRepositoryIdentity(payload)) return null;
+
+  const matches =
+    payload.owner.toLowerCase() === owner.toLowerCase() &&
+    payload.name.toLowerCase() === name.toLowerCase();
+  if (!matches) return null;
+
+  delete window.__REPO_SSR__;
+  return {
+    id: payload.id,
+    owner: payload.owner,
+    name: payload.name,
+    last_updated_at: payload.last_updated_at,
+  };
+}
+
 // Promise-level dedup + short TTL cache for the owner/name → repository row
 // lookup. Before this, every repo-view hook resolved the id independently,
 // firing 4-6 identical queries per page view (#1815).
@@ -42,6 +91,13 @@ export function getRepositoryByOwnerName(
   const cached = repositoryLookupCache.get(key);
   if (cached && Date.now() - cached.timestamp < REPOSITORY_LOOKUP_TTL_MS) {
     return cached.promise;
+  }
+
+  const ssrRow = consumeSSRRepository(owner, name);
+  if (ssrRow) {
+    const seeded = Promise.resolve(ssrRow);
+    repositoryLookupCache.set(key, { promise: seeded, timestamp: Date.now() });
+    return seeded;
   }
 
   const promise = (async (): Promise<RepositoryIdentity | null> => {


### PR DESCRIPTION
## Summary

Phase 2 item from #1815: on `/:owner/:repo`, the first Supabase query (owner/name → repository id) couldn't start until the SPA booted (~1.1s on mobile). The `ssr-repo` edge function already fetches the repository row for social meta tags — this PR inlines that row into the HTML shell so client hooks skip the round trip entirely.

### Edge side
- `ssr-repo.ts` injects `<script>window.__REPO_SSR__ = JSON.parse("...")</script>` on the success path only, with a minimal `{ id, owner, name, last_updated_at }` payload (reusing the existing repository fetch; `_shared/supabase.ts` now selects `last_updated_at` too)
- Escaping mirrors the existing hardened `__SSR_DATA__` pattern: `JSON.stringify`, escape every `<` as `<` (no `</script>` breakout via repo-controlled strings), emitted as a string literal for `JSON.parse`. Verified round-trip with a hostile `evil</script><script>…` owner — zero raw `<` in output
- Wrapped in try/catch returning undefined: the prefetch can never fail page rendering. Skeleton/not-found/error paths inject nothing

### Client side
- `getRepositoryByOwnerName()` (the shared deduped lookup from #1817) consults `window.__REPO_SSR__` before querying: runtime-validated, matched case-insensitively (GitHub names are case-insensitive), consumed **one-shot** (global deleted on first use) so client-side navigation never reuses stale data, and seeded into the existing TTL cache
- Typed via `declare global` — no `any`

### Scope caveat
`ssr-repo` runs on `/:owner/:repo` only (when `shouldSSR` passes); sub-tab routes and client-side navigations get no payload and fall back to querying exactly as today. Edge functions are Deno modules with no local test harness — escaping was verified via a standalone round-trip check; `_shared` changes are additive (optional param, extra column).

## Testing

- `repository-lookup.test.ts` extended to 10 cases: SSR seed without query, case-insensitive match, mismatch ignored (payload preserved), malformed payload ignored, one-shot consumption, plus the existing dedup/TTL/miss/error semantics
- Full vitest suite: 1925 passed / 26 skipped; `npm run build` + typecheck clean
- Rebased onto main post-#1817 with the SSR consumption grafted onto the canonical lookup implementation

Part of #1815

https://claude.ai/code/session_014rHyvtukqw8HhDfdVzNkdF