### PR TITLE
perf: CDN-cache the trending repositories API

### DIFF
--- a/netlify/functions/__tests__/api-trending-repositories.test.ts
+++ b/netlify/functions/__tests__/api-trending-repositories.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { HandlerEvent, HandlerContext, HandlerResponse } from '@netlify/functions';
+
+// The module reads Supabase env vars at load time, so they must exist before import.
+const { mockRpc } = vi.hoisted(() => {
+  process.env.SUPABASE_URL = 'https://example.supabase.co';
+  process.env.SUPABASE_ANON_KEY = 'test-anon-key';
+  return { mockRpc: vi.fn() };
+});
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({ rpc: mockRpc })),
+}));
+
+import { handler } from '../api-trending-repositories.mts';
+
+interface TrendingRepoRow {
+  repository_id: string;
+  owner: string;
+  name: string;
+  description: string | null;
+  language: string | null;
+  stars: number;
+  trending_score: string;
+  star_change: string;
+  pr_change: string;
+  contributor_change: string;
+  last_activity: string;
+  avatar_url: string | null;
+  html_url: string;
+}
+
+const sampleRepo: TrendingRepoRow = {
+  repository_id: 'repo-1',
+  owner: 'test-owner',
+  name: 'test-repo',
+  description: 'A test repository',
+  language: 'TypeScript',
+  stars: 1234,
+  trending_score: '42.5',
+  star_change: '10',
+  pr_change: '5',
+  contributor_change: '2',
+  last_activity: '2026-07-01T00:00:00Z',
+  avatar_url: 'https://example.com/avatar.png',
+  html_url: 'https://github.com/test-owner/test-repo',
+};
+
+interface MakeEventOptions {
+  httpMethod?: string;
+  queryStringParameters?: Record<string, string>;
+}
+
+function makeEvent(options: MakeEventOptions = {}): HandlerEvent {
+  const queryStringParameters = options.queryStringParameters ?? {};
+  const rawQuery = new URLSearchParams(queryStringParameters).toString();
+
+  return {
+    rawUrl: `https://example.com/.netlify/functions/api-trending-repositories?${rawQuery}`,
+    rawQuery,
+    path: '/.netlify/functions/api-trending-repositories',
+    httpMethod: options.httpMethod ?? 'GET',
+    headers: {},
+    multiValueHeaders: {},
+    queryStringParameters,
+    multiValueQueryStringParameters: {},
+    body: null,
+    isBase64Encoded: false,
+  };
+}
+
+const context = {} as HandlerContext;
+
+function mockSuccessfulRpc(repos: TrendingRepoRow[] = [sampleRepo]): void {
+  mockRpc.mockImplementation((fnName: string) => {
+    if (fnName === 'get_trending_repositories_with_fallback') {
+      return Promise.resolve({ data: repos, error: null });
+    }
+    if (fnName === 'get_trending_statistics') {
+      return Promise.resolve({
+        data: [
+          {
+            total_trending_repos: repos.length,
+            avg_trending_score: 42.5,
+            top_language: 'TypeScript',
+            total_star_growth: 10,
+            total_new_contributors: 2,
+          },
+        ],
+        error: null,
+      });
+    }
+    return Promise.resolve({ data: null, error: null });
+  });
+}
+
+async function invoke(event: HandlerEvent): Promise<HandlerResponse> {
+  const response = await handler(event, context, () => undefined);
+  if (!response) {
+    throw new Error('Handler returned no response');
+  }
+  return response;
+}
+
+describe('api-trending-repositories handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('CDN caching headers', () => {
+    it('sets CDN and browser cache headers on successful responses', async () => {
+      mockSuccessfulRpc();
+
+      const response = await invoke(makeEvent());
+
+      expect(response.statusCode).toBe(200);
+      expect(response.headers?.['Cache-Control']).toBe('public, max-age=60');
+      expect(response.headers?.['Netlify-CDN-Cache-Control']).toBe(
+        'public, s-maxage=300, stale-while-revalidate=3600'
+      );
+    });
+
+    it('does not cache database error responses', async () => {
+      mockRpc.mockResolvedValue({
+        data: null,
+        error: { message: 'db down', details: null, hint: null, code: '500' },
+      });
+
+      const response = await invoke(makeEvent());
+
+      expect(response.statusCode).toBe(500);
+      expect(response.headers?.['Cache-Control']).toBe('no-store');
+      expect(response.headers?.['Netlify-CDN-Cache-Control']).toBeUndefined();
+    });
+
+    it('does not cache unexpected error responses', async () => {
+      mockRpc.mockRejectedValue(new Error('network exploded'));
+
+      const response = await invoke(makeEvent());
+
+      expect(response.statusCode).toBe(500);
+      expect(response.headers?.['Cache-Control']).toBe('no-store');
+      expect(response.headers?.['Netlify-CDN-Cache-Control']).toBeUndefined();
+    });
+
+    it('does not cache method-not-allowed responses', async () => {
+      const response = await invoke(makeEvent({ httpMethod: 'POST' }));
+
+      expect(response.statusCode).toBe(405);
+      expect(response.headers?.['Cache-Control']).toBe('no-store');
+      expect(response.headers?.['Netlify-CDN-Cache-Control']).toBeUndefined();
+    });
+  });
+
+  describe('query parameter bounding', () => {
+    it('coerces junk parameters to safe defaults so the CDN cache is not fragmented', async () => {
+      mockSuccessfulRpc();
+
+      const response = await invoke(
+        makeEvent({
+          queryStringParameters: {
+            period: 'bogus',
+            limit: 'NaN-city',
+            minStars: '-50',
+            sort: 'drop-tables',
+          },
+        })
+      );
+
+      expect(response.statusCode).toBe(200);
+      expect(mockRpc).toHaveBeenCalledWith('get_trending_repositories_with_fallback', {
+        p_time_period: '7 days',
+        p_limit: 50,
+        p_language: undefined,
+        p_min_stars: 0,
+      });
+
+      const body = JSON.parse(response.body ?? '{}');
+      expect(body.metadata.period).toBe('7d');
+      expect(body.metadata.limit).toBe(50);
+      expect(body.metadata.minStars).toBe(0);
+      expect(body.metadata.sort).toBe('trending_score');
+    });
+
+    it('caps limit at 100', async () => {
+      mockSuccessfulRpc();
+
+      const response = await invoke(makeEvent({ queryStringParameters: { limit: '9999' } }));
+
+      expect(response.statusCode).toBe(200);
+      expect(mockRpc).toHaveBeenCalledWith(
+        'get_trending_repositories_with_fallback',
+        expect.objectContaining({ p_limit: 100 })
+      );
+    });
+
+    it('passes through valid parameters', async () => {
+      mockSuccessfulRpc();
+
+      const response = await invoke(
+        makeEvent({
+          queryStringParameters: {
+            period: '30d',
+            limit: '25',
+            language: 'TypeScript',
+            minStars: '100',
+            sort: 'star_change',
+          },
+        })
+      );
+
+      expect(response.statusCode).toBe(200);
+      expect(mockRpc).toHaveBeenCalledWith('get_trending_repositories_with_fallback', {
+        p_time_period: '30 days',
+        p_limit: 25,
+        p_language: 'TypeScript',
+        p_min_stars: 100,
+      });
+
+      const body = JSON.parse(response.body ?? '{}');
+      expect(body.metadata.sort).toBe('star_change');
+    });
+  });
+
+  describe('response shape', () => {
+    it('returns mapped repositories and statistics', async () => {
+      mockSuccessfulRpc();
+
+      const response = await invoke(makeEvent());
+      const body = JSON.parse(response.body ?? '{}');
+
+      expect(body.repositories).toHaveLength(1);
+      expect(body.repositories[0]).toMatchObject({
+        id: 'repo-1',
+        owner: 'test-owner',
+        name: 'test-repo',
+        trending_score: 42.5,
+      });
+      expect(body.metadata.statistics).toMatchObject({ top_language: 'TypeScript' });
+      expect(typeof body.generated_at).toBe('string');
+    });
+  });
+});

--- a/netlify/functions/api-trending-repositories.mts
+++ b/netlify/functions/api-trending-repositories.mts
@@ -18,15 +18,74 @@ function getSupabase(): SupabaseClient {
   return supabase;
 }
 
+const VALID_PERIODS = ['24h', '7d', '30d'] as const;
+type Period = (typeof VALID_PERIODS)[number];
+
+const VALID_SORTS = ['trending_score', 'star_change', 'pr_change', 'contributor_change'] as const;
+type SortField = (typeof VALID_SORTS)[number];
+
 interface TrendingQuery {
-  period?: '24h' | '7d' | '30d';
-  limit?: number;
+  period: Period;
+  limit: number;
   language?: string;
-  minStars?: number;
-  sort?: 'trending_score' | 'star_change' | 'pr_change' | 'contributor_change';
+  minStars: number;
+  sort: SortField;
 }
 
-export const handler: Handler = async (event: HandlerEvent, context: HandlerContext) => {
+interface TrendingRepoRow {
+  repository_id: string;
+  owner: string;
+  name: string;
+  description: string | null;
+  language: string | null;
+  stars: number | null;
+  trending_score: number | string | null;
+  star_change: number | string | null;
+  pr_change: number | string | null;
+  contributor_change: number | string | null;
+  last_activity: string | null;
+  avatar_url: string | null;
+  html_url: string | null;
+}
+
+function toNumber(value: number | string | null): number {
+  const parsed = typeof value === 'number' ? value : Number.parseFloat(value ?? '0');
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function parsePeriod(value: string | null): Period {
+  return (VALID_PERIODS as readonly string[]).includes(value ?? '') ? (value as Period) : '7d';
+}
+
+function parseSort(value: string | null): SortField {
+  return (VALID_SORTS as readonly string[]).includes(value ?? '')
+    ? (value as SortField)
+    : 'trending_score';
+}
+
+function parseBoundedInt(value: string | null, fallback: number, min: number, max: number): number {
+  const parsed = Number.parseInt(value ?? '', 10);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  return Math.min(Math.max(parsed, min), max);
+}
+
+// Response is identical for all visitors (public data, anon Supabase key, no
+// auth/cookies), so let Netlify's CDN cache it. Browser cache is kept short so
+// clients pick up fresh data quickly; the CDN serves warm hits for 5 minutes
+// and stale-while-revalidate for up to an hour.
+const CACHE_HEADERS = {
+  'Cache-Control': 'public, max-age=60',
+  'Netlify-CDN-Cache-Control': 'public, s-maxage=300, stale-while-revalidate=3600',
+};
+
+// Errors must never be cached by the CDN or the browser.
+const NO_STORE_HEADERS = {
+  'Cache-Control': 'no-store',
+};
+
+export const handler: Handler = async (event: HandlerEvent, _context: HandlerContext) => {
   try {
     // Set CORS headers
     const headers = {
@@ -49,24 +108,20 @@ export const handler: Handler = async (event: HandlerEvent, context: HandlerCont
     if (event.httpMethod !== 'GET') {
       return {
         statusCode: 405,
-        headers,
+        headers: { ...headers, ...NO_STORE_HEADERS },
         body: JSON.stringify({ error: 'Method not allowed' }),
       };
     }
 
-    // Parse query parameters
-    const params = new URLSearchParams(event.queryStringParameters || {});
+    // Parse query parameters, coercing everything to bounded/known values so
+    // junk params can't fragment the CDN cache or reach the database.
+    const params = new URLSearchParams(event.rawQuery || '');
     const query: TrendingQuery = {
-      period: (params.get('period') as '24h' | '7d' | '30d') || '7d',
-      limit: Math.min(parseInt(params.get('limit') || '50'), 100), // Cap at 100
+      period: parsePeriod(params.get('period')),
+      limit: parseBoundedInt(params.get('limit'), 50, 1, 100),
       language: params.get('language') || undefined,
-      minStars: parseInt(params.get('minStars') || '0'),
-      sort:
-        (params.get('sort') as
-          | 'trending_score'
-          | 'star_change'
-          | 'pr_change'
-          | 'contributor_change') || 'trending_score',
+      minStars: parseBoundedInt(params.get('minStars'), 0, 0, 1_000_000),
+      sort: parseSort(params.get('sort')),
     };
 
     // Convert period to interval
@@ -101,7 +156,7 @@ export const handler: Handler = async (event: HandlerEvent, context: HandlerCont
 
       return {
         statusCode: 500,
-        headers,
+        headers: { ...headers, ...NO_STORE_HEADERS },
         body: JSON.stringify({
           error: 'Failed to fetch trending repositories',
           details: error.message,
@@ -110,14 +165,12 @@ export const handler: Handler = async (event: HandlerEvent, context: HandlerCont
     }
 
     // Sort results if requested (the SQL function returns by trending_score by default)
-    let sortedRepos = trendingRepos || [];
+    let sortedRepos: TrendingRepoRow[] = trendingRepos || [];
 
     if (query.sort !== 'trending_score' && sortedRepos.length > 0) {
-      sortedRepos = [...sortedRepos].sort((a, b) => {
-        const aValue = a[query.sort!] || 0;
-        const bValue = b[query.sort!] || 0;
-        return bValue - aValue;
-      });
+      sortedRepos = [...sortedRepos].sort(
+        (a, b) => toNumber(b[query.sort]) - toNumber(a[query.sort])
+      );
     }
 
     // Get trending statistics for metadata
@@ -133,10 +186,10 @@ export const handler: Handler = async (event: HandlerEvent, context: HandlerCont
         description: repo.description,
         language: repo.language,
         stars: repo.stars,
-        trending_score: parseFloat(repo.trending_score || '0'),
-        star_change: parseFloat(repo.star_change || '0'),
-        pr_change: parseFloat(repo.pr_change || '0'),
-        contributor_change: parseFloat(repo.contributor_change || '0'),
+        trending_score: toNumber(repo.trending_score),
+        star_change: toNumber(repo.star_change),
+        pr_change: toNumber(repo.pr_change),
+        contributor_change: toNumber(repo.contributor_change),
         last_activity: repo.last_activity,
         avatar_url: repo.avatar_url,
         html_url: repo.html_url,
@@ -157,7 +210,7 @@ export const handler: Handler = async (event: HandlerEvent, context: HandlerCont
 
     return {
       statusCode: 200,
-      headers,
+      headers: { ...headers, ...CACHE_HEADERS },
       body: JSON.stringify(response),
     };
   } catch (error) {
@@ -171,6 +224,7 @@ export const handler: Handler = async (event: HandlerEvent, context: HandlerCont
       headers: {
         'Access-Control-Allow-Origin': '*',
         'Content-Type': 'application/json',
+        ...NO_STORE_HEADERS,
       },
       body: JSON.stringify({
         error: 'Internal server error',


### PR DESCRIPTION
## Summary

Phase 2 item from #1815: `/.netlify/functions/api-trending-repositories` takes ~1.5s server-side and sits on the /trending page's critical path (LCP 4.9s). The response is identical for all visitors (anon Supabase key only, no cookies/auth read), so it's now CDN-cached.

### Headers
- **200 only:** `Netlify-CDN-Cache-Control: public, s-maxage=300, stale-while-revalidate=3600` (5-min warm hits, background revalidation up to 1h) + `Cache-Control: public, max-age=60` for browsers (Netlify strips the CDN header before it reaches clients)
- **All error paths** (405, RPC 500, catch-all 500): explicit `Cache-Control: no-store`, no CDN header — errors are never cached
- CORS headers preserved; first use of `Netlify-CDN-Cache-Control` in this repo

### Param hardening (cache-fragmentation + correctness)
Params were previously unbounded (`period`/`sort` blind casts passed junk to the RPC; `limit`/`minStars` could be NaN). Now: `period`/`sort` validated against allowed sets (fallback `7d`/`trending_score`), `limit` clamped 1–100, `minStars` ≥ 0. `language` stays free-form — a junk value just misses the cache and hits the function, same as today.

### Incidental cleanup (touch-it-make-it-better)
Fixed the file's pre-existing strict-mode type errors: typed RPC rows (no `any`), `event.rawQuery` instead of a mis-typed `URLSearchParams` construction, safe numeric coercion.

## Testing

- New `api-trending-repositories.test.ts` — 8 tests: cache headers on 200, `no-store`/no-CDN-header on 405 and both 500 paths, junk-param coercion, limit clamp, valid passthrough, response shape
- `tsc --project tsconfig.functions.json`: the function file is now error-free (was 2 errors)
- Warm-hit latency is only verifiable on a Netlify deploy: check for `Cache-Status: "Netlify Edge"; hit` on the deployed endpoint. Target 1.5s → <100ms for warm hits. Each `period`/param combo warms independently per 5-min window.

Part of #1815

https://claude.ai/code/session_014rHyvtukqw8HhDfdVzNkdF