### PR TITLE
fix: drop nonexistent templates dir from Fly Dockerfile

### DIFF
--- a/fly-social-cards/Dockerfile
+++ b/fly-social-cards/Dockerfile
@@ -12,7 +12,6 @@ RUN npm ci --only=production && npm cache clean --force
 
 # Copy application code
 COPY src ./src
-COPY templates ./templates
 
 # Create non-root user
 RUN groupadd -g 1001 nodejs && \


### PR DESCRIPTION
One-line fix: the Dockerfile's `COPY templates ./templates` references a directory that has never existed in the repo, so **every `deploy-social-cards` workflow run has failed since at least January 2026** — production Fly has been running a stale image (likely a contributor to the original card flakiness). This unblocks the deploy that ships #1826's card redirects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014rHyvtukqw8HhDfdVzNkdF