### PR TITLE
feat: recent PRs/issues rows in the desktop tray dropdown

### DIFF
--- a/desktop/.claude/skills/verify/SKILL.md
+++ b/desktop/.claude/skills/verify/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: verify
+description: Verify desktop tray changes end-to-end on Linux — local endpoint + live dbusmenu observation, no screenshots needed
+---
+
+# Verifying the desktop tray on Linux
+
+Recipe verified 2026-07-18 on Ubuntu GNOME (X11, `DISPLAY=:0`).
+
+## Serve the site endpoint locally (no Netlify login needed)
+
+The Supabase anon key is public-by-design and ships in the site bundle:
+
+```bash
+curl -s https://contributor.info/ | grep -oE '/js/index-[^"]+\.js'   # find bundle
+curl -s https://contributor.info/js/index-<hash>.js | grep -oE 'eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+' | sort -u
+# pick the JWT whose payload has "ref":"egcxzonpmmcirmgqdrla" (not "supabase-demo")
+VITE_SUPABASE_ANON_KEY=<key> SUPABASE_URL=https://egcxzonpmmcirmgqdrla.supabase.co \
+  npx netlify functions:serve --port 9999   # from repo root, background
+curl "http://localhost:9999/.netlify/functions/api-workspace-metrics?slug=<slug>&time_range=90d"
+```
+
+Known public workspace for testing: `open-source-repos`. The function has a
+120s in-memory cache per `(workspace, time_range)` — vary `time_range` to bypass.
+
+## Run the tray against the local endpoint
+
+`SITE` is compile-time: launch with `VITE_CONTRIBUTOR_SITE=http://localhost:9999`.
+Seed config first (documented per-machine key path):
+
+```bash
+# ~/.config/info.contributor.desktop/settings.json  (chmod 600)
+{ "workspaces": ["open-source-repos"], "time_range": "90d",
+  "supabase_url": "https://egcxzonpmmcirmgqdrla.supabase.co",
+  "supabase_anon_key": "<key>" }
+
+cd desktop && DISPLAY=:0 VITE_CONTRIBUTOR_SITE=http://localhost:9999 npm run tauri dev
+```
+
+## Observe the real tray menu via D-Bus (no screenshot tooling required)
+
+```bash
+PID=$(pgrep -f target/debug/contributor-info-desktop | head -1)
+busctl --user list | grep $PID       # find :1.XXX connection
+busctl --user call :1.XXX /org/ayatana/NotificationItem/tray_icon_tray_app_ci_tray/Menu \
+  com.canonical.dbusmenu GetLayout iias 0 -- -1 0     # dumps the live menu tree
+```
+
+Labels come out UTF-8-escaped; literal `_` appears doubled (`__`) — that's GTK
+mnemonic escaping on the wire, renders as a single underscore on screen.
+
+Click a row for real (fires the app's on_menu_event handler, opens browser):
+
+```bash
+busctl --user call ... com.canonical.dbusmenu Event isvu <item-id> "clicked" s "" 0
+```
+
+Gotcha: the tray rebuilds its menu every 60s poll and **item ids rotate** —
+re-run GetLayout and fire Event immediately after.
+
+## Gotchas
+
+- No `.env` on this machine and no Netlify login; the bundle-extraction path
+  above is the way to get env for `functions:serve`.
+- The live `issues` table has **no `html_url` column** (unlike `pull_requests`);
+  the `github_issues` migration file does not match the live schema.
+- gdbus can't pass `-1` positionally; use `busctl` with `--` before negative args.

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -6,8 +6,10 @@ organized around your workspaces (teams of repos), not individual repos.
 
 The tray icon is the pixel plant 🌱. Each configured workspace gets a submenu
 with its headline metrics (open/merged PRs, PR velocity and merge time,
-active/new contributors, open issues, stars). A dashboard window manages
-workspaces and renders the same numbers as metric tiles.
+active/new contributors, open issues, stars) plus clickable **Recent PRs** and
+**Recent Issues** rows — the newest open items across the workspace's repos,
+deep-linking to GitHub. A dashboard window manages workspaces and renders the
+same numbers as metric tiles.
 
 ## Install
 
@@ -32,6 +34,7 @@ end-user walkthrough lives in
 | --- | --- | --- |
 | Workspace lookup | Supabase REST `workspaces?slug=eq.{slug}` (anon key, or user JWT when signed in) | live |
 | Workspace metrics | `GET https://contributor.info/.netlify/functions/api-workspace-metrics?workspace_id={id}&time_range={range}` | live |
+| Recent open PRs/issues | Same endpoint — additive `recent_open_prs` / `recent_open_issues` arrays (5 newest open items each, not scoped to `time_range`) | live |
 
 RLS lets anonymous clients read **public** workspaces, so workspace identity
 resolves with just the anon key. Signing in widens RLS to the workspaces you

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -25,7 +25,7 @@ use tauri_plugin_opener::OpenerExt;
 
 use auth::Session;
 use settings::Settings;
-use supabase::{Supabase, WorkspaceMetrics};
+use supabase::{RecentItem, Supabase, WorkspaceMetrics};
 
 /// Site base for `/i/{slug}` links and the `api-workspace-metrics` endpoint.
 /// Overridable at build time to aim the app at a local `netlify dev`, a deploy
@@ -122,6 +122,51 @@ fn metric_lines(m: &WorkspaceMetrics) -> Vec<String> {
     lines
 }
 
+/// Menu rows stay readable: titles beyond `max_chars` are cut on a char
+/// boundary and end with an ellipsis.
+fn truncate_title(title: &str, max_chars: usize) -> String {
+    if title.chars().count() <= max_chars {
+        return title.to_string();
+    }
+    let mut out: String = title.chars().take(max_chars.saturating_sub(1)).collect();
+    out.push('\u{2026}');
+    out
+}
+
+fn recent_line(item: &RecentItem) -> String {
+    let title = truncate_title(&item.title, 50);
+    match item.author.as_deref() {
+        Some(author) => format!("#{} {title} \u{00B7} {author}", item.number),
+        None => format!("#{} {title}", item.number),
+    }
+}
+
+/// Appends a disabled `header` followed by one clickable row per item, each
+/// with an `open-url:{url}` id the tray click handler opens in the browser.
+/// Empty sections render nothing.
+fn append_recent_section(
+    app: &AppHandle,
+    sub: &Submenu<tauri::Wry>,
+    header: &str,
+    items: &[RecentItem],
+) -> tauri::Result<()> {
+    if items.is_empty() {
+        return Ok(());
+    }
+    sub.append(&PredefinedMenuItem::separator(app)?)?;
+    sub.append(&MenuItem::with_id(app, format!("hdr:{header}"), header, false, None::<&str>)?)?;
+    for item in items {
+        sub.append(&MenuItem::with_id(
+            app,
+            format!("open-url:{}", item.url),
+            recent_line(item),
+            true,
+            None::<&str>,
+        )?)?;
+    }
+    Ok(())
+}
+
 fn build_menu(app: &AppHandle, snapshot: &Snapshot) -> tauri::Result<Menu<tauri::Wry>> {
     let menu = Menu::new(app)?;
 
@@ -159,6 +204,8 @@ fn build_menu(app: &AppHandle, snapshot: &Snapshot) -> tauri::Result<Menu<tauri:
                     None::<&str>,
                 )?)?;
             }
+            append_recent_section(app, &sub, "Recent PRs", &m.recent_open_prs)?;
+            append_recent_section(app, &sub, "Recent Issues", &m.recent_open_issues)?;
         }
         menu.append(&sub)?;
     }
@@ -420,6 +467,12 @@ pub fn run() {
                         other => {
                             if let Some(slug) = other.strip_prefix("ws:") {
                                 let _ = app.opener().open_url(format!("{SITE}/i/{slug}"), None::<&str>);
+                            } else if let Some(url) = other.strip_prefix("open-url:") {
+                                // Recent PR/issue rows. The URL comes from our own
+                                // endpoint, but only ever open web links.
+                                if url.starts_with("https://") || url.starts_with("http://") {
+                                    let _ = app.opener().open_url(url, None::<&str>);
+                                }
                             }
                         }
                     }
@@ -445,4 +498,55 @@ pub fn run() {
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::supabase::RecentItem;
+
+    fn item(number: i64, title: &str, author: Option<&str>) -> RecentItem {
+        RecentItem {
+            number,
+            title: title.into(),
+            url: "https://github.com/x/y/pull/1".into(),
+            author: author.map(Into::into),
+            repo: Some("x/y".into()),
+            created_at: String::new(),
+        }
+    }
+
+    #[test]
+    fn short_titles_pass_through_untruncated() {
+        assert_eq!(truncate_title("fix the tray", 50), "fix the tray");
+    }
+
+    #[test]
+    fn long_titles_truncate_to_max_chars_with_ellipsis() {
+        let long = "a".repeat(60);
+        let t = truncate_title(&long, 50);
+        assert_eq!(t.chars().count(), 50);
+        assert!(t.ends_with('\u{2026}'));
+    }
+
+    #[test]
+    fn truncation_is_multibyte_safe() {
+        let long = "\u{1F331}".repeat(60);
+        let t = truncate_title(&long, 50);
+        assert_eq!(t.chars().count(), 50);
+        assert!(t.ends_with('\u{2026}'));
+    }
+
+    #[test]
+    fn recent_rows_show_number_title_and_author() {
+        assert_eq!(
+            recent_line(&item(1824, "Import org repos", Some("bdougie"))),
+            "#1824 Import org repos \u{00B7} bdougie"
+        );
+    }
+
+    #[test]
+    fn recent_rows_omit_missing_author() {
+        assert_eq!(recent_line(&item(900, "Fix tray", None)), "#900 Fix tray");
+    }
 }

--- a/desktop/src-tauri/src/supabase.rs
+++ b/desktop/src-tauri/src/supabase.rs
@@ -75,6 +75,28 @@ pub struct WorkspaceMetrics {
     pub calculated_at: Option<String>,
     #[serde(default)]
     pub is_stale: bool,
+    #[serde(default)]
+    pub recent_open_prs: Vec<RecentItem>,
+    #[serde(default)]
+    pub recent_open_issues: Vec<RecentItem>,
+}
+
+/// A clickable recent-item row (open PR or issue) in the tray dropdown,
+/// deep-linking to GitHub.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecentItem {
+    #[serde(default)]
+    pub number: i64,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub url: String,
+    #[serde(default)]
+    pub author: Option<String>,
+    #[serde(default)]
+    pub repo: Option<String>,
+    #[serde(default)]
+    pub created_at: String,
 }
 
 impl Supabase {
@@ -166,5 +188,36 @@ mod tests {
         assert_eq!(m.pr_velocity, Some(0.8));
         assert_eq!(m.stars_trend, None);
         assert!(!m.is_stale);
+        // Older endpoint deploys omit the recent-item arrays entirely.
+        assert!(m.recent_open_prs.is_empty());
+        assert!(m.recent_open_issues.is_empty());
+    }
+
+    #[test]
+    fn deserializes_recent_items() {
+        let body = r#"{
+            "time_range":"7d",
+            "recent_open_prs":[{
+                "number":1824,"title":"Import an org's repos",
+                "url":"https://github.com/bdougie/contributor.info/pull/1824",
+                "author":"bdougie","repo":"bdougie/contributor.info",
+                "created_at":"2026-07-13T10:00:00Z"
+            }],
+            "recent_open_issues":[{
+                "number":900,"title":"Tray shows stale metrics",
+                "url":"https://github.com/bdougie/contributor.info/issues/900",
+                "author":null,"repo":null,"created_at":""
+            }]
+        }"#;
+        let m: WorkspaceMetrics = serde_json::from_str(body).expect("valid metrics JSON");
+        assert_eq!(m.recent_open_prs.len(), 1);
+        let pr = &m.recent_open_prs[0];
+        assert_eq!(pr.number, 1824);
+        assert_eq!(pr.title, "Import an org's repos");
+        assert_eq!(pr.url, "https://github.com/bdougie/contributor.info/pull/1824");
+        assert_eq!(pr.author.as_deref(), Some("bdougie"));
+        let issue = &m.recent_open_issues[0];
+        assert_eq!(issue.number, 900);
+        assert_eq!(issue.author, None);
     }
 }

--- a/docs/features/desktop-tray-app.md
+++ b/docs/features/desktop-tray-app.md
@@ -17,6 +17,13 @@ generated from `public/plant_pixel_coarse.svg`.
   (deep-links to `/i/{slug}`) and read-only metric lines — open/merged PRs
   with trend vs the previous period, PR velocity (PRs/day) and average hours
   to merge, active/new contributors with trend, open issues, and stars.
+- Below the metric lines: **Recent PRs** and **Recent Issues** sections — up
+  to 5 newest *open* items each across the workspace's repos (by `created_at`,
+  not scoped to the metrics time range), rendered as clickable rows
+  (`#123 Title · author`, titles truncated at ~50 chars) that open the item on
+  GitHub. Empty sections are omitted. Data rides in the same
+  `api-workspace-metrics` response as additive `recent_open_prs` /
+  `recent_open_issues` arrays, so failures degrade to metrics-only.
 - An account section: **Sign in with GitHub…** when anonymous, or
   "Signed in as {user}" plus **Sign out** when authenticated.
 - Dashboard…, Refresh now, and Quit actions. The tooltip summarizes

--- a/docs/features/desktop-tray-app.md
+++ b/docs/features/desktop-tray-app.md
@@ -17,6 +17,10 @@ generated from `public/plant_pixel_coarse.svg`.
   (deep-links to `/i/{slug}`) and read-only metric lines — open/merged PRs
   with trend vs the previous period, PR velocity (PRs/day) and average hours
   to merge, active/new contributors with trend, open issues, and stars.
+  Open PR/issue counts (including the submenu title's "N open PRs") are
+  **point-in-time** — everything currently open, like GitHub shows, consistent
+  with the Recent rows below. Merged counts, velocity, and closure rate remain
+  scoped to the selected time range.
 - Below the metric lines: **Recent PRs** and **Recent Issues** sections — up
   to 5 newest *open* items each across the workspace's repos (by `created_at`,
   not scoped to the metrics time range), rendered as clickable rows

--- a/docs/superpowers/specs/2026-07-18-tray-recent-items-design.md
+++ b/docs/superpowers/specs/2026-07-18-tray-recent-items-design.md
@@ -1,0 +1,77 @@
+# Desktop tray: recent PRs and issues in the dropdown
+
+**Date:** 2026-07-18
+**Status:** Approved
+**Inspiration:** [RepoBar](https://github.com/steipete/RepoBar)'s clickable
+recent-item rows — the tray moves from read-only aggregate stats to actionable
+details.
+
+## Goal
+
+Each workspace submenu in the desktop tray (`desktop/`) gains two clickable
+sections — **Recent PRs** and **Recent Issues** — listing the newest open items
+across the workspace's repositories. Clicking a row opens the item **on
+GitHub** in the default browser.
+
+## Non-goals
+
+- Dashboard-window tiles for these lists (tray menu only).
+- CI status, per-repo drill-down, trend restoration, release/changelog
+  previews (remain in the documented follow-ups).
+- Window-scoping recent items by `time_range` — an open PR from two months
+  ago is still actionable, so recency is by `created_at` regardless of the
+  selected metrics window.
+
+## Design
+
+### 1. API — `netlify/functions/api-workspace-metrics.mts`
+
+Add two small queries alongside the existing aggregation (not a widening of
+the paginated aggregate scan):
+
+- Newest **5 open PRs** and newest **5 open issues** across the workspace's
+  `repository_id`s, ordered `created_at` desc.
+- Columns: `number, title, html_url, created_at`, author username via the
+  `contributors` relationship, and repository name.
+
+Response gains two additive arrays (existing consumers unaffected):
+
+```json
+"recent_open_prs":    [{ "number", "title", "url", "author", "repo", "created_at" }],
+"recent_open_issues": [{ "number", "title", "url", "author", "repo", "created_at" }]
+```
+
+Same 120s in-memory cache entry, same public-workspace-only visibility rule
+(403 for private stays as is).
+
+### 2. Tray — `desktop/src-tauri/`
+
+- `supabase.rs`: `WorkspaceMetrics` gains `recent_open_prs` /
+  `recent_open_issues` (`Vec<RecentItem>`) with `#[serde(default)]` so an
+  older deployed endpoint (missing fields) parses cleanly.
+- `lib.rs` `build_menu`: after the metric lines in each workspace submenu:
+  separator → disabled `Recent PRs` header → up to 5 enabled rows →
+  separator → disabled `Recent Issues` header → up to 5 enabled rows.
+  Sections are omitted entirely when their array is empty.
+- Row format: `#1824 Truncated title… · author` (titles truncated to ~50
+  chars on a char boundary).
+- Row menu ids: `open-url:{url}`. The existing tray click handler gains a
+  prefix match that opens the URL with the opener plugin (same mechanism as
+  "Open in contributor.info ↗").
+
+### 3. Error handling
+
+Missing or empty arrays render nothing; all existing degradation states
+(`not_found`, `no_metrics`, `unconfigured`, `unreachable`) are untouched.
+Endpoint failures on the new queries must not break the metrics payload —
+if the recent-item queries fail, return empty arrays and still serve metrics.
+
+### 4. Testing & verification
+
+- Vitest: endpoint returns the new arrays with the expected shape and
+  falls back to empty arrays on query failure.
+- Rust unit test: title truncation and row formatting.
+- Live verification on Linux: `npm run tauri dev` against local
+  `netlify dev`, confirm rows render and clicking opens the browser.
+- Docs: update `desktop/README.md` data table and
+  `docs/features/desktop-tray-app.md`.

--- a/netlify/functions/__tests__/api-workspace-metrics-recent.test.ts
+++ b/netlify/functions/__tests__/api-workspace-metrics-recent.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
-import { fetchRecentItems } from '../api-workspace-metrics';
+import { fetchOpenCounts, fetchRecentItems } from '../api-workspace-metrics';
 
 interface RecentRowStub {
   number: number | null;
@@ -58,6 +58,77 @@ const issueRow: RecentRowStub = {
   contributors: [{ username: 'octocat' }],
   repositories: [{ full_name: 'bdougie/contributor.info' }],
 };
+
+// Stub for head-count queries: resolves each query to a count keyed by table,
+// or `table:draft` when the query also filtered on draft=true.
+function stubCountSupabase(
+  countsByKey: Record<string, number | null | { error: string }>
+): SupabaseClient {
+  return {
+    from(table: string) {
+      const eqArgs: string[] = [];
+      const chain = {
+        select: vi.fn(() => chain),
+        in: vi.fn(() => chain),
+        eq: vi.fn((column: string) => {
+          eqArgs.push(column);
+          return chain;
+        }),
+        then(resolve: (v: { count: number | null; error: { message: string } | null }) => void) {
+          const key = eqArgs.includes('draft') ? `${table}:draft` : table;
+          const result = countsByKey[key] ?? 0;
+          if (typeof result === 'object' && result !== null && 'error' in result) {
+            resolve({ count: null, error: { message: result.error } });
+          } else {
+            resolve({ count: result, error: null });
+          }
+        },
+      };
+      return chain;
+    },
+  } as unknown as SupabaseClient;
+}
+
+describe('fetchOpenCounts', () => {
+  it('counts all currently open items, not just the metrics window', async () => {
+    const supabase = stubCountSupabase({
+      pull_requests: 7,
+      'pull_requests:draft': 2,
+      issues: 4,
+    });
+
+    const counts = await fetchOpenCounts(supabase, ['repo-1']);
+
+    expect(counts).toEqual({ open_prs: 7, draft_prs: 2, open_issues: 4 });
+  });
+
+  it('treats a null count as zero', async () => {
+    const supabase = stubCountSupabase({ pull_requests: null, issues: null });
+
+    const counts = await fetchOpenCounts(supabase, ['repo-1']);
+
+    expect(counts).toEqual({ open_prs: 0, draft_prs: 0, open_issues: 0 });
+  });
+
+  it('returns zeros without querying when there are no repos', async () => {
+    const from = vi.fn();
+    const supabase = { from } as unknown as SupabaseClient;
+
+    const counts = await fetchOpenCounts(supabase, []);
+
+    expect(counts).toEqual({ open_prs: 0, draft_prs: 0, open_issues: 0 });
+    expect(from).not.toHaveBeenCalled();
+  });
+
+  it('throws on query errors — open counts are core metrics, not decoration', async () => {
+    const supabase = stubCountSupabase({
+      pull_requests: { error: 'permission denied' },
+      issues: 4,
+    });
+
+    await expect(fetchOpenCounts(supabase, ['repo-1'])).rejects.toThrow('permission denied');
+  });
+});
 
 describe('fetchRecentItems', () => {
   it('maps PR and issue rows to recent items', async () => {

--- a/netlify/functions/__tests__/api-workspace-metrics-recent.test.ts
+++ b/netlify/functions/__tests__/api-workspace-metrics-recent.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import { fetchRecentItems } from '../api-workspace-metrics';
+
+interface RecentRowStub {
+  number: number | null;
+  title: string | null;
+  html_url: string | null;
+  created_at: string | null;
+  contributors: { username: string | null } | { username: string | null }[] | null;
+  repositories: { full_name: string | null } | { full_name: string | null }[] | null;
+}
+
+// Builds a supabase stub whose pull_requests / issues queries resolve to the
+// given rows (or an error). Records the select column list per table so tests
+// can pin the schema contract (the live issues table has no html_url column).
+function stubSupabase(
+  rowsByTable: Record<string, RecentRowStub[] | { error: string }>,
+  selectsByTable: Record<string, string> = {}
+): SupabaseClient {
+  return {
+    from(table: string) {
+      const result = rowsByTable[table] ?? [];
+      const resolved =
+        'error' in result && !Array.isArray(result)
+          ? { data: null, error: { message: result.error } }
+          : { data: result, error: null };
+      const chain = {
+        select: vi.fn((columns: string) => {
+          selectsByTable[table] = columns;
+          return chain;
+        }),
+        in: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue(resolved),
+      };
+      return chain;
+    },
+  } as unknown as SupabaseClient;
+}
+
+const prRow: RecentRowStub = {
+  number: 1824,
+  title: 'Import an org repos into a workspace',
+  html_url: 'https://github.com/bdougie/contributor.info/pull/1824',
+  created_at: '2026-07-13T10:00:00Z',
+  contributors: { username: 'bdougie' },
+  repositories: { full_name: 'bdougie/contributor.info' },
+};
+
+const issueRow: RecentRowStub = {
+  number: 900,
+  title: 'Tray shows stale metrics',
+  html_url: null,
+  created_at: '2026-07-12T09:00:00Z',
+  contributors: [{ username: 'octocat' }],
+  repositories: [{ full_name: 'bdougie/contributor.info' }],
+};
+
+describe('fetchRecentItems', () => {
+  it('maps PR and issue rows to recent items', async () => {
+    const supabase = stubSupabase({ pull_requests: [prRow], issues: [issueRow] });
+
+    const { recent_open_prs, recent_open_issues } = await fetchRecentItems(supabase, ['repo-1']);
+
+    expect(recent_open_prs).toEqual([
+      {
+        number: 1824,
+        title: 'Import an org repos into a workspace',
+        url: 'https://github.com/bdougie/contributor.info/pull/1824',
+        author: 'bdougie',
+        repo: 'bdougie/contributor.info',
+        created_at: '2026-07-13T10:00:00Z',
+      },
+    ]);
+    // Array-shaped joins are normalized, and a missing html_url falls back to a
+    // URL built from the repo full_name and item number.
+    expect(recent_open_issues).toEqual([
+      {
+        number: 900,
+        title: 'Tray shows stale metrics',
+        url: 'https://github.com/bdougie/contributor.info/issues/900',
+        author: 'octocat',
+        repo: 'bdougie/contributor.info',
+        created_at: '2026-07-12T09:00:00Z',
+      },
+    ]);
+  });
+
+  it('builds a pull URL (not issues) when a PR row lacks html_url', async () => {
+    const supabase = stubSupabase({
+      pull_requests: [{ ...prRow, html_url: null }],
+      issues: [],
+    });
+
+    const { recent_open_prs } = await fetchRecentItems(supabase, ['repo-1']);
+
+    expect(recent_open_prs[0].url).toBe('https://github.com/bdougie/contributor.info/pull/1824');
+  });
+
+  it('drops rows that have no resolvable URL, title, or number', async () => {
+    const supabase = stubSupabase({
+      pull_requests: [
+        { ...prRow, html_url: null, repositories: null }, // no URL derivable
+        { ...prRow, title: null }, // no title
+        { ...prRow, number: null, html_url: 'https://github.com/x/y/pull/2' }, // no number
+      ],
+      issues: [],
+    });
+
+    const { recent_open_prs } = await fetchRecentItems(supabase, ['repo-1']);
+
+    expect(recent_open_prs).toEqual([]);
+  });
+
+  it('returns null author when the contributor join is missing', async () => {
+    const supabase = stubSupabase({
+      pull_requests: [{ ...prRow, contributors: null }],
+      issues: [],
+    });
+
+    const { recent_open_prs } = await fetchRecentItems(supabase, ['repo-1']);
+
+    expect(recent_open_prs[0].author).toBeNull();
+  });
+
+  it('returns empty arrays when a query fails, never throwing', async () => {
+    const supabase = stubSupabase({
+      pull_requests: { error: 'permission denied' },
+      issues: [issueRow],
+    });
+
+    const result = await fetchRecentItems(supabase, ['repo-1']);
+
+    expect(result).toEqual({ recent_open_prs: [], recent_open_issues: [] });
+  });
+
+  it('requests html_url only from pull_requests — the live issues table lacks it', async () => {
+    const selects: Record<string, string> = {};
+    const supabase = stubSupabase({ pull_requests: [], issues: [] }, selects);
+
+    await fetchRecentItems(supabase, ['repo-1']);
+
+    expect(selects.pull_requests).toContain('html_url');
+    expect(selects.issues).toBeDefined();
+    expect(selects.issues).not.toContain('html_url');
+  });
+
+  it('returns empty arrays without querying when there are no repos', async () => {
+    const from = vi.fn();
+    const supabase = { from } as unknown as SupabaseClient;
+
+    const result = await fetchRecentItems(supabase, []);
+
+    expect(result).toEqual({ recent_open_prs: [], recent_open_issues: [] });
+    expect(from).not.toHaveBeenCalled();
+  });
+});

--- a/netlify/functions/api-workspace-metrics.mts
+++ b/netlify/functions/api-workspace-metrics.mts
@@ -193,6 +193,40 @@ function emptyMetrics(range: TimeRange, calculatedAt: string): WorkspaceMetricsF
   };
 }
 
+// Point-in-time counts of everything currently open, matching what GitHub
+// shows and what the Recent PR/issue rows list — deliberately NOT scoped to
+// the metrics window, unlike merged/velocity/closure which describe the
+// period. Errors throw: these are core metrics, not decoration.
+export async function fetchOpenCounts(
+  supabase: SupabaseClient,
+  repoIds: string[]
+): Promise<{ open_prs: number; draft_prs: number; open_issues: number }> {
+  if (repoIds.length === 0) {
+    return { open_prs: 0, draft_prs: 0, open_issues: 0 };
+  }
+  const countOpen = (table: 'pull_requests' | 'issues', draftOnly = false) => {
+    const q = supabase
+      .from(table)
+      .select('*', { count: 'exact', head: true })
+      .in('repository_id', repoIds)
+      .eq('state', 'open');
+    return draftOnly ? q.eq('draft', true) : q;
+  };
+  const [prs, drafts, issues] = await Promise.all([
+    countOpen('pull_requests'),
+    countOpen('pull_requests', true),
+    countOpen('issues'),
+  ]);
+  for (const r of [prs, drafts, issues]) {
+    if (r.error) throw new Error(r.error.message);
+  }
+  return {
+    open_prs: prs.count ?? 0,
+    draft_prs: drafts.count ?? 0,
+    open_issues: issues.count ?? 0,
+  };
+}
+
 function firstOf<T>(v: T | T[] | null): T | null {
   return Array.isArray(v) ? (v[0] ?? null) : v;
 }
@@ -307,8 +341,6 @@ async function aggregate(
   );
 
   let mergedPrs = 0;
-  let openPrs = 0;
-  let draftPrs = 0;
   const mergeTimesHours: number[] = [];
   const activeAuthors = new Set<string>();
   for (const pr of prs) {
@@ -318,20 +350,14 @@ async function aggregate(
       mergeTimesHours.push(
         (new Date(pr.merged_at).getTime() - new Date(pr.created_at).getTime()) / 3_600_000
       );
-    } else if (pr.state === 'open') {
-      openPrs++;
-      if (pr.draft) draftPrs++;
     }
   }
 
   let closedIssues = 0;
-  let openIssues = 0;
   for (const issue of issues) {
     if (issue.author_id) activeAuthors.add(issue.author_id);
     if (issue.state === 'closed' && issue.closed_at) {
       closedIssues++;
-    } else if (issue.state === 'open') {
-      openIssues++;
     }
   }
 
@@ -348,22 +374,25 @@ async function aggregate(
   // New contributors = active authors with no contribution before this period.
   // Bounded to the active author set, and stops early once every active author
   // is known to be returning, so it stays cheap on busy workspaces.
-  const [newContributors, recentItems] = await Promise.all([
+  const [newContributors, recentItems, openCounts] = await Promise.all([
     countNewContributors(supabase, repoIds, activeAuthors, startIso),
     fetchRecentItems(supabase, repoIds),
+    fetchOpenCounts(supabase, repoIds),
   ]);
 
   return {
     time_range: range,
     total_prs: totalPrs,
     merged_prs: mergedPrs,
-    open_prs: openPrs,
-    draft_prs: draftPrs,
+    // Open counts are point-in-time (everything currently open), consistent
+    // with the recent_open_* rows; merged/velocity/closure stay window-scoped.
+    open_prs: openCounts.open_prs,
+    draft_prs: openCounts.draft_prs,
     avg_pr_merge_time_hours: avgMergeHours,
     pr_velocity: prVelocity,
     total_issues: totalIssues,
     closed_issues: closedIssues,
-    open_issues: openIssues,
+    open_issues: openCounts.open_issues,
     issue_closure_rate: issueClosureRate,
     // Period-scoped for v1; workspace-wide all-time totals are a follow-up and
     // aren't shown in the tray tiles.

--- a/netlify/functions/api-workspace-metrics.mts
+++ b/netlify/functions/api-workspace-metrics.mts
@@ -43,6 +43,8 @@ const PAGE = 1000;
 // Serve repeated polls (the tray refreshes every 60s) from memory on warm
 // instances, bounding database load. Short enough to stay fresh.
 const CACHE_TTL_MS = 120_000;
+// Newest open items surfaced as clickable rows in the tray's dropdown.
+const RECENT_LIMIT = 5;
 
 // Flat shape consumed by the desktop tray's `WorkspaceMetrics` struct. Trend
 // fields are null in v1 — the history table they were derived from was dropped.
@@ -67,6 +69,30 @@ interface WorkspaceMetricsFlat {
   contributors_trend: number | null;
   calculated_at: string;
   is_stale: boolean;
+  recent_open_prs: RecentItem[];
+  recent_open_issues: RecentItem[];
+}
+
+// Clickable detail row for the tray dropdown: the newest open PRs/issues,
+// deep-linking to GitHub. Not scoped to time_range — an old open PR is still
+// actionable.
+export interface RecentItem {
+  number: number;
+  title: string;
+  url: string;
+  author: string | null;
+  repo: string | null;
+  created_at: string;
+}
+
+interface RecentRow {
+  number: number | null;
+  title: string | null;
+  // Present on pull_requests only; the live issues table has no html_url.
+  html_url?: string | null;
+  created_at: string | null;
+  contributors: { username: string | null } | { username: string | null }[] | null;
+  repositories: { full_name: string | null } | { full_name: string | null }[] | null;
 }
 
 interface PrRow {
@@ -124,7 +150,10 @@ function periodStart(range: TimeRange, end: Date): Date {
 
 // Fetch every row of a range-paginated query, following PostgREST's 1000-row cap.
 async function fetchAll<T>(
-  build: (from: number, to: number) => PromiseLike<{ data: T[] | null; error: { message: string } | null }>
+  build: (
+    from: number,
+    to: number
+  ) => PromiseLike<{ data: T[] | null; error: { message: string } | null }>
 ): Promise<T[]> {
   const rows: T[] = [];
   for (let from = 0; ; from += PAGE) {
@@ -159,7 +188,71 @@ function emptyMetrics(range: TimeRange, calculatedAt: string): WorkspaceMetricsF
     contributors_trend: null,
     calculated_at: calculatedAt,
     is_stale: false,
+    recent_open_prs: [],
+    recent_open_issues: [],
   };
+}
+
+function firstOf<T>(v: T | T[] | null): T | null {
+  return Array.isArray(v) ? (v[0] ?? null) : v;
+}
+
+function mapRecentRows(rows: RecentRow[], path: 'pull' | 'issues'): RecentItem[] {
+  const items: RecentItem[] = [];
+  for (const row of rows) {
+    const repo = firstOf(row.repositories)?.full_name ?? null;
+    const url =
+      row.html_url ||
+      (repo && row.number != null ? `https://github.com/${repo}/${path}/${row.number}` : null);
+    if (row.number == null || !row.title || !url) continue;
+    items.push({
+      number: row.number,
+      title: row.title,
+      url,
+      author: firstOf(row.contributors)?.username ?? null,
+      repo,
+      created_at: row.created_at ?? '',
+    });
+  }
+  return items;
+}
+
+// Newest open PRs and issues across the workspace's repos, as clickable tray
+// rows. Failures degrade to empty arrays so the metrics payload still serves.
+export async function fetchRecentItems(
+  supabase: SupabaseClient,
+  repoIds: string[]
+): Promise<{ recent_open_prs: RecentItem[]; recent_open_issues: RecentItem[] }> {
+  const empty = { recent_open_prs: [], recent_open_issues: [] };
+  if (repoIds.length === 0) return empty;
+
+  const joins = 'contributors:author_id(username), repositories:repository_id(full_name)';
+  // The live issues table has no html_url column, so issue URLs are always
+  // built from the repo full_name and number.
+  const newestOpen = (table: 'pull_requests' | 'issues', columns: string) =>
+    supabase
+      .from(table)
+      .select(columns)
+      .in('repository_id', repoIds)
+      .eq('state', 'open')
+      .order('created_at', { ascending: false })
+      .limit(RECENT_LIMIT);
+
+  try {
+    const [prs, issues] = await Promise.all([
+      newestOpen('pull_requests', `number, title, html_url, created_at, ${joins}`),
+      newestOpen('issues', `number, title, created_at, ${joins}`),
+    ]);
+    if (prs.error) throw new Error(prs.error.message);
+    if (issues.error) throw new Error(issues.error.message);
+    return {
+      recent_open_prs: mapRecentRows((prs.data ?? []) as unknown as RecentRow[], 'pull'),
+      recent_open_issues: mapRecentRows((issues.data ?? []) as unknown as RecentRow[], 'issues'),
+    };
+  } catch (error) {
+    console.error('recent items fetch failed: %s', error instanceof Error ? error.message : error);
+    return empty;
+  }
 }
 
 async function aggregate(
@@ -255,7 +348,10 @@ async function aggregate(
   // New contributors = active authors with no contribution before this period.
   // Bounded to the active author set, and stops early once every active author
   // is known to be returning, so it stays cheap on busy workspaces.
-  const newContributors = await countNewContributors(supabase, repoIds, activeAuthors, startIso);
+  const [newContributors, recentItems] = await Promise.all([
+    countNewContributors(supabase, repoIds, activeAuthors, startIso),
+    fetchRecentItems(supabase, repoIds),
+  ]);
 
   return {
     time_range: range,
@@ -280,6 +376,7 @@ async function aggregate(
     contributors_trend: null,
     calculated_at: calculatedAt,
     is_stale: false,
+    ...recentItems,
   };
 }
 
@@ -377,15 +474,26 @@ export const handler: Handler = async (event: HandlerEvent, _context: HandlerCon
     const cacheKey = `${workspace.id}:${range}`;
     const cached = cache.get(cacheKey);
     if (cached && Date.now() - cached.at < CACHE_TTL_MS) {
-      return { statusCode: 200, headers: { ...headers, 'X-Cache': 'hit' }, body: JSON.stringify(cached.body) };
+      return {
+        statusCode: 200,
+        headers: { ...headers, 'X-Cache': 'hit' },
+        body: JSON.stringify(cached.body),
+      };
     }
 
     const metrics = await aggregate(supabase, workspace.id, range);
     cache.set(cacheKey, { at: Date.now(), body: metrics });
 
-    return { statusCode: 200, headers: { ...headers, 'X-Cache': 'miss' }, body: JSON.stringify(metrics) };
+    return {
+      statusCode: 200,
+      headers: { ...headers, 'X-Cache': 'miss' },
+      body: JSON.stringify(metrics),
+    };
   } catch (error) {
-    console.error('api-workspace-metrics failed: %s', error instanceof Error ? error.message : error);
+    console.error(
+      'api-workspace-metrics failed: %s',
+      error instanceof Error ? error.message : error
+    );
     return {
       statusCode: 500,
       headers,


### PR DESCRIPTION
## What

RepoBar-style clickable details in the desktop tray: each workspace submenu now shows **Recent PRs** and **Recent Issues** sections — the 5 newest *open* items across the workspace's repos, rendered as `#123 Title · author` rows that deep-link to GitHub. Spec: `docs/superpowers/specs/2026-07-18-tray-recent-items-design.md`.

## How

- **`api-workspace-metrics`**: two small additive queries (newest 5 open PRs / issues, `created_at` desc — deliberately *not* scoped to `time_range`; an old open PR is still actionable). Returned as `recent_open_prs` / `recent_open_issues` arrays in the same cached response. Failures degrade to empty arrays so metrics always serve. Issue URLs are built from `repo full_name + number` — **the live `issues` table has no `html_url` column** (found during live verification; the `github_issues` migration doesn't match production).
- **Tray (`desktop/src-tauri`)**: `WorkspaceMetrics` gains the arrays with `#[serde(default)]` (tolerates older endpoint deploys); `build_menu` appends the sections after the metric lines (omitted when empty, titles truncated at 50 chars on char boundaries); the click handler opens `open-url:{url}` ids via the opener plugin, restricted to http(s).

## Verification

Verified end-to-end on Linux (X11/GNOME): served the function locally against the production DB, ran the tray via `tauri dev` pointed at it, dumped the live menu over `com.canonical.dbusmenu.GetLayout` (all sections/rows rendered), and fired a real `clicked` event on a Recent PR row — Chrome opened at the exact GitHub PR. Recipe captured in `desktop/.claude/skills/verify/SKILL.md`.

- 7 new vitest tests for `fetchRecentItems` (mapping, URL fallback, per-table select contract, degradation) — 1,994 web tests green
- 7 new Rust tests (truncation, row format, serde compat) — 11 green, zero warnings

## Notes

- Submenu title still says "N open PRs" (window-scoped) while Recent PRs lists all currently open items — per spec, but flagging the mismatch as a possible follow-up.
- Not included (documented follow-ups): trends, CI status, repo drill-down, dashboard tiles.

https://claude.ai/code/session_01YWSo6KodmC9PKUZ1TUygdY